### PR TITLE
feat(ci): add GitHub Actions deploy workflow for Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Build & Deploy to Netlify
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: 'app/package-lock.json'
+
+    - name: Install dependencies
+      # --force needed: lockfile contains platform-specific @rollup packages from macOS
+      run: cd app && npm ci --force
+
+    - name: Build
+      # Astro SSR defers DB connections to request time — no DATABASE_URL needed at build
+      run: cd app && npm run build
+
+    - name: Deploy to Netlify
+      run: npx netlify deploy --prod --dir=app/dist --auth=$NETLIFY_AUTH_TOKEN --site=$NETLIFY_SITE_ID
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -112,27 +112,28 @@ curl -I https://<preview-url>/enrollment
 
 ## 6. Deploy
 
-### Option A: Push to Deployment Branch
+### Automatic (CI/CD — standard path)
 
-```bash
-git push origin <branch>:main
-```
+Merging a PR to `main` triggers the `deploy.yml` GitHub Actions workflow, which:
+1. Builds the app (`cd app && npm run build`)
+2. Deploys to Netlify via CLI (`npx netlify deploy --prod --dir=app/dist`)
 
-Netlify will detect the push and trigger a build automatically.
+No Netlify git integration is used — GitHub Actions owns the build and deploy pipeline.
 
-### Option B: CLI Deploy from Repo Root
+**Required GitHub secrets:**
+- `NETLIFY_SITE_ID` — Netlify site UUID
+- `NETLIFY_AUTH_TOKEN` — Netlify personal access token
+
+### Manual CLI Deploy (emergency or ad-hoc)
 
 **CRITICAL: Run from the repository root, NOT from `app/`.** The `netlify.toml` has `base=app`, so deploying from `app/` causes path doubling.
 
 ```bash
-# From repo root
-npx netlify deploy --prod --dir=app/dist
-```
+# Build first
+cd app && npm run build
 
-### Preflight Script (Optional)
-
-```bash
-cd app && NETLIFY_SITE_ID=<site-id> npm run predeploy:production
+# Deploy from repo root
+cd .. && npx netlify deploy --prod --dir=app/dist
 ```
 
 ---


### PR DESCRIPTION
## Summary
- New `deploy.yml` workflow: builds and deploys to Netlify on push to `main`
- Updated deploy runbook to reflect CI/CD pipeline (no more Netlify git integration)

## Why
Netlify's auto-build was configured to watch the `testing` branch, not `main`. None of our merges to `main` triggered builds. Rather than fixing Netlify's branch config, this PR moves deployment into GitHub Actions where we control it.

## How it works
1. PR merged to `main`
2. `deploy.yml` triggers: checkout → install → build → `npx netlify deploy --prod`
3. Netlify receives the built artifacts directly

## Required secrets
- `NETLIFY_SITE_ID` — already set
- `NETLIFY_AUTH_TOKEN` — **needs to be set before merging** (generate at https://app.netlify.com/user/applications#personal-access-tokens)

## Test plan
- [ ] Set `NETLIFY_AUTH_TOKEN` secret in GitHub repo settings
- [ ] CI passes on this PR
- [ ] After merge, deploy workflow runs and site updates at https://spicebushmontessori.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic deployment pipeline that builds and publishes to production when changes are pushed to the main branch.

* **Documentation**
  * Updated deployment documentation to reflect the new continuous integration and deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->