### PR TITLE
fix(a11y): scope scroll-behavior smooth under prefers-reduced-motion no-preference

### DIFF
--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -469,9 +469,11 @@ p {
   animation-delay: 1s;
 }
 
-/* Smooth scroll behavior for anchor links */
-html {
-  scroll-behavior: smooth;
+/* Smooth scroll behavior for anchor links (only when motion is allowed) */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 
 /* Focus states for accessibility */


### PR DESCRIPTION
Closes #67. Standalone a11y fix (blog plan PR-0a, R3-F5 — independent of the blog stack).

The unconditional `html { scroll-behavior: smooth }` in `global.css` won the cascade over the `prefers-reduced-motion: reduce` block at equal specificity (source order), so smooth scrolling ran even for reduced-motion users (WCAG 2.3.3). Fix wraps the rule in `@media (prefers-reduced-motion: no-preference)` — one file, +5/−3.

**Gates:** lint 0 warnings · typecheck 0 errors (206 files) · vitest 215/215 · format:check clean · prod build verified on this branch.
**Note:** no new test — jsdom doesn't evaluate CSS media-query cascade; behavioral check (dev-tools emulation) recorded as a manual rollout QA step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated smooth-scroll behavior to respect system motion preferences for users who prefer reduced motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->