### PR TITLE
feat(blog): content pipeline enablement — core lib + admin endpoint (PR-1)

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -286,6 +286,11 @@ describe('renderPostBody — URI / XSS matrix', () => {
     expect(renderPostBody('![x](images/x.png)')).not.toContain('images/x.png');
     // fragment-only stripped (R4-F6)
     expect(renderPostBody('[anchor](#top)')).not.toContain('#top');
+    // Positive companions: the safe shell survives (only the dangerous href is dropped),
+    // so a mutation that nukes the whole link structure — not just the scheme — is also caught.
+    // eslint-disable-next-line no-script-url -- intentional XSS test vector
+    expect(renderPostBody('[x](javascript:alert(1))')).toContain('>x<');
+    expect(renderPostBody('[anchor](#top)')).toContain('anchor');
   });
 
   it('normalizes www.-leading hrefs to https (walkTokens, R1-F19)', () => {
@@ -307,6 +312,15 @@ describe('renderPostBody — URI / XSS matrix', () => {
     expect(doc.querySelector('noscript')).toBeNull();
     expect(doc.querySelector('script')).toBeNull();
     expect(doc.querySelector('[onerror]')).toBeNull();
+  });
+
+  it('strips data-* and aria-* attributes (pins ALLOW_DATA_ATTR/ALLOW_ARIA_ATTR, R2-F3)', () => {
+    // These flags default to true and are evaluated BEFORE the ALLOWED_ATTR allowlist, so
+    // setting them false is the only thing keeping data-*/aria-* out — pin both directly.
+    expect(renderPostBody('<p data-admin-alert>x</p>')).not.toContain('data-admin-alert');
+    expect(renderPostBody('<a aria-hidden="true" href="https://e.com">x</a>')).not.toContain(
+      'aria-hidden'
+    );
   });
 
   it('retains NO author id on the public render (R4-F1)', () => {
@@ -520,6 +534,37 @@ describe('getManagedBlogPosts', () => {
     // Ordering applied: date DESC → draft(2025), published(2024), weird(2023).
     expect(posts.map(p => p.slug)).toEqual(['draft-post', 'published-post', 'weird-post']);
   });
+
+  it('surfaces a bare title-only draft the write path accepts (F1)', async () => {
+    // validateBlogData exempts drafts from date/excerpt, so a title-only draft is a valid
+    // save. The admin list must show it (author visibility) — unlike the public path, which
+    // drops rows missing date/excerpt. It carries the undated-last position in the ordering.
+    queryRowsMock.mockResolvedValueOnce([
+      { id: '1', slug: 'bare-draft', title: 'Bare Draft', status: 'draft', data: {} },
+      {
+        id: '2',
+        slug: 'published-post',
+        title: 'Published',
+        status: 'published',
+        data: { date: '2024-01-01', excerpt: 'E' }
+      }
+    ]);
+
+    const posts = await getManagedBlogPosts();
+    expect(posts.map(p => p.slug)).toEqual(['published-post', 'bare-draft']); // undated last
+    const bare = posts.find(p => p.slug === 'bare-draft');
+    expect(bare).toBeDefined();
+    expect(bare?.status).toBe('draft');
+    expect(bare?.date).toBe('');
+    expect(bare?.excerpt).toBe('');
+  });
+
+  it('still drops a row with no usable title (structural floor)', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      { id: '1', slug: 'no-title', title: null, status: 'draft', data: {} }
+    ]);
+    expect(await getManagedBlogPosts()).toEqual([]);
+  });
 });
 
 describe('escapeXml + renderBlogSitemapXml', () => {
@@ -558,7 +603,11 @@ describe('resolveLegacyBlogRedirect', () => {
     expect(await resolveLegacyBlogRedirect('2024-01-01-nonexistent')).toBeNull();
   });
 
-  it('returns null when the stripped target is a draft (getEntry returns null)', async () => {
+  // At this layer a draft and a miss are indistinguishable: db.content.getEntry already
+  // filters drafts in SQL, so both surface as `null`. This pins the null-passthrough contract
+  // (no 301 emitted when getPublishedPost resolves to null); the draft-exclusion guarantee
+  // itself is pinned by the SQL-string assertion in db/__tests__/content.test.ts (R1-F41).
+  it('returns null when getPublishedPost resolves to null (miss or SQL-filtered draft)', async () => {
     getEntryMock.mockResolvedValueOnce(null);
     expect(await resolveLegacyBlogRedirect('2099-01-01-secret-draft')).toBeNull();
   });

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -1,0 +1,570 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getCollectionMock, getEntryMock, queryRowsMock } = vi.hoisted(() => ({
+  getCollectionMock: vi.fn(),
+  getEntryMock: vi.fn(),
+  queryRowsMock: vi.fn()
+}));
+
+vi.mock('@lib/db', () => ({
+  db: {
+    content: {
+      getCollection: getCollectionMock,
+      getEntry: getEntryMock
+    }
+  }
+}));
+
+vi.mock('@lib/db/client', () => ({
+  queryRows: queryRowsMock
+}));
+
+import type { ContentEntry } from '@lib/db/types';
+import {
+  compareBlogPosts,
+  escapeXml,
+  getManagedBlogPosts,
+  getPublishedPosts,
+  normalizeBlogData,
+  normalizeBlogEntry,
+  renderBlogSitemapXml,
+  renderPostBody,
+  resolveLegacyBlogRedirect,
+  validateBlogData,
+  type BlogPost
+} from './blog-content';
+
+const makeEntry = (
+  slug: string,
+  data: Record<string, unknown>,
+  body = 'Body text'
+): ContentEntry => ({
+  id: slug,
+  slug,
+  collection: 'blog',
+  data,
+  body
+});
+
+const completeData = {
+  title: 'Garden Day',
+  date: '2024-10-29',
+  excerpt: 'A day in the garden',
+  author: 'Ms. Rivera',
+  image: 'https://cdn.example.com/garden.png',
+  imageAlt: 'Children planting seedlings',
+  seoTitle: 'Garden Day SEO',
+  seoDescription: 'Garden Day description'
+};
+
+const makePost = (overrides: Partial<BlogPost> = {}): BlogPost => ({
+  slug: 'a-post',
+  title: 'A Post',
+  date: '2024-01-01',
+  author: 'Spicebush Team',
+  excerpt: 'An excerpt',
+  body: 'Body',
+  status: 'published',
+  ...overrides
+});
+
+beforeEach(() => {
+  getCollectionMock.mockReset();
+  getEntryMock.mockReset();
+  queryRowsMock.mockReset();
+});
+
+describe('normalizeBlogEntry', () => {
+  it('maps a complete row to a BlogPost', () => {
+    const post = normalizeBlogEntry(makeEntry('garden-day', completeData, 'Hello world'));
+    expect(post).toEqual({
+      slug: 'garden-day',
+      title: 'Garden Day',
+      date: '2024-10-29',
+      author: 'Ms. Rivera',
+      excerpt: 'A day in the garden',
+      body: 'Hello world',
+      image: 'https://cdn.example.com/garden.png',
+      imageAlt: 'Children planting seedlings',
+      seoTitle: 'Garden Day SEO',
+      seoDescription: 'Garden Day description',
+      status: 'published'
+    });
+  });
+
+  it('defaults author and leaves optionals undefined when missing', () => {
+    const post = normalizeBlogEntry(
+      makeEntry('minimal', { title: 'T', date: '2024-01-01', excerpt: 'E' })
+    );
+    expect(post?.author).toBe('Spicebush Team');
+    expect(post?.image).toBeUndefined();
+    expect(post?.imageAlt).toBeUndefined();
+    expect(post?.seoTitle).toBeUndefined();
+    expect(post?.seoDescription).toBeUndefined();
+  });
+
+  it('tolerates garbage data without throwing', () => {
+    const post = normalizeBlogEntry({
+      id: 'x',
+      slug: 'x',
+      collection: 'blog',
+      data: { title: 123, date: {}, excerpt: [] } as unknown as Record<string, unknown>,
+      body: 'b'
+    });
+    // Non-string title/date/excerpt coerce to '' and are treated as missing → skipped.
+    expect(post).toBeNull();
+  });
+
+  it('reads title from data.title (title-column override already merged)', () => {
+    const post = normalizeBlogEntry(
+      makeEntry('p', { title: 'Title From Data', date: '2024-01-01', excerpt: 'E' })
+    );
+    expect(post?.title).toBe('Title From Data');
+  });
+
+  it('skips rows missing title, date, or excerpt', () => {
+    expect(normalizeBlogEntry(makeEntry('p', { date: '2024-01-01', excerpt: 'E' }))).toBeNull();
+    expect(normalizeBlogEntry(makeEntry('p', { title: 'T', excerpt: 'E' }))).toBeNull();
+    expect(normalizeBlogEntry(makeEntry('p', { title: 'T', date: '2024-01-01' }))).toBeNull();
+  });
+
+  it('skips a row whose slug fails ^[a-z0-9-_]{1,100}$ (R1-F1)', () => {
+    expect(
+      normalizeBlogEntry(makeEntry('Bad Slug!', { title: 'T', date: '2024-01-01', excerpt: 'E' }))
+    ).toBeNull();
+    expect(
+      normalizeBlogEntry(
+        makeEntry('a'.repeat(101), { title: 'T', date: '2024-01-01', excerpt: 'E' })
+      )
+    ).toBeNull();
+  });
+
+  it("coerces '' optionals to undefined (R2-F20)", () => {
+    const post = normalizeBlogEntry(
+      makeEntry('p', {
+        title: 'T',
+        date: '2024-01-01',
+        excerpt: 'E',
+        image: '',
+        imageAlt: '',
+        seoTitle: '',
+        seoDescription: ''
+      })
+    );
+    expect(post?.image).toBeUndefined();
+    expect(post?.imageAlt).toBeUndefined();
+    expect(post?.seoTitle).toBeUndefined();
+    expect(post?.seoDescription).toBeUndefined();
+  });
+
+  it('nulls data.image failing the backslash-aware scheme regex (R2-F7/F1/R3-F2)', () => {
+    for (const bad of ['/\\evil.com/x.png', '//evil.com/x.png', 'http://insecure/x.png']) {
+      const post = normalizeBlogEntry(
+        makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', image: bad })
+      );
+      expect(post?.image).toBeUndefined();
+    }
+  });
+
+  it('keeps a valid https or single-slash site-relative image', () => {
+    const https = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', image: 'https://ok/x.png' })
+    );
+    expect(https?.image).toBe('https://ok/x.png');
+    const relative = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', image: '/img/x.png' })
+    );
+    expect(relative?.image).toBe('/img/x.png');
+  });
+});
+
+describe('compareBlogPosts', () => {
+  it('sorts date DESC, slug DESC tiebreak, undated last (R3-F18)', () => {
+    const posts = [
+      makePost({ slug: 'old', date: '2023-01-01' }),
+      makePost({ slug: 'undated', date: '' }),
+      makePost({ slug: 'new', date: '2025-01-01' }),
+      makePost({ slug: 'mid-a', date: '2024-10-29' }),
+      makePost({ slug: 'mid-b', date: '2024-10-29' })
+    ];
+    const sorted = [...posts].sort(compareBlogPosts).map(p => p.slug);
+    // Same-date pair (mid-a, mid-b) deterministic by slug DESC → mid-b before mid-a.
+    expect(sorted).toEqual(['new', 'mid-b', 'mid-a', 'old', 'undated']);
+  });
+
+  it('getPublishedPosts returns normalized + sorted output', async () => {
+    getCollectionMock.mockResolvedValueOnce([
+      makeEntry('first', { title: 'First', date: '2024-01-01', excerpt: 'E' }),
+      makeEntry('second', { title: 'Second', date: '2025-01-01', excerpt: 'E' }),
+      makeEntry('Bad Slug!', { title: 'Skip', date: '2024-01-01', excerpt: 'E' })
+    ]);
+    const posts = await getPublishedPosts();
+    expect(posts.map(p => p.slug)).toEqual(['second', 'first']);
+    expect(getCollectionMock).toHaveBeenCalledWith('blog');
+  });
+});
+
+describe('renderPostBody — happy path + heading clamp', () => {
+  it('renders headings, paragraphs, links, images, formatting, lists, blockquote, code, GFM table', () => {
+    const md = [
+      '## Heading',
+      '',
+      'A paragraph with **bold** and *italic* and a [link](https://e.com).',
+      '',
+      '![alt text here](https://e.com/i.png)',
+      '',
+      '- one',
+      '- two',
+      '',
+      '> a quote',
+      '',
+      '`inline code`',
+      '',
+      '| a | b |',
+      '| --- | --- |',
+      '| 1 | 2 |'
+    ].join('\n');
+    const html = renderPostBody(md);
+    expect(html).toContain('<h2>Heading</h2>');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+    expect(html).toContain('<a href="https://e.com">link</a>');
+    expect(html).toContain('<img src="https://e.com/i.png" alt="alt text here">');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('<code>inline code</code>');
+    expect(html).toContain('<table>');
+  });
+
+  it('demotes body h1 → h2', () => {
+    expect(renderPostBody('# Title')).toContain('<h2>Title</h2>');
+    expect(renderPostBody('# Title')).not.toContain('<h1>');
+  });
+
+  it('clamps heading skips: ## then #### → h2, h3; first ### → h2', () => {
+    const html = renderPostBody('## A\n\n#### B');
+    expect(html).toContain('<h2>A</h2>');
+    expect(html).toContain('<h3>B</h3>');
+    expect(html).not.toContain('<h4>');
+    expect(renderPostBody('### First')).toContain('<h2>First</h2>');
+  });
+
+  it('emits NO ids on headings (R4-F6)', () => {
+    expect(renderPostBody('## My Heading')).not.toContain('id=');
+  });
+
+  it('uses a per-call previousDepth — second call clamps from a fresh depth (R4-F22)', () => {
+    const first = renderPostBody('## A\n\n### B');
+    expect(first).toContain('<h2>A</h2>');
+    expect(first).toContain('<h3>B</h3>');
+    // A fresh call must clamp its first ### to h2, not continue the prior call's depth.
+    const second = renderPostBody('### First');
+    expect(second).toContain('<h2>First</h2>');
+    expect(second).not.toContain('<h3>');
+  });
+
+  it('returns empty string for empty/undefined body', () => {
+    expect(renderPostBody('')).toBe('');
+    expect(renderPostBody(undefined as unknown as string)).toBe('');
+  });
+});
+
+describe('renderPostBody — URI / XSS matrix', () => {
+  it('strips dangerous and disallowed URI schemes', () => {
+    // eslint-disable-next-line no-script-url -- intentional XSS test vector
+    expect(renderPostBody('[x](javascript:alert(1))')).not.toContain('javascript:');
+    expect(renderPostBody('[x](data:text/html,evil)')).not.toContain('data:');
+    expect(renderPostBody('[x](//evil.com)')).not.toContain('//evil.com');
+    // Backslash form: never becomes protocol-relative `//evil.com`. The backslash is
+    // percent-encoded (`%5C`), yielding a harmless same-origin path — not an off-site link.
+    expect(renderPostBody('[x](/\\evil.com/x)')).not.toContain('//evil.com');
+    expect(renderPostBody('[x](/\\evil.com/x)')).not.toContain('href="/\\');
+    expect(renderPostBody('![x](/\\evil.com/x.png)')).not.toContain('//evil.com');
+    expect(renderPostBody('[x](http://insecure/p)')).not.toContain('http://insecure');
+    expect(renderPostBody('![x](http://insecure/x.png)')).not.toContain('http://insecure');
+    // relative non-slash path stripped
+    expect(renderPostBody('![x](images/x.png)')).not.toContain('images/x.png');
+    // fragment-only stripped (R4-F6)
+    expect(renderPostBody('[anchor](#top)')).not.toContain('#top');
+  });
+
+  it('normalizes www.-leading hrefs to https (walkTokens, R1-F19)', () => {
+    expect(renderPostBody('[text](www.example.com)')).toContain('href="https://www.example.com"');
+  });
+
+  it('neutralizes raw inline HTML vectors directly (R4-F2)', () => {
+    expect(renderPostBody('<img src=x onerror=alert(1)>')).not.toContain('onerror');
+    expect(renderPostBody('<svg onload=alert(1)>')).not.toContain('onload');
+    expect(renderPostBody('<svg onload=alert(1)></svg>')).not.toContain('<svg');
+    expect(renderPostBody('<iframe src="https://e.com"></iframe>')).not.toContain('<iframe');
+    expect(renderPostBody('<a href="jAvAsCrIpT:alert(1)">x</a>')).not.toMatch(/javascript:/i);
+    // mXSS-style payload: the string `onerror=` survives only inertly inside a quoted `title`
+    // attribute value. Parse the real DOM to prove no executable <img>/<noscript>/<script>
+    // element exists and no element actually carries an onerror handler.
+    const mxss = renderPostBody('<noscript><p title="</noscript><img src=x onerror=alert(1)>">');
+    const doc = new DOMParser().parseFromString(mxss, 'text/html');
+    expect(doc.querySelector('img')).toBeNull();
+    expect(doc.querySelector('noscript')).toBeNull();
+    expect(doc.querySelector('script')).toBeNull();
+    expect(doc.querySelector('[onerror]')).toBeNull();
+  });
+
+  it('retains NO author id on the public render (R4-F1)', () => {
+    expect(renderPostBody('<h2 id="evil-clobber">x</h2>')).not.toContain('evil-clobber');
+    expect(renderPostBody('<h2 id="evil-clobber">x</h2>')).not.toContain('id=');
+    expect(renderPostBody('<a id="custom-id" href="https://e.com">x</a>')).not.toContain(
+      'custom-id'
+    );
+  });
+});
+
+describe('normalizeBlogData', () => {
+  it('coerces and trims short fields, defaults author', () => {
+    const out = normalizeBlogData({
+      date: ' 2024-01-01 ',
+      author: '  ',
+      image: ' https://e.com/x.png ',
+      seoTitle: ' SEO '
+    });
+    expect(out.date).toBe('2024-01-01');
+    expect(out.author).toBe('Spicebush Team');
+    expect(out.image).toBe('https://e.com/x.png');
+    expect(out.seoTitle).toBe('SEO');
+  });
+
+  it('trims body and excerpt (R2-F8 backstop)', () => {
+    const out = normalizeBlogData({ body: '\n   Hello world\n  ', excerpt: '  hi  ' });
+    expect(out.body).toBe('Hello world');
+    expect(out.excerpt).toBe('hi');
+  });
+
+  it('deletes blank image/imageAlt/seoTitle/seoDescription/date keys (R2-F20)', () => {
+    const out = normalizeBlogData({
+      image: '',
+      imageAlt: '   ',
+      seoTitle: '',
+      seoDescription: '',
+      date: ''
+    });
+    expect('image' in out).toBe(false);
+    expect('imageAlt' in out).toBe(false);
+    expect('seoTitle' in out).toBe(false);
+    expect('seoDescription' in out).toBe(false);
+    expect('date' in out).toBe(false);
+  });
+
+  it('does not mutate the input', () => {
+    const input = { author: '' };
+    const out = normalizeBlogData(input);
+    expect(input.author).toBe('');
+    expect(out.author).toBe('Spicebush Team');
+  });
+});
+
+describe('validateBlogData', () => {
+  const validDraft = { slug: 'my-post', excerpt: 'x', body: 'y', date: '2024-01-01' };
+
+  it('rejects missing/empty/whitespace-only rawStatus FIRST (R2-F2)', () => {
+    expect(validateBlogData({ ...validDraft }, 'T', undefined)).toBe(
+      'Status must be Draft or Published'
+    );
+    expect(validateBlogData({ ...validDraft }, 'T', '')).toBe('Status must be Draft or Published');
+    expect(validateBlogData({ ...validDraft }, 'T', '   ')).toBe(
+      'Status must be Draft or Published'
+    );
+  });
+
+  it('rejects an invalid status value', () => {
+    expect(validateBlogData({ ...validDraft }, 'T', 'archived')).toBe(
+      'Status must be Draft or Published'
+    );
+  });
+
+  it('rejects missing title', () => {
+    expect(validateBlogData({ ...validDraft }, '', 'draft')).toBe('Title is required');
+    expect(validateBlogData({ ...validDraft }, null, 'draft')).toBe('Title is required');
+  });
+
+  it('rejects a date-prefixed slug (R2-F19)', () => {
+    const error = validateBlogData(
+      { slug: '2026-08-01-fall-festival', title: 'x', excerpt: 'y', body: 'z', date: '2026-08-01' },
+      'x',
+      'published'
+    );
+    expect(error).toMatch(/date/i);
+  });
+
+  it('rejects a malformed slug', () => {
+    expect(validateBlogData({ ...validDraft, slug: 'Bad Slug' }, 'T', 'draft')).toMatch(/Address/);
+  });
+
+  it('rejects over-cap title/slug/excerpt/body', () => {
+    expect(validateBlogData({ ...validDraft }, 'a'.repeat(301), 'draft')).toMatch(/Title/);
+    expect(validateBlogData({ ...validDraft, slug: 'a'.repeat(101) }, 'T', 'draft')).toMatch(
+      /Address/
+    );
+    expect(validateBlogData({ ...validDraft, excerpt: 'a'.repeat(1001) }, 'T', 'draft')).toMatch(
+      /Excerpt/
+    );
+    expect(validateBlogData({ ...validDraft, body: 'a'.repeat(200001) }, 'T', 'draft')).toMatch(
+      /Body/
+    );
+  });
+
+  it('rejects an image URL failing the scheme (R2-F1/R3-F2)', () => {
+    for (const bad of [
+      // eslint-disable-next-line no-script-url -- intentional XSS test vector
+      'javascript:alert(1)',
+      'data:image/svg+xml,evil',
+      '//evil.com',
+      'http://insecure',
+      '/\\evil.com/x.png'
+    ]) {
+      expect(validateBlogData({ ...validDraft, image: bad }, 'T', 'draft')).toMatch(
+        /Featured image/
+      );
+    }
+  });
+
+  it('rejects junk imageAlt quality (R1-F37)', () => {
+    const base = { ...validDraft, image: 'https://e.com/x.png' };
+    expect(validateBlogData({ ...base, imageAlt: 'Photo' }, 'T', 'draft')).toMatch(/alt/i);
+    expect(validateBlogData({ ...base, imageAlt: 'IMG_1234.jpg' }, 'T', 'draft')).toMatch(/alt/i);
+    expect(validateBlogData({ ...base, imageAlt: 'short' }, 'T', 'draft')).toMatch(/alt/i);
+    expect(
+      validateBlogData({ ...base, imageAlt: 'Children planting seedlings' }, 'T', 'draft')
+    ).toBeNull();
+  });
+
+  it('requires excerpt/body/valid date when publishing', () => {
+    expect(
+      validateBlogData({ slug: 'p', body: 'y', date: '2024-01-01' }, 'T', 'published')
+    ).toMatch(/Excerpt/);
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', date: '2024-01-01' }, 'T', 'published')
+    ).toMatch(/Body/);
+    expect(validateBlogData({ slug: 'p', excerpt: 'x', body: 'y' }, 'T', 'published')).toMatch(
+      /date/i
+    );
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', body: 'y', date: 'not-a-date' }, 'T', 'published')
+    ).toMatch(/date/i);
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', body: 'y', date: '2024-13-40' }, 'T', 'published')
+    ).toMatch(/date/i);
+  });
+
+  it('requires imageAlt when publishing with an image', () => {
+    expect(
+      validateBlogData(
+        { slug: 'p', excerpt: 'x', body: 'y', date: '2024-01-01', image: 'https://e.com/x.png' },
+        'T',
+        'published'
+      )
+    ).toMatch(/alt/i);
+  });
+
+  it('rejects body images without quality alt at publish, accepts good alt (R2-F26)', () => {
+    const base = { slug: 'p', excerpt: 'x', date: '2024-01-01' };
+    expect(validateBlogData({ ...base, body: '![](x)' }, 'T', 'published')).toMatch(/body/i);
+    expect(validateBlogData({ ...base, body: '![photo](x)' }, 'T', 'published')).toMatch(/body/i);
+    expect(
+      validateBlogData({ ...base, body: '![Children planting seedlings](x)' }, 'T', 'published')
+    ).toBeNull();
+  });
+
+  it('exempts drafts from body-image alt rules', () => {
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', body: '![](x)', date: '' }, 'T', 'draft')
+    ).toBeNull();
+  });
+
+  it('accepts blank-SEO and imageless publish (R2-F20)', () => {
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', body: 'y', date: '2024-01-01' }, 'T', 'published')
+    ).toBeNull();
+  });
+});
+
+describe('getManagedBlogPosts', () => {
+  it('issues SQL with NO status filter and includes stray-status rows (R1-F9)', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      {
+        id: '1',
+        slug: 'published-post',
+        title: 'Published',
+        status: 'published',
+        data: { date: '2024-01-01', excerpt: 'E' }
+      },
+      {
+        id: '2',
+        slug: 'draft-post',
+        title: 'Draft',
+        status: 'draft',
+        data: { date: '2025-01-01', excerpt: 'E' }
+      },
+      {
+        id: '3',
+        slug: 'weird-post',
+        title: 'Weird',
+        status: 'archived',
+        data: { date: '2023-01-01', excerpt: 'E' }
+      }
+    ]);
+
+    const posts = await getManagedBlogPosts();
+    const sqlArg = queryRowsMock.mock.calls[0][0] as string;
+    expect(sqlArg).not.toContain("status = 'published'");
+    expect(sqlArg).not.toMatch(/status\s*=/);
+    expect(posts.map(p => p.status)).toEqual(['draft', 'published', 'archived']);
+    // Ordering applied: date DESC → draft(2025), published(2024), weird(2023).
+    expect(posts.map(p => p.slug)).toEqual(['draft-post', 'published-post', 'weird-post']);
+  });
+});
+
+describe('escapeXml + renderBlogSitemapXml', () => {
+  it('escapes & < > " \'', () => {
+    expect(escapeXml(`a&b<c>d"e'f`)).toBe('a&amp;b&lt;c&gt;d&quot;e&apos;f');
+  });
+
+  it('renders exact slashless <loc> strings, no trailing-slash variant (R2-F17)', () => {
+    const xml = renderBlogSitemapXml(
+      [makePost({ slug: 'first' }), makePost({ slug: 'second' })],
+      'https://spicebushmontessori.org'
+    );
+    expect(xml).toContain('<loc>https://spicebushmontessori.org/blog</loc>');
+    expect(xml).toContain('<loc>https://spicebushmontessori.org/blog/first</loc>');
+    expect(xml).toContain('<loc>https://spicebushmontessori.org/blog/second</loc>');
+    expect(xml).not.toContain('<loc>https://spicebushmontessori.org/blog/</loc>');
+    expect(xml).not.toContain('/blog/first/</loc>');
+  });
+});
+
+describe('resolveLegacyBlogRedirect', () => {
+  it('returns the stripped slug when the date-prefixed target is published', async () => {
+    getEntryMock.mockResolvedValueOnce({
+      id: 'clean',
+      slug: 'clean',
+      collection: 'blog',
+      data: { title: 'T', date: '2024-05-20', excerpt: 'E' },
+      body: 'b'
+    });
+    expect(await resolveLegacyBlogRedirect('2024-05-20-clean')).toBe('clean');
+    expect(getEntryMock).toHaveBeenCalledWith('blog', 'clean');
+  });
+
+  it('returns null for a date-prefixed miss', async () => {
+    getEntryMock.mockResolvedValueOnce(null);
+    expect(await resolveLegacyBlogRedirect('2024-01-01-nonexistent')).toBeNull();
+  });
+
+  it('returns null when the stripped target is a draft (getEntry returns null)', async () => {
+    getEntryMock.mockResolvedValueOnce(null);
+    expect(await resolveLegacyBlogRedirect('2099-01-01-secret-draft')).toBeNull();
+  });
+
+  it('returns null for a non-date-prefixed slug without querying', async () => {
+    expect(await resolveLegacyBlogRedirect('regular-slug')).toBeNull();
+    expect(getEntryMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -1,0 +1,436 @@
+/**
+ * Blog content library — the single home for all blog-specific read-path logic,
+ * validation, rendering, and sitemap string-building.
+ *
+ * Living under `src/lib/**` means this file is auto-coverage-measured (vitest
+ * `include: ['src/lib/**\/*.ts']`). The thin endpoint/sitemap shells defer their
+ * logic here so the shared admin endpoint is not gated for blog-only branches.
+ */
+import { Marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+import { db } from '@lib/db';
+import { queryRows } from '@lib/db/client';
+import type { ContentEntry } from '@lib/db/types';
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  date: string;
+  author: string;
+  excerpt: string;
+  body: string;
+  image?: string;
+  imageAlt?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+  status: string;
+};
+
+// Length caps — authoritative numbers per docs/specs/blog.md Data Model.
+const TITLE_MAX = 300;
+const SLUG_MAX = 100;
+const EXCERPT_MAX = 1000;
+const BODY_MAX = 200000;
+
+const DEFAULT_AUTHOR = 'Spicebush Team';
+
+// Slug charset + length, shared by the read-path trust boundary and the write-path validator.
+const SLUG_REGEX = /^[a-z0-9-_]{1,100}$/;
+
+// Legacy date-prefix namespace (`YYYY-MM-DD-…`), reserved for the redirect fallback.
+const DATE_PREFIX_REGEX = /^\d{4}-\d{2}-\d{2}-(.+)$/;
+
+// Featured-image URL scheme: HTTPS absolute OR a single-slash site-relative path that is
+// NOT `//` or `/\` (backslash-aware — browsers parse `/\evil.com` as `//evil.com`). R2-F1/F7/R3-F2.
+const IMAGE_SCHEME_REGEX = /^(\/(?![/\\])|https:\/\/)/;
+
+// Publish date format (YYYY-MM-DD).
+const DATE_FORMAT_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// imageAlt quality floors (R1-F37): not filename-like, not a single generic word.
+const FILENAME_LIKE_REGEX = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
+const GENERIC_WORD_REGEX = /^(image|photo|picture)$/i;
+const IMAGE_ALT_MIN = 6;
+
+const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const emptyToUndefined = (value: string): string | undefined =>
+  value.length > 0 ? value : undefined;
+
+/**
+ * Read-path trust boundary — the single tolerant mapper from a stored `ContentEntry`
+ * to a `BlogPost`. Returns `null` to skip a row that cannot be trusted/rendered.
+ *
+ * Data-key invariant (AMENDMENT 1): `body` is read from `entry.body`; `title` and every
+ * other field are read from `entry.data.*` (`toContentEntry` merges the title column into
+ * `entry.data.title`). There is no top-level `entry.date`/`entry.author`.
+ *
+ * `status` defaults to `'published'` here — the published read path only ever sees
+ * published rows. `getManagedBlogPosts` overwrites `status` from the SQL column afterward.
+ */
+export function normalizeBlogEntry(entry: ContentEntry): BlogPost | null {
+  const slug = typeof entry.slug === 'string' ? entry.slug : '';
+  if (!SLUG_REGEX.test(slug)) return null;
+
+  const data = (entry.data ?? {}) as Record<string, unknown>;
+
+  const title = asTrimmedString(data.title);
+  const date = asTrimmedString(data.date);
+  const excerpt = asTrimmedString(data.excerpt);
+  if (!title || !date || !excerpt) return null;
+
+  const body = typeof entry.body === 'string' ? entry.body : '';
+  const author = asTrimmedString(data.author) || DEFAULT_AUTHOR;
+
+  // Null/strip a featured image failing the backslash-aware scheme — treat as absent.
+  const rawImage = asTrimmedString(data.image);
+  const image = rawImage && IMAGE_SCHEME_REGEX.test(rawImage) ? rawImage : undefined;
+
+  return {
+    slug,
+    title,
+    date,
+    author,
+    excerpt,
+    body,
+    image,
+    imageAlt: emptyToUndefined(asTrimmedString(data.imageAlt)),
+    seoTitle: emptyToUndefined(asTrimmedString(data.seoTitle)),
+    seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
+    status: 'published'
+  };
+}
+
+/**
+ * The ONLY ordering implementation (R1-F9): date DESC, slug DESC tiebreak, undated-last (R3-F18).
+ */
+export function compareBlogPosts(a: BlogPost, b: BlogPost): number {
+  const aDated = a.date.length > 0;
+  const bDated = b.date.length > 0;
+  if (aDated !== bDated) return aDated ? -1 : 1; // undated sorts last
+
+  if (a.date !== b.date) return a.date < b.date ? 1 : -1; // date DESC
+  if (a.slug !== b.slug) return a.slug < b.slug ? 1 : -1; // slug DESC
+  return 0;
+}
+
+/**
+ * Public index read path: published rows only (filtered in SQL), normalized + sorted.
+ */
+export async function getPublishedPosts(): Promise<BlogPost[]> {
+  // >~50 posts → switch to a no-body list projection (R1-F53)
+  const entries = await db.content.getCollection('blog');
+  return entries
+    .map(normalizeBlogEntry)
+    .filter((post): post is BlogPost => post !== null)
+    .sort(compareBlogPosts);
+}
+
+/**
+ * Public post read path: a single published post (drafts are `null` via SQL), normalized.
+ */
+export async function getPublishedPost(slug: string): Promise<BlogPost | null> {
+  const entry = await db.content.getEntry('blog', slug);
+  return entry ? normalizeBlogEntry(entry) : null;
+}
+
+/**
+ * Admin list read path: ALL `type='blog'` rows with NO status filter (R1-F9) — drafts and
+ * stray-status rows included. Uncached (queries directly) so the author always sees their save.
+ */
+export async function getManagedBlogPosts(): Promise<BlogPost[]> {
+  const rows = await queryRows<{
+    id: string;
+    slug: string;
+    title: string | null;
+    status: string;
+    data: Record<string, unknown> | null;
+  }>("SELECT id, slug, title, status, data FROM content WHERE type = 'blog'", []);
+
+  return rows
+    .map(row => {
+      const data = { ...(row.data ?? {}) };
+      // Merge the title column into data.title (mirrors toContentEntry).
+      if (typeof row.title === 'string' && row.title.length > 0) {
+        data.title = row.title;
+      }
+      const entry: ContentEntry = {
+        id: row.id,
+        slug: row.slug,
+        collection: 'blog',
+        data,
+        body: typeof data.body === 'string' ? data.body : ''
+      };
+      const post = normalizeBlogEntry(entry);
+      if (!post) return null;
+      // Admin list shows the real status from the SQL column, not the published default.
+      post.status = row.status;
+      return post;
+    })
+    .filter((post): post is BlogPost => post !== null)
+    .sort(compareBlogPosts);
+}
+
+/**
+ * Date-prefix 301 fallback (R2-F37). Returns the stripped slug when `slug` is date-prefixed
+ * (`YYYY-MM-DD-…`) AND the stripped target resolves to a PUBLISHED post; `null` otherwise
+ * (no prefix, miss, or stripped target is a draft). Unit-pinned so a refactor cannot leak
+ * draft existence via 301.
+ */
+export async function resolveLegacyBlogRedirect(slug: string): Promise<string | null> {
+  const match = DATE_PREFIX_REGEX.exec(slug);
+  if (!match) return null;
+  const stripped = match[1];
+  const post = await getPublishedPost(stripped);
+  return post ? stripped : null;
+}
+
+/**
+ * Write-path normalizer (called by the endpoint BEFORE validation). Returns a new object.
+ */
+export function normalizeBlogData(data: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { ...data };
+
+  // Trim short string fields.
+  for (const key of ['date', 'author', 'image', 'imageAlt', 'seoTitle', 'seoDescription']) {
+    if (typeof normalized[key] === 'string') {
+      normalized[key] = (normalized[key] as string).trim();
+    }
+  }
+
+  // Backstop the `_raw` path that skipped the parser trim (R2-F8).
+  if (typeof normalized.body === 'string') {
+    normalized.body = normalized.body.trim();
+  }
+  if (typeof normalized.excerpt === 'string') {
+    normalized.excerpt = normalized.excerpt.trim();
+  }
+
+  // Delete optional keys whose trimmed value is '' (R2-F20).
+  for (const key of ['image', 'imageAlt', 'seoTitle', 'seoDescription', 'date']) {
+    if (normalized[key] === '') {
+      delete normalized[key];
+    }
+  }
+
+  // Default author when missing/empty.
+  if (typeof normalized.author !== 'string' || normalized.author.trim().length === 0) {
+    normalized.author = DEFAULT_AUTHOR;
+  }
+
+  // Leave categories / tags untouched (R1-F12).
+  return normalized;
+}
+
+const isValidImageAlt = (alt: string): boolean =>
+  alt.length >= IMAGE_ALT_MIN && !FILENAME_LIKE_REGEX.test(alt) && !GENERIC_WORD_REGEX.test(alt);
+
+/**
+ * Collect every image token's alt text from a markdown body (R2-F26). Image tokens are
+ * nested inside paragraph/list/table tokens, so reuse marked's full traversal via walkTokens.
+ */
+const collectBodyImageAlts = (markdown: string): string[] => {
+  const alts: string[] = [];
+  const collector = new Marked({ gfm: true, async: false });
+  collector.use({
+    walkTokens(token) {
+      if (token.type === 'image') {
+        alts.push(typeof token.text === 'string' ? token.text : '');
+      }
+    }
+  });
+  collector.parse(markdown);
+  return alts;
+};
+
+/**
+ * Write-path validator. Returns a plain-language error string, or `null` if valid.
+ * Order matters — the explicit-status check is FIRST.
+ *
+ * `data.slug` arrives via an augmented copy (`{ ...data, slug }`) so this function is testable
+ * in isolation; the endpoint NEVER persists `slug` into the JSONB `data` column.
+ */
+export function validateBlogData(
+  data: Record<string, unknown>,
+  title: string | null,
+  rawStatus: string | undefined
+): string | null {
+  // 1. Explicit-status check FIRST, against the RAW pre-default value (R2-F2).
+  const statusValue = typeof rawStatus === 'string' ? rawStatus.trim().toLowerCase() : '';
+  if (statusValue !== 'draft' && statusValue !== 'published') {
+    return 'Status must be Draft or Published';
+  }
+  const isPublishing = statusValue === 'published';
+
+  // 2. Slug shape + date-prefix rejection (R2-F19).
+  const slug = typeof data.slug === 'string' ? data.slug : '';
+  if (!SLUG_REGEX.test(slug)) {
+    return 'Address must be 1–100 characters of lowercase letters, numbers, hyphen, or underscore';
+  }
+  if (/^\d{4}-\d{2}-\d{2}-/.test(slug)) {
+    return 'Address must not start with a date (YYYY-MM-DD-) — that format is reserved';
+  }
+
+  // 3. Length caps (R1-F6).
+  const titleValue = typeof title === 'string' ? title.trim() : '';
+  if (!titleValue) {
+    return 'Title is required';
+  }
+  if (titleValue.length > TITLE_MAX) {
+    return `Title must be ${TITLE_MAX} characters or fewer`;
+  }
+  if (slug.length > SLUG_MAX) {
+    return `Address must be ${SLUG_MAX} characters or fewer`;
+  }
+  const excerpt = typeof data.excerpt === 'string' ? data.excerpt : '';
+  if (excerpt.length > EXCERPT_MAX) {
+    return `Excerpt must be ${EXCERPT_MAX} characters or fewer`;
+  }
+  const body = typeof data.body === 'string' ? data.body : '';
+  if (body.length > BODY_MAX) {
+    return `Body must be ${BODY_MAX} characters or fewer`;
+  }
+
+  // 4. Featured-image URL scheme (backslash-aware) — R2-F1/R3-F2.
+  const image = typeof data.image === 'string' ? data.image : '';
+  if (image && !IMAGE_SCHEME_REGEX.test(image)) {
+    return 'Featured image must be an HTTPS URL or a site-relative path';
+  }
+
+  // 5. imageAlt quality when both image and imageAlt are present (R1-F37).
+  const imageAlt = typeof data.imageAlt === 'string' ? data.imageAlt : '';
+  if (image && imageAlt && !isValidImageAlt(imageAlt)) {
+    return 'Featured image alt text must be descriptive (at least 6 characters, not a filename or a single generic word)';
+  }
+
+  // Drafts are exempt from the publish requirements below.
+  if (!isPublishing) {
+    return null;
+  }
+
+  // 6. Publish requirements.
+  if (!excerpt.trim()) {
+    return 'Excerpt is required to publish';
+  }
+  if (!body.trim()) {
+    return 'Body is required to publish';
+  }
+  const date = typeof data.date === 'string' ? data.date.trim() : '';
+  if (!date || !DATE_FORMAT_REGEX.test(date) || Number.isNaN(Date.parse(date))) {
+    return 'A valid publish date (YYYY-MM-DD) is required to publish';
+  }
+  if (image && !imageAlt) {
+    return 'Featured image alt text is required to publish';
+  }
+
+  // 7. Body-image alt walk (publish-only) — every body image needs quality alt text (R2-F26).
+  for (const alt of collectBodyImageAlts(body)) {
+    if (!isValidImageAlt(alt.trim())) {
+      return 'Every image in the post body must have descriptive alt text (at least 6 characters, not a filename or a single generic word)';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The ONLY place `set:html` content is produced. Pipeline: marked (walkTokens www-normalizer +
+ * heading renderer override) → DOMPurify.sanitize(STRICT_CONFIG) → string.
+ *
+ * `previousDepth` (and the `Marked` instance) are created FRESH per call (R4-F22) — module-scope
+ * state would let the admin list's second post continue the first post's heading clamp.
+ */
+export function renderPostBody(markdown: string): string {
+  if (typeof markdown !== 'string' || markdown.length === 0) return '';
+
+  let previousDepth = 1; // the page <h1> precedes the body
+  const renderer = new Marked({ gfm: true, async: false });
+
+  renderer.use({
+    walkTokens(token) {
+      // marked stores both link and image URLs on `token.href`.
+      if (
+        (token.type === 'link' || token.type === 'image') &&
+        typeof token.href === 'string' &&
+        token.href.startsWith('www.')
+      ) {
+        token.href = `https://${token.href}`;
+      }
+    },
+    renderer: {
+      heading({ tokens, depth }) {
+        // Demote h1 → h2, then clamp heading-level skips. NO id emission (R4-F6).
+        let level = depth === 1 ? 2 : depth;
+        level = Math.min(level, previousDepth + 1);
+        previousDepth = level;
+        const text = this.parser.parseInline(tokens);
+        return `<h${level}>${text}</h${level}>\n`;
+      }
+    }
+  });
+
+  const html = renderer.parse(markdown) as string;
+
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: [
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'p',
+      'a',
+      'ul',
+      'ol',
+      'li',
+      'strong',
+      'em',
+      'b',
+      'i',
+      'blockquote',
+      'code',
+      'pre',
+      'img',
+      'hr',
+      'br',
+      'table',
+      'thead',
+      'tbody',
+      'tr',
+      'th',
+      'td',
+      'del'
+    ],
+    ALLOWED_ATTR: ['href', 'src', 'alt', 'title'], // NO 'id'
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: false,
+    ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i
+  });
+}
+
+/**
+ * Escape `& < > " '` for XML safety (`&` first).
+ */
+export function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Build the `<urlset>` sitemap document. Emits SLASHLESS URLs (R2-F5/F17): `{origin}/blog`
+ * and `{origin}/blog/{slug}` — never `/blog/`. No `lastmod` (R1-F7). Every URL is XML-escaped.
+ */
+export function renderBlogSitemapXml(posts: BlogPost[], origin: string): string {
+  const urls = [
+    `  <url>\n    <loc>${escapeXml(`${origin}/blog`)}</loc>\n  </url>`,
+    ...posts.map(
+      post => `  <url>\n    <loc>${escapeXml(`${origin}/blog/${post.slug}`)}</loc>\n  </url>`
+    )
+  ];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>`;
+}

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -58,27 +58,32 @@ const emptyToUndefined = (value: string): string | undefined =>
   value.length > 0 ? value : undefined;
 
 /**
- * Read-path trust boundary — the single tolerant mapper from a stored `ContentEntry`
- * to a `BlogPost`. Returns `null` to skip a row that cannot be trusted/rendered.
+ * Shared field mapper — builds a `BlogPost` from a stored `ContentEntry` WITHOUT the
+ * date/excerpt completeness gate. Returns `null` only when the row is structurally
+ * untrustworthy (slug fails the charset/length shape or title is absent).
  *
  * Data-key invariant (AMENDMENT 1): `body` is read from `entry.body`; `title` and every
  * other field are read from `entry.data.*` (`toContentEntry` merges the title column into
  * `entry.data.title`). There is no top-level `entry.date`/`entry.author`.
  *
- * `status` defaults to `'published'` here — the published read path only ever sees
- * published rows. `getManagedBlogPosts` overwrites `status` from the SQL column afterward.
+ * `status` defaults to `'published'` — the published read path only ever sees published
+ * rows. `getManagedBlogPosts` overwrites `status` from the SQL column afterward.
+ *
+ * The two read paths differ only in their completeness requirement, layered on top:
+ *   - `normalizeBlogEntry` (public): also drops rows missing date or excerpt.
+ *   - `getManagedBlogPosts` (admin): keeps bare drafts so an author always sees their save.
  */
-export function normalizeBlogEntry(entry: ContentEntry): BlogPost | null {
+function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
   const slug = typeof entry.slug === 'string' ? entry.slug : '';
   if (!SLUG_REGEX.test(slug)) return null;
 
   const data = (entry.data ?? {}) as Record<string, unknown>;
 
   const title = asTrimmedString(data.title);
+  if (!title) return null;
+
   const date = asTrimmedString(data.date);
   const excerpt = asTrimmedString(data.excerpt);
-  if (!title || !date || !excerpt) return null;
-
   const body = typeof entry.body === 'string' ? entry.body : '';
   const author = asTrimmedString(data.author) || DEFAULT_AUTHOR;
 
@@ -99,6 +104,19 @@ export function normalizeBlogEntry(entry: ContentEntry): BlogPost | null {
     seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
     status: 'published'
   };
+}
+
+/**
+ * Public read-path trust boundary — the single tolerant mapper from a stored `ContentEntry`
+ * to a renderable `BlogPost`. Returns `null` to skip a row that cannot be trusted/rendered:
+ * a bad slug, or a row missing the title/date/excerpt the public index and post page require.
+ */
+export function normalizeBlogEntry(entry: ContentEntry): BlogPost | null {
+  const post = mapEntryToBlogPost(entry);
+  if (!post) return null;
+  // Public surfaces require a date and excerpt; a bare draft is not renderable here.
+  if (!post.date || !post.excerpt) return null;
+  return post;
 }
 
 /**
@@ -161,7 +179,10 @@ export async function getManagedBlogPosts(): Promise<BlogPost[]> {
         data,
         body: typeof data.body === 'string' ? data.body : ''
       };
-      const post = normalizeBlogEntry(entry);
+      // Relaxed mapping (NOT normalizeBlogEntry): the admin list must show bare drafts —
+      // a title-only draft is a valid save (validateBlogData exempts drafts from
+      // date/excerpt), so requiring date+excerpt here would hide the author's own row.
+      const post = mapEntryToBlogPost(entry);
       if (!post) return null;
       // Admin list shows the real status from the SQL column, not the published default.
       post.status = row.status;

--- a/app/src/lib/db/__tests__/content.test.ts
+++ b/app/src/lib/db/__tests__/content.test.ts
@@ -113,6 +113,22 @@ describe('db.content facade', () => {
     );
   });
 
+  it('pins draft-invisibility: fetchCollection AND fetchEntry SQL filter status = published (R1-F41)', async () => {
+    queryRowsMock.mockResolvedValueOnce([]);
+    queryFirstMock.mockResolvedValueOnce(null);
+
+    await getCollection('blog');
+    expect(queryRowsMock).toHaveBeenCalledWith(expect.stringContaining("status = 'published'"), [
+      'blog'
+    ]);
+
+    await getEntry('blog', 'some-slug');
+    expect(queryFirstMock).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE type = $1 AND slug = $2 AND status = 'published'"),
+      ['blog', 'some-slug']
+    );
+  });
+
   it('parses and caches settings values from the service client', async () => {
     queryFirstMock.mockResolvedValueOnce({ key: 'homepage', value: '{"cta":"Join"}' });
 

--- a/app/src/lib/site-origin.ts
+++ b/app/src/lib/site-origin.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared site-origin resolver.
+ *
+ * Precedence: `site?.origin` → `process.env.PUBLIC_SITE_URL` → hardcoded prod fallback.
+ * Hoisted verbatim from `robots.txt.ts` so the same resolution is reused by robots,
+ * the blog sitemap shell, and per-post ogImage construction (PR-4).
+ *
+ * NOTE: a structurally-similar private `resolveSiteOrigin` exists in `seo-config.ts`
+ * (accepts `URL | string`); this file is NOT a refactor of that helper.
+ */
+export function resolveSiteOrigin(site?: URL): string {
+  if (site?.origin) return site.origin;
+
+  if (typeof process !== 'undefined' && typeof process.env.PUBLIC_SITE_URL === 'string') {
+    try {
+      return new URL(process.env.PUBLIC_SITE_URL).origin;
+    } catch {
+      // fall through to fallback
+    }
+  }
+
+  return 'https://spicebushmontessori.org';
+}

--- a/app/src/pages/api/admin/content.test.ts
+++ b/app/src/pages/api/admin/content.test.ts
@@ -118,6 +118,29 @@ describe('POST /api/admin/content — createOnly (test 12)', () => {
     expect(queryMock.mock.calls[0][0]).toContain('DO NOTHING');
     expect(invalidateMock).toHaveBeenCalledWith('blog');
   });
+
+  it('coerces a JSON-body createOnly:"false" (string) to the DO UPDATE branch (F2)', async () => {
+    // The JSON path passes the body through untouched, so a string "false" would be truthy
+    // and wrongly take DO NOTHING — turning an edit into a 400 collision. parseBooleanValue
+    // must coerce it to false regardless of source.
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never);
+    const request = new Request(ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        collection: 'blog',
+        slug: 'a-new-post',
+        title: 'A New Post',
+        status: 'published',
+        createOnly: 'false',
+        data: { date: '2024-01-01', excerpt: 'An excerpt', body: 'Hello world' }
+      })
+    });
+    const response = await callPost(request);
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DO UPDATE');
+    expect(queryMock.mock.calls[0][0]).not.toContain('DO NOTHING');
+  });
 });
 
 describe('POST /api/admin/content — allowlist + delete + origin + redirect (test 13)', () => {

--- a/app/src/pages/api/admin/content.test.ts
+++ b/app/src/pages/api/admin/content.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lib/admin-auth-check', () => ({ checkAdminAuth: vi.fn() }));
+vi.mock('@lib/db/client', () => ({ query: vi.fn() }));
+vi.mock('@lib/db', () => ({ db: { cache: { invalidateCollection: vi.fn() } } }));
+
+import { checkAdminAuth } from '@lib/admin-auth-check';
+import { query } from '@lib/db/client';
+import { db } from '@lib/db';
+import { POST } from './content';
+
+const queryMock = vi.mocked(query);
+const invalidateMock = vi.mocked(db.cache.invalidateCollection);
+const authMock = vi.mocked(checkAdminAuth);
+
+const ENDPOINT = 'http://localhost/api/admin/content';
+
+const formRequest = (
+  fields: Record<string, string>,
+  headers: Record<string, string> = {}
+): Request => {
+  const body = new URLSearchParams(fields);
+  return new Request(ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
+    body: body.toString()
+  });
+};
+
+const callPost = (request: Request) =>
+  POST({ request, locals: {} } as unknown as Parameters<typeof POST>[0]);
+
+// A valid published blog post field set used as a baseline.
+const validBlogFields = (): Record<string, string> => ({
+  collection: 'blog',
+  slug: 'a-new-post',
+  title: 'A New Post',
+  status: 'published',
+  'data.date': '2024-01-01',
+  'data.excerpt': 'An excerpt',
+  'data.body_raw': 'Hello world'
+});
+
+beforeEach(() => {
+  queryMock.mockReset();
+  invalidateMock.mockReset();
+  authMock.mockReset();
+  // Default: authenticated admin. Default query resolves as a successful upsert.
+  authMock.mockResolvedValue({
+    isAuthenticated: true,
+    isAdmin: true,
+    session: { userEmail: 'admin@spicebush.org' } as never,
+    user: null
+  });
+  queryMock.mockResolvedValue({ rows: [], rowCount: 1 } as never);
+});
+
+describe('POST /api/admin/content — _raw round-trip (test 11)', () => {
+  it('stores _raw fields byte-identical as strings (not coerced)', async () => {
+    const response = await callPost(
+      formRequest({
+        collection: 'blog',
+        slug: 'raw-post',
+        title: 'Raw Post',
+        status: 'draft',
+        'data.body_raw': '{"a":1}',
+        'data.excerpt_raw': '2024'
+      })
+    );
+    expect(response.status).toBe(200);
+    const dataJson = queryMock.mock.calls[0][1]?.[3] as string;
+    const stored = JSON.parse(dataJson);
+    expect(stored.body).toBe('{"a":1}');
+    expect(typeof stored.body).toBe('string');
+    expect(stored.excerpt).toBe('2024');
+    expect(typeof stored.excerpt).toBe('string');
+  });
+
+  it('keeps a "true" body_raw as the string "true"', async () => {
+    await callPost(
+      formRequest({
+        collection: 'blog',
+        slug: 'bool-post',
+        title: 'Bool Post',
+        status: 'draft',
+        'data.body_raw': 'true'
+      })
+    );
+    const dataJson = queryMock.mock.calls[0][1]?.[3] as string;
+    expect(JSON.parse(dataJson).body).toBe('true');
+  });
+});
+
+describe('POST /api/admin/content — createOnly (test 12)', () => {
+  it('returns 400 with a collision message when the row already exists', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+    const response = await callPost(formRequest({ ...validBlogFields(), createOnly: 'true' }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/already exists/i);
+    // Insert-only SQL path was used.
+    expect(queryMock.mock.calls[0][0]).toContain('DO NOTHING');
+    expect(invalidateMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the upsert (DO UPDATE) when createOnly is absent', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never);
+    const response = await callPost(formRequest(validBlogFields()));
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DO UPDATE');
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+
+  it('succeeds on createOnly when no conflict (rowCount 1)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never);
+    const response = await callPost(formRequest({ ...validBlogFields(), createOnly: 'true' }));
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DO NOTHING');
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+});
+
+describe('POST /api/admin/content — allowlist + delete + origin + redirect (test 13)', () => {
+  it('accepts a valid blog POST (upsert + cache invalidate)', async () => {
+    const response = await callPost(formRequest(validBlogFields()));
+    expect(response.status).toBe(200);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+
+  it('handles action=delete for blog (DELETE + invalidate + success)', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'blog', slug: 'gone', action: 'delete' })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DELETE FROM content');
+    expect(queryMock.mock.calls[0][1]).toEqual(['blog', 'gone']);
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+
+  it('rejects a non-allowlisted collection with 400', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'users', slug: 'x', title: 'x', status: 'draft' })
+    );
+    expect(response.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a mismatched Origin header with 403', async () => {
+    const response = await callPost(
+      formRequest(validBlogFields(), { origin: 'https://evil.example.com' })
+    );
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects Sec-Fetch-Site: cross-site with 403', async () => {
+    const response = await callPost(
+      formRequest(validBlogFields(), { 'sec-fetch-site': 'cross-site' })
+    );
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when Origin matches the request origin', async () => {
+    const response = await callPost(formRequest(validBlogFields(), { origin: 'http://localhost' }));
+    expect(response.status).toBe(200);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds (fail-open) when both Origin and Sec-Fetch-Site are absent', async () => {
+    const response = await callPost(formRequest(validBlogFields()));
+    expect(response.status).toBe(200);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('parseRedirectPath rejects backslash + protocol-relative paths', async () => {
+    // Validation failure (date-prefixed slug) with a malicious redirectTo: because the redirect is
+    // rejected (→ null), responseByFormat returns JSON 400, NOT a 303 to the evil path.
+    const backslash = await callPost(
+      formRequest({ ...validBlogFields(), slug: '2026-08-01-festival', redirectTo: '/\\evil.com' })
+    );
+    expect(backslash.status).toBe(400);
+    expect(backslash.headers.get('location')).toBeNull();
+
+    const protoRel = await callPost(
+      formRequest({ ...validBlogFields(), slug: '2026-08-01-festival', redirectTo: '//evil.com' })
+    );
+    expect(protoRel.status).toBe(400);
+    expect(protoRel.headers.get('location')).toBeNull();
+  });
+
+  it('parseRedirectPath accepts a safe path → 303 Location on a validation failure', async () => {
+    const response = await callPost(
+      formRequest({
+        ...validBlogFields(),
+        slug: '2026-08-01-festival',
+        redirectTo: '/admin/blog?saved=new'
+      })
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('/admin/blog');
+    expect(response.headers.get('location')).toContain('error=');
+  });
+
+  it('accepts a safe redirectTo → 303 Location on success', async () => {
+    const response = await callPost(
+      formRequest({ ...validBlogFields(), redirectTo: '/admin/blog?saved=new' })
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe('/admin/blog?saved=new');
+  });
+});
+
+describe('POST /api/admin/content — blog validation (test 13 / acceptance)', () => {
+  it('rejects a missing status with 400 (R2-F2)', async () => {
+    const fields = validBlogFields();
+    delete fields.status;
+    const response = await callPost(formRequest(fields));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Status must be Draft or Published');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a date-prefixed slug with 400 (R2-F19)', async () => {
+    const response = await callPost(
+      formRequest({ ...validBlogFields(), slug: '2026-08-01-festival' })
+    );
+    expect(response.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a published body containing ![](x) with 400 (R2-F26)', async () => {
+    const response = await callPost(
+      formRequest({ ...validBlogFields(), 'data.body_raw': '![](x)' })
+    );
+    expect(response.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes a mixed-case status to lowercase before storing', async () => {
+    // validateBlogData accepts status case-insensitively; the SQL read filter is exact
+    // `status = 'published'`, so the stored value must be lowercase or the post vanishes.
+    const response = await callPost(formRequest({ ...validBlogFields(), status: 'Published' }));
+    expect(response.status).toBe(200);
+    // Stored status is the 5th positional param ($5) in the upsert values.
+    expect(queryMock.mock.calls[0][1]?.[4]).toBe('published');
+  });
+});
+
+describe('POST /api/admin/content — auth (test 14)', () => {
+  it('returns 403 ONLY for an authenticated non-admin', async () => {
+    authMock.mockResolvedValue({
+      isAuthenticated: true,
+      isAdmin: false,
+      session: { userEmail: 'user@x.org' } as never,
+      user: null
+    });
+    const response = await callPost(formRequest(validBlogFields()));
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/admin/content — existing-collection regression (test 15, R4-F32)', () => {
+  it('still saves an existing collection (faq) through the modified handler, headers absent', async () => {
+    const response = await callPost(
+      formRequest({
+        collection: 'faq',
+        slug: 'q1',
+        title: 'Q1',
+        status: 'published',
+        'data.section_title': 'General',
+        'data.question': 'How?',
+        'data.answer': 'Like so.'
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DO UPDATE');
+    expect(invalidateMock).toHaveBeenCalledWith('faq');
+  });
+
+  it('still deletes an existing collection (faq) via action=delete, headers absent', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'faq', slug: 'q1', action: 'delete' })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DELETE FROM content');
+    expect(invalidateMock).toHaveBeenCalledWith('faq');
+  });
+});

--- a/app/src/pages/api/admin/content.ts
+++ b/app/src/pages/api/admin/content.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { checkAdminAuth } from '@lib/admin-auth-check';
 import { db } from '@lib/db';
 import { query } from '@lib/db/client';
+import { normalizeBlogData, validateBlogData } from '@lib/blog-content';
 
 const ALLOWED_COLLECTIONS = new Set([
   'hours',
@@ -12,7 +13,8 @@ const ALLOWED_COLLECTIONS = new Set([
   'photos',
   'faq',
   'testimonials',
-  'media-slots'
+  'media-slots',
+  'blog'
 ]);
 
 type ContentPayload = {
@@ -24,6 +26,8 @@ type ContentPayload = {
   dataJson?: string;
   baseDataJson?: string;
   redirectTo?: string;
+  createOnly?: boolean;
+  action?: string;
 };
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -100,6 +104,14 @@ const parseFormDataPayload = (formData: FormData): ContentPayload => {
       continue;
     }
 
+    // `_raw` suffix: store the raw string, skipping parseSimpleValue coercion + trim.
+    // The blog form uses data.body_raw / data.excerpt_raw; the parser's trim is restored
+    // by normalizeBlogData (R2-F8).
+    if (dataKey.endsWith('_raw')) {
+      data[dataKey.slice(0, -4)] = typeof value === 'string' ? value : '';
+      continue;
+    }
+
     data[dataKey] = parseFormValue(value);
   }
 
@@ -111,7 +123,9 @@ const parseFormDataPayload = (formData: FormData): ContentPayload => {
     data: Object.keys(data).length > 0 ? data : undefined,
     dataJson: String(formData.get('dataJson') ?? ''),
     baseDataJson: String(formData.get('baseDataJson') ?? ''),
-    redirectTo: String(formData.get('redirectTo') ?? '')
+    redirectTo: String(formData.get('redirectTo') ?? ''),
+    createOnly: parseBooleanValue(formData.get('createOnly'), false),
+    action: String(formData.get('action') ?? '')
   };
 };
 
@@ -132,8 +146,8 @@ const parseJsonObject = (value: string): Record<string, unknown> | null => {
 
 const parseRedirectPath = (value: unknown): string | null => {
   if (typeof value !== 'string') return null;
-  if (!value.startsWith('/') || value.startsWith('//')) return null;
-  return value;
+  // Reject backslash-leading paths (`/\evil.com`) that browsers resolve off-site as `//evil.com`.
+  return /^\/(?![/\\])/.test(value) ? value : null;
 };
 
 const parseBody = async (request: Request): Promise<ContentPayload | null> => {
@@ -402,6 +416,21 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
   }
 
+  // Defense-in-depth CSRF check (SameSite=Lax remains the primary defense). Rejects only on
+  // positive cross-site evidence — fails open when both headers are absent. Hardens ALL admin
+  // collection POSTs, not just blog.
+  const requestOrigin = new URL(request.url).origin;
+  const origin = request.headers.get('origin');
+  if (
+    (origin && origin !== requestOrigin) ||
+    request.headers.get('sec-fetch-site') === 'cross-site'
+  ) {
+    return new Response(JSON.stringify({ error: 'Cross-site request rejected' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
   const payload = await parseBody(request);
   if (!payload) {
     return new Response(JSON.stringify({ error: 'Invalid request body' }), {
@@ -413,7 +442,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const collection = payload.collection?.trim();
   const slug = payload.slug?.trim().toLowerCase();
   const title = payload.title?.trim() || null;
-  const status = payload.status?.trim() || 'published';
+  let status = payload.status?.trim() || 'published';
   const redirectTo = parseRedirectPath(payload.redirectTo);
 
   if (!collection || !ALLOWED_COLLECTIONS.has(collection)) {
@@ -428,6 +457,26 @@ export const POST: APIRoute = async ({ request, locals }) => {
     );
   }
 
+  // Form-based delete: `action=delete` runs the same DELETE as the standalone DELETE export and
+  // responds via responseByFormat (HTML form posts get a 303). No data parse needed.
+  if (payload.action === 'delete') {
+    try {
+      await query(
+        `
+          DELETE FROM content
+          WHERE type = $1 AND slug = $2
+        `,
+        [collection, slug]
+      );
+
+      db.cache.invalidateCollection(collection);
+
+      return responseByFormat(redirectTo, { success: true, collection, slug });
+    } catch {
+      return responseByFormat(redirectTo, { error: 'Failed to delete content' }, 500);
+    }
+  }
+
   const rawData = parseDataPayload(payload);
   if (!rawData) {
     return responseByFormat(redirectTo, { error: 'Content data must be a JSON object' }, 400);
@@ -438,6 +487,21 @@ export const POST: APIRoute = async ({ request, locals }) => {
     data = normalizeFaqData(rawData);
   } else if (collection === 'testimonials') {
     data = normalizeTestimonialsData(rawData);
+  } else if (collection === 'blog') {
+    data = normalizeBlogData(rawData);
+  }
+
+  if (collection === 'blog') {
+    // Pass payload.status (RAW form value, BEFORE the `|| 'published'` default at the `status`
+    // local above) so blog status omission is a 400, never a silent publish. The default stays
+    // untouched for all other collections (R2-F2). `{ ...data, slug }` lets validateBlogData see
+    // the slug for the date-prefix/shape check; `slug` is NEVER persisted into the JSONB data.
+    const error = validateBlogData({ ...data, slug }, title, payload.status);
+    if (error) return responseByFormat(redirectTo, { error }, 400);
+    // Canonicalize to the validated lowercase status. validateBlogData accepts status
+    // case-insensitively; the SQL read filter is exact `status = 'published'`, so storing
+    // 'Published' verbatim would make the post silently invisible on the public site.
+    status = (payload.status as string).trim().toLowerCase();
   }
 
   if (collection === 'faq') {
@@ -467,9 +531,41 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
   }
 
+  const upsertValues = [
+    collection,
+    slug,
+    title,
+    JSON.stringify(data),
+    status,
+    session.userEmail ?? null,
+    new Date().toISOString()
+  ];
+
   try {
-    await query(
-      `
+    if (payload.createOnly) {
+      // Insert-only: a conflicting (type, slug) is left untouched and reported as a collision.
+      const result = await query(
+        `
+          INSERT INTO content (type, slug, title, data, status, author_email, updated_at)
+          VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+          ON CONFLICT (type, slug) DO NOTHING
+        `,
+        upsertValues
+      );
+
+      if (result.rowCount === 0) {
+        return responseByFormat(
+          redirectTo,
+          {
+            error:
+              'A post with this address already exists — change the address or edit the existing post.'
+          },
+          400
+        );
+      }
+    } else {
+      await query(
+        `
         INSERT INTO content (type, slug, title, data, status, author_email, updated_at)
         VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
         ON CONFLICT (type, slug)
@@ -480,16 +576,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
           author_email = EXCLUDED.author_email,
           updated_at = EXCLUDED.updated_at
       `,
-      [
-        collection,
-        slug,
-        title,
-        JSON.stringify(data),
-        status,
-        session.userEmail ?? null,
-        new Date().toISOString()
-      ]
-    );
+        upsertValues
+      );
+    }
 
     db.cache.invalidateCollection(collection);
 

--- a/app/src/pages/api/admin/content.ts
+++ b/app/src/pages/api/admin/content.ts
@@ -146,6 +146,11 @@ const parseJsonObject = (value: string): Record<string, unknown> | null => {
 
 const parseRedirectPath = (value: unknown): string | null => {
   if (typeof value !== 'string') return null;
+  // Reject any control character (CR/LF included) so a redirectTo can never carry a
+  // header-splitting payload regardless of which response branch sets the Location header
+  // (defense-in-depth — the success branch sets Location directly, unnormalized). R2-F1.
+  // eslint-disable-next-line no-control-regex -- intentionally matching control chars to reject them
+  if (/[\x00-\x1f]/.test(value)) return null;
   // Reject backslash-leading paths (`/\evil.com`) that browsers resolve off-site as `//evil.com`.
   return /^\/(?![/\\])/.test(value) ? value : null;
 };
@@ -444,6 +449,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const title = payload.title?.trim() || null;
   let status = payload.status?.trim() || 'published';
   const redirectTo = parseRedirectPath(payload.redirectTo);
+  // Coerce defensively regardless of source (R2-F2 work order §6 Change 5): the form path
+  // already coerced via parseFormDataPayload, but the JSON path passes the body through
+  // untouched, so a JSON `createOnly: "false"` (string) would be truthy and wrongly take the
+  // insert-only DO NOTHING branch — turning an edit into a 400 collision.
+  const createOnly = parseBooleanValue(payload.createOnly, false);
 
   if (!collection || !ALLOWED_COLLECTIONS.has(collection)) {
     return responseByFormat(redirectTo, { error: 'Collection is not allowed' }, 400);
@@ -542,7 +552,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   ];
 
   try {
-    if (payload.createOnly) {
+    if (createOnly) {
       // Insert-only: a conflicting (type, slug) is left untouched and reported as a collision.
       const result = await query(
         `

--- a/app/src/pages/robots.txt.ts
+++ b/app/src/pages/robots.txt.ts
@@ -1,21 +1,8 @@
 import type { APIRoute } from 'astro';
 import { getSeoSettings } from '@lib/seo-config';
+import { resolveSiteOrigin } from '@lib/site-origin';
 
 export const prerender = false;
-
-const resolveSiteOrigin = (site?: URL): string => {
-  if (site?.origin) return site.origin;
-
-  if (typeof process !== 'undefined' && typeof process.env.PUBLIC_SITE_URL === 'string') {
-    try {
-      return new URL(process.env.PUBLIC_SITE_URL).origin;
-    } catch {
-      // fall through to fallback
-    }
-  }
-
-  return 'https://spicebushmontessori.org';
-};
 
 export const GET: APIRoute = async ({ site }) => {
   const siteOrigin = resolveSiteOrigin(site);

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -323,14 +323,20 @@ receive a `303` redirect (with `redirectTo`) rather than a JSON body.
 
 **`parseRedirectPath` hardening**: the `redirectTo` validator rejects
 backslash-leading paths (`/\evil.com`) that browsers resolve off-site as
-`//evil.com` — regex `^\/(?![/\\])`. A rejected `redirectTo` falls back to a JSON
+`//evil.com` — regex `^\/(?![/\\])`. It also rejects any value containing a
+control character (`\x00`–`\x1f`, CR/LF included) so a `redirectTo` can never
+carry a header-splitting payload regardless of which response branch sets the
+`Location` header (defense-in-depth). A rejected `redirectTo` falls back to a JSON
 response (no `303` to the unsafe path).
 
 **Blog explicit-status requirement**: blog POSTs must carry a `status` of `draft`
 or `published` **explicitly**. A missing / empty / whitespace-only status is a
 `400` ("Status must be Draft or Published"), checked first against the raw form
 value — never silently defaulted to `published`. The `status || 'published'`
-default still applies to all other collections.
+default still applies to all other collections. The validated status is stored
+**lowercased** (`draft` / `published`) so a mixed-case input (e.g. `Published`)
+cannot pass validation yet stay invisible behind the exact `status = 'published'`
+read filter.
 
 ---
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -286,15 +286,51 @@ characters.
 
 Generic content upsert/delete for allowed collections: `hours`, `staff`,
 `tuition`, `settings`, `school-info`, `photos`, `faq`, `testimonials`,
-`media-slots`.
+`media-slots`, `blog`.
 
 **POST**: Upserts a content entry by `(collection, slug)`. Slug is validated
 (`[a-z0-9-_]+`). Supports `dataJson`, `baseDataJson`, and `data.*` form fields.
-Collection-specific normalization for `faq` and `testimonials`.
+Collection-specific normalization for `faq`, `testimonials`, and `blog`.
 
 **DELETE**: Removes a content entry by `(collection, slug)`.
 
 Invalidates the relevant cache namespace on success.
+
+**Origin check (defense-in-depth CSRF)**: every POST is rejected with `403`
+("Cross-site request rejected") when the `Origin` header is present and does not
+match the request origin, OR when `Sec-Fetch-Site: cross-site` is sent. The check
+**fails open** when both headers are absent (rejecting only on positive cross-site
+evidence). `SameSite=Lax` cookies remain the primary CSRF defense; this hardens all
+admin collection POSTs.
+
+**`_raw` field suffix**: a `data.*_raw` form field bypasses `parseSimpleValue`
+type-coercion (and the implicit trim) and is stored as the raw string under the
+key with `_raw` stripped (e.g. `data.body_raw` → `data.body`). Used by the blog
+form for `data.body_raw` and `data.excerpt_raw`; follows the existing `_csv` /
+`_lines` convention.
+
+**`createOnly` flag**: when truthy, the upsert becomes insert-only
+(`INSERT … ON CONFLICT (type, slug) DO NOTHING`) and the result `rowCount` is
+checked. A conflict (`rowCount === 0`) returns `400` ("A post with this address
+already exists…") and leaves the existing row untouched. When falsy, the normal
+`ON CONFLICT … DO UPDATE` upsert runs. Used by the blog add-form to prevent
+silently overwriting an existing post.
+
+**Form-based delete (`action=delete`)**: a POST carrying `action=delete` runs the
+same DELETE as the standalone `DELETE` export (allowlist + slug check + cache
+invalidation) and responds via the shared response helper, so HTML form posts
+receive a `303` redirect (with `redirectTo`) rather than a JSON body.
+
+**`parseRedirectPath` hardening**: the `redirectTo` validator rejects
+backslash-leading paths (`/\evil.com`) that browsers resolve off-site as
+`//evil.com` — regex `^\/(?![/\\])`. A rejected `redirectTo` falls back to a JSON
+response (no `303` to the unsafe path).
+
+**Blog explicit-status requirement**: blog POSTs must carry a `status` of `draft`
+or `published` **explicitly**. A missing / empty / whitespace-only status is a
+`400` ("Status must be Draft or Published"), checked first against the raw form
+value — never silently defaulted to `published`. The `status || 'published'`
+default still applies to all other collections.
 
 ---
 


### PR DESCRIPTION
Closes #68. First of the 5-PR blog stack (plan: `docs/plans/blog-implementation-plan.md` §14; parent #66).

**Adds** `app/src/lib/blog-content.ts` (normalize/validate/compare/render — strict DOMPurify config per spec §8 verbatim: no ids, fragments stripped, HTTPS-only body URLs, `ALLOW_DATA_ATTR`/`ALLOW_ARIA_ATTR` pinned false; h1→h2 demotion + heading-skip clamp with per-call state; sitemap builder; legacy-slug redirect resolver) and `app/src/lib/site-origin.ts` (hoisted from robots.txt.ts). **Extends** `api/admin/content.ts` additively: blog allowlist, same-origin check (fail-open per plan), `_raw` field suffix, blog validate hooks with raw-status passthrough, `createOnly` guard, `action=delete`, backslash-hardened `parseRedirectPath`. All 9 existing collections regression-tested untouched.

**Tests:** +70 (blog-content 48, endpoint 22) incl. XSS/URI matrix with data-/aria-attribute vectors, draft-invisibility SQL pins, mutation-verified sanitizer pins. **Gates:** lint 0 warnings · typecheck 0 errors · vitest 287/287 · format:check clean.

**Review-fleet catches fixed in `4f5b17a`:** drafts-invisible-in-admin (medium), data/aria XSS vectors (medium), CRLF anchor in redirect path, +4 more.
**Deviation (deliberate, pinned by test):** blog status canonicalized to lowercase at write — case-insensitive validation + exact-match SQL read filter would otherwise make a `'Published'` post silently invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)