### PR TITLE
feat(blog): /admin/blog authoring page (PR-2)

### DIFF
--- a/app/src/components/AdminNav.astro
+++ b/app/src/components/AdminNav.astro
@@ -12,7 +12,8 @@ import {
   LineChart,
   Tent,
   Bell,
-  HandHeart
+  HandHeart,
+  Newspaper
 } from 'lucide-astro';
 
 export interface Props {
@@ -95,6 +96,14 @@ const displayName = userEmail.includes('@') ? userEmail.split('@')[0] : userEmai
         >
           <ImageIcon className="w-5 h-5 mr-3" />
           Media
+        </a>
+        <a
+          href="/admin/blog"
+          aria-current={currentPath === '/admin/blog' ? 'page' : undefined}
+          class="admin-nav-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg"
+        >
+          <Newspaper className="w-5 h-5 mr-3" />
+          Blog
         </a>
 
         <!-- Programs -->

--- a/app/src/lib/blog-admin-client.test.ts
+++ b/app/src/lib/blog-admin-client.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initBlogAdmin } from '@lib/blog-admin-client';
+import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+
+// vitest's `environment: 'jsdom'` is global (vitest.config.ts:22) — no per-file docblock needed.
+
+type FormKind = 'add' | 'edit';
+
+interface BuildOptions {
+  kind: FormKind;
+  status?: string; // initial status select value
+  imageValue?: string; // initial image URL value
+}
+
+/**
+ * Build a blog form into a fresh Document and return both. Mirrors the markup blog.astro renders:
+ * the field `name`s come from BLOG_FORM_FIELDS so the test pins the same contract the page uses.
+ */
+function buildDoc(options: BuildOptions, existingSlugs: string[] = []): { doc: Document } {
+  const doc = document.implementation.createHTMLDocument('blog-admin');
+
+  const slugContainer = doc.createElement('div');
+  slugContainer.setAttribute('data-existing-slugs', JSON.stringify(existingSlugs));
+  doc.body.appendChild(slugContainer);
+
+  const form = doc.createElement('form');
+  form.setAttribute('data-blog-form', '');
+  if (options.kind === 'add') form.setAttribute('data-new-blog-form', '');
+
+  const title = doc.createElement('input');
+  title.setAttribute('name', BLOG_FORM_FIELDS.title);
+  title.required = true;
+  form.appendChild(title);
+
+  const slug = doc.createElement('input');
+  slug.setAttribute('name', BLOG_FORM_FIELDS.slug);
+  slug.required = true;
+  form.appendChild(slug);
+
+  const status = doc.createElement('select');
+  status.setAttribute('name', BLOG_FORM_FIELDS.status);
+  const draftOpt = doc.createElement('option');
+  draftOpt.value = 'draft';
+  draftOpt.textContent = 'Draft';
+  const publishedOpt = doc.createElement('option');
+  publishedOpt.value = 'published';
+  publishedOpt.textContent = 'Published';
+  status.append(draftOpt, publishedOpt);
+  status.value = options.status ?? 'draft';
+  form.appendChild(status);
+
+  const date = doc.createElement('input');
+  date.type = 'date';
+  date.setAttribute('name', BLOG_FORM_FIELDS.date);
+  form.appendChild(date);
+
+  const excerpt = doc.createElement('textarea');
+  excerpt.setAttribute('name', BLOG_FORM_FIELDS.excerptRaw);
+  form.appendChild(excerpt);
+
+  const body = doc.createElement('textarea');
+  body.setAttribute('name', BLOG_FORM_FIELDS.bodyRaw);
+  form.appendChild(body);
+
+  const image = doc.createElement('input');
+  image.setAttribute('name', BLOG_FORM_FIELDS.image);
+  image.value = options.imageValue ?? '';
+  form.appendChild(image);
+
+  const imageAlt = doc.createElement('input');
+  imageAlt.setAttribute('name', BLOG_FORM_FIELDS.imageAlt);
+  form.appendChild(imageAlt);
+
+  doc.body.appendChild(form);
+  return { doc };
+}
+
+const field = (doc: Document, name: string): HTMLInputElement | HTMLTextAreaElement =>
+  doc.querySelector(`[name="${name}"]`) as HTMLInputElement | HTMLTextAreaElement;
+
+describe('initBlogAdmin — conditional required', () => {
+  it('sets required on excerpt/body/date at init for a published edit-form, with NO events (R2-F9)', () => {
+    const { doc } = buildDoc({ kind: 'edit', status: 'published' });
+    initBlogAdmin(doc);
+
+    expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(true);
+  });
+
+  it('leaves excerpt/body/date optional at init for a draft form', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' });
+    initBlogAdmin(doc);
+
+    expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(false);
+  });
+
+  it('sets required on publish-fields when status flips to published via change', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' });
+    initBlogAdmin(doc);
+
+    const status = doc.querySelector(`[name="${BLOG_FORM_FIELDS.status}"]`) as HTMLSelectElement;
+    status.value = 'published';
+    status.dispatchEvent(new Event('change'));
+
+    expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(true);
+  });
+
+  it('clears required on publish-fields when status reverts to draft', () => {
+    const { doc } = buildDoc({ kind: 'edit', status: 'published' });
+    initBlogAdmin(doc);
+
+    const status = doc.querySelector(`[name="${BLOG_FORM_FIELDS.status}"]`) as HTMLSelectElement;
+    status.value = 'draft';
+    status.dispatchEvent(new Event('change'));
+
+    expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(false);
+  });
+
+  it('requires imageAlt when an image value is set, releases it when cleared', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' });
+    initBlogAdmin(doc);
+
+    const image = doc.querySelector(`[name="${BLOG_FORM_FIELDS.image}"]`) as HTMLInputElement;
+    image.value = 'https://example.com/x.jpg';
+    image.dispatchEvent(new Event('input'));
+    expect(field(doc, BLOG_FORM_FIELDS.imageAlt).required).toBe(true);
+
+    image.value = '';
+    image.dispatchEvent(new Event('input'));
+    expect(field(doc, BLOG_FORM_FIELDS.imageAlt).required).toBe(false);
+  });
+
+  it('requires imageAlt at init when the image field starts non-empty (edit-form)', () => {
+    const { doc } = buildDoc({ kind: 'edit', status: 'draft', imageValue: '/images/seed.jpg' });
+    initBlogAdmin(doc);
+    expect(field(doc, BLOG_FORM_FIELDS.imageAlt).required).toBe(true);
+  });
+});
+
+describe('initBlogAdmin — slug collision (add-form)', () => {
+  it('sets custom validity + renders an inline alert when the slug collides', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' }, ['existing-post']);
+    initBlogAdmin(doc);
+
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+    slug.value = 'existing-post';
+    slug.dispatchEvent(new Event('input'));
+
+    expect(slug.validationMessage.length).toBeGreaterThan(0);
+    const alert = doc.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent ?? '').toContain('already exists');
+  });
+
+  it('clears custom validity and removes the alert when the slug changes to a free value', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' }, ['existing-post']);
+    initBlogAdmin(doc);
+
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+    slug.value = 'existing-post';
+    slug.dispatchEvent(new Event('input'));
+    expect(doc.querySelector('[role="alert"]')).not.toBeNull();
+
+    slug.value = 'a-free-slug';
+    slug.dispatchEvent(new Event('input'));
+    expect(slug.validationMessage).toBe('');
+    expect(doc.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('does not re-create/churn the alert node on a same-state (still-colliding) input', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' }, ['existing-post']);
+    initBlogAdmin(doc);
+
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+    slug.value = 'existing-post';
+    slug.dispatchEvent(new Event('input'));
+    const firstAlert = doc.querySelector('[role="alert"]');
+    expect(firstAlert).not.toBeNull();
+
+    // Still colliding (same value) — fire input again; the node must be the SAME reference.
+    slug.dispatchEvent(new Event('input'));
+    const secondAlert = doc.querySelector('[role="alert"]');
+    expect(secondAlert).toBe(firstAlert);
+  });
+
+  it('does nothing for an edit-form (no slug autofill / collision wiring)', () => {
+    const { doc } = buildDoc({ kind: 'edit', status: 'draft' }, ['existing-post']);
+    initBlogAdmin(doc);
+
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+    slug.value = 'existing-post';
+    slug.dispatchEvent(new Event('input'));
+    expect(slug.validationMessage).toBe('');
+    expect(doc.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+describe('initBlogAdmin — slug autofill (add-form)', () => {
+  it('slugifies the title into the slug input until the slug is manually edited', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' });
+    initBlogAdmin(doc);
+
+    const title = doc.querySelector(`[name="${BLOG_FORM_FIELDS.title}"]`) as HTMLInputElement;
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+
+    title.value = 'Nurturing Growth!';
+    title.dispatchEvent(new Event('input'));
+    expect(slug.value).toBe('nurturing-growth');
+
+    // User manually edits the slug — autofill stops.
+    slug.value = 'my-custom-slug';
+    slug.dispatchEvent(new Event('input'));
+    title.value = 'Something Else';
+    title.dispatchEvent(new Event('input'));
+    expect(slug.value).toBe('my-custom-slug');
+  });
+});
+
+describe('initBlogAdmin — error flash focus (R3-F22)', () => {
+  it('focuses the error flash once when present', () => {
+    const doc = document.implementation.createHTMLDocument('flash');
+    const flash = doc.createElement('p');
+    flash.setAttribute('data-error-flash', '');
+    flash.setAttribute('role', 'alert');
+    flash.setAttribute('tabindex', '-1');
+    doc.body.appendChild(flash);
+
+    // A detached createHTMLDocument has no defaultView, so jsdom does not move activeElement on
+    // .focus(); assert the behavioral contract (focus() invoked once on the flash) via a spy.
+    const focusSpy = vi.spyOn(flash, 'focus');
+    initBlogAdmin(doc);
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when no error flash is present', () => {
+    const doc = document.implementation.createHTMLDocument('no-flash');
+    expect(() => initBlogAdmin(doc)).not.toThrow();
+  });
+});

--- a/app/src/lib/blog-admin-client.test.ts
+++ b/app/src/lib/blog-admin-client.test.ts
@@ -221,6 +221,25 @@ describe('initBlogAdmin — slug autofill (add-form)', () => {
     title.dispatchEvent(new Event('input'));
     expect(slug.value).toBe('my-custom-slug');
   });
+
+  it('fires the collision warning when the auto-generated slug collides (R2-F12)', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' }, ['nurturing-growth']);
+    initBlogAdmin(doc);
+
+    const title = doc.querySelector(`[name="${BLOG_FORM_FIELDS.title}"]`) as HTMLInputElement;
+    const slug = doc.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`) as HTMLInputElement;
+
+    // Typing the title autofills a slug that collides with an existing post; the collision check
+    // must fire even though no `input` event was dispatched on the slug itself.
+    title.value = 'Nurturing Growth!';
+    title.dispatchEvent(new Event('input'));
+
+    expect(slug.value).toBe('nurturing-growth');
+    expect(slug.validationMessage.length).toBeGreaterThan(0);
+    const alert = doc.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent ?? '').toContain('already exists');
+  });
 });
 
 describe('initBlogAdmin — error flash focus (R3-F22)', () => {

--- a/app/src/lib/blog-admin-client.ts
+++ b/app/src/lib/blog-admin-client.ts
@@ -1,0 +1,198 @@
+/**
+ * Client behavior for `/admin/blog` (R2-F36 + R4-F7). Trimmed to faq.astro's complexity class:
+ * conditional-`required` toggling, add-form slug autofill, and a blocking slug-collision check.
+ *
+ * Deliberately CUT (R4-F7): body-image-alt scanner, imageAlt filename/generic-word predicate,
+ * backslash-URL tail check. `minlength`/`pattern` on imageAlt/image are declarative in the page
+ * markup, NOT set here. The server (`validateBlogData`) remains the source of truth.
+ *
+ * `initBlogAdmin(doc)` takes an optional Document so jsdom unit tests can pass a constructed one.
+ */
+import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+
+const COLLISION_MESSAGE =
+  'A post with this address already exists — choose a different address or edit the existing post.';
+
+const slugify = (value: string): string =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+/**
+ * Wire conditional-`required` state for one blog form. Runs once at init (computing state from the
+ * INITIAL field values — R2-F9), then re-runs on status `change` and image-URL `input`.
+ */
+function initConditionalRequired(form: HTMLFormElement): void {
+  const statusSelect = form.querySelector(`[name="${BLOG_FORM_FIELDS.status}"]`);
+  const excerpt = form.querySelector(`[name="${BLOG_FORM_FIELDS.excerptRaw}"]`);
+  const body = form.querySelector(`[name="${BLOG_FORM_FIELDS.bodyRaw}"]`);
+  const date = form.querySelector(`[name="${BLOG_FORM_FIELDS.date}"]`);
+  const image = form.querySelector(`[name="${BLOG_FORM_FIELDS.image}"]`);
+  const imageAlt = form.querySelector(`[name="${BLOG_FORM_FIELDS.imageAlt}"]`);
+
+  const setRequired = (el: Element | null, required: boolean): void => {
+    if (
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement
+    ) {
+      el.required = required;
+    }
+  };
+
+  const syncPublishRequired = (): void => {
+    const publishing =
+      statusSelect instanceof HTMLSelectElement && statusSelect.value === 'published';
+    setRequired(excerpt, publishing);
+    setRequired(body, publishing);
+    setRequired(date, publishing);
+  };
+
+  const syncImageAltRequired = (): void => {
+    const hasImage = image instanceof HTMLInputElement && image.value.trim().length > 0;
+    setRequired(imageAlt, hasImage);
+  };
+
+  if (statusSelect instanceof HTMLSelectElement) {
+    statusSelect.addEventListener('change', syncPublishRequired);
+  }
+  if (image instanceof HTMLInputElement) {
+    image.addEventListener('input', syncImageAltRequired);
+  }
+
+  // Initial state from the rendered values, NO events required (R2-F9).
+  syncPublishRequired();
+  syncImageAltRequired();
+}
+
+/**
+ * Slug autofill from the title (add-form only). Mirrors faq.astro:776-796 — slugify the title into
+ * the slug input on `input`, stopping once the user manually edits the slug. No date prefix.
+ */
+function initSlugAutofill(form: HTMLFormElement): void {
+  const title = form.querySelector(`[name="${BLOG_FORM_FIELDS.title}"]`);
+  const slug = form.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`);
+  if (!(title instanceof HTMLInputElement) || !(slug instanceof HTMLInputElement)) return;
+
+  title.addEventListener('input', () => {
+    if (slug.dataset.manual === 'true') return;
+    const normalized = slugify(title.value);
+    if (normalized.length > 0) {
+      slug.value = normalized.slice(0, 100);
+    }
+  });
+
+  slug.addEventListener('input', () => {
+    slug.dataset.manual = 'true';
+  });
+}
+
+/**
+ * Blocking slug-collision check (R2-F12 / R2-F30) on the add-form. Reads the server-rendered slug
+ * list from `[data-existing-slugs]`; mutates the inline `role="alert"` ONLY on state transition.
+ */
+function initSlugCollision(doc: Document, form: HTMLFormElement): void {
+  const slug = form.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`);
+  if (!(slug instanceof HTMLInputElement)) return;
+
+  const listContainer = doc.querySelector('[data-existing-slugs]');
+  let existing: string[] = [];
+  if (listContainer instanceof HTMLElement && listContainer.dataset.existingSlugs) {
+    try {
+      const parsed: unknown = JSON.parse(listContainer.dataset.existingSlugs);
+      if (Array.isArray(parsed)) {
+        existing = parsed.filter((item): item is string => typeof item === 'string');
+      }
+    } catch {
+      existing = [];
+    }
+  }
+
+  const alertId = 'blog-slug-collision-alert';
+  let inCollision = false;
+
+  const showAlert = (): void => {
+    if (doc.getElementById(alertId)) return;
+    const alert = doc.createElement('p');
+    alert.id = alertId;
+    alert.setAttribute('role', 'alert');
+    alert.className = 'mt-1 text-sm text-red-800';
+    alert.textContent = COLLISION_MESSAGE;
+    slug.insertAdjacentElement('afterend', alert);
+    const describedBy = slug.getAttribute('aria-describedby');
+    slug.setAttribute('aria-describedby', describedBy ? `${describedBy} ${alertId}` : alertId);
+  };
+
+  const hideAlert = (): void => {
+    const alert = doc.getElementById(alertId);
+    if (alert) alert.remove();
+    const describedBy = slug.getAttribute('aria-describedby');
+    if (describedBy) {
+      const next = describedBy
+        .split(/\s+/)
+        .filter(token => token && token !== alertId)
+        .join(' ');
+      if (next) {
+        slug.setAttribute('aria-describedby', next);
+      } else {
+        slug.removeAttribute('aria-describedby');
+      }
+    }
+  };
+
+  const evaluate = (): void => {
+    const collision = existing.includes(slug.value.trim());
+    if (collision === inCollision) return; // mutate ONLY on state transition (R2-F30)
+    inCollision = collision;
+    if (collision) {
+      showAlert();
+      slug.setCustomValidity(COLLISION_MESSAGE);
+    } else {
+      hideAlert();
+      slug.setCustomValidity('');
+    }
+  };
+
+  slug.addEventListener('input', evaluate);
+  evaluate();
+}
+
+/**
+ * Error-flash focus init (R3-F22). Focus the error flash once, then strip `?error=` from the URL so
+ * a reload/back does not re-focus stale state. Guarded for jsdom's partial location/history.
+ */
+function initErrorFlashFocus(doc: Document): void {
+  const flash = doc.querySelector('[data-error-flash]');
+  if (!(flash instanceof HTMLElement)) return;
+  flash.focus();
+
+  try {
+    const loc = doc.defaultView?.location;
+    const hist = doc.defaultView?.history;
+    if (loc && hist && typeof hist.replaceState === 'function') {
+      const url = new URL(loc.href);
+      if (url.searchParams.has('error')) {
+        url.searchParams.delete('error');
+        hist.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+      }
+    }
+  } catch {
+    // jsdom may lack a usable location/history; the focus already happened, so swallow.
+  }
+}
+
+export function initBlogAdmin(doc: Document = document): void {
+  const forms = doc.querySelectorAll('[data-blog-form]');
+  forms.forEach(form => {
+    if (!(form instanceof HTMLFormElement)) return;
+    initConditionalRequired(form);
+    if (form.hasAttribute('data-new-blog-form')) {
+      initSlugAutofill(form);
+      initSlugCollision(doc, form);
+    }
+  });
+
+  initErrorFlashFocus(doc);
+}

--- a/app/src/lib/blog-admin-client.ts
+++ b/app/src/lib/blog-admin-client.ts
@@ -70,8 +70,12 @@ function initConditionalRequired(form: HTMLFormElement): void {
 /**
  * Slug autofill from the title (add-form only). Mirrors faq.astro:776-796 — slugify the title into
  * the slug input on `input`, stopping once the user manually edits the slug. No date prefix.
+ *
+ * `onAutofill` is invoked after the slug value is written programmatically so the caller can re-run
+ * the collision check (R2-F12). We deliberately do NOT dispatch an `input` event on the slug here:
+ * that would trip the manual-edit listener below (`dataset.manual='true'`) and stop autofill.
  */
-function initSlugAutofill(form: HTMLFormElement): void {
+function initSlugAutofill(form: HTMLFormElement, onAutofill?: () => void): void {
   const title = form.querySelector(`[name="${BLOG_FORM_FIELDS.title}"]`);
   const slug = form.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`);
   if (!(title instanceof HTMLInputElement) || !(slug instanceof HTMLInputElement)) return;
@@ -81,6 +85,7 @@ function initSlugAutofill(form: HTMLFormElement): void {
     const normalized = slugify(title.value);
     if (normalized.length > 0) {
       slug.value = normalized.slice(0, 100);
+      onAutofill?.();
     }
   });
 
@@ -92,10 +97,14 @@ function initSlugAutofill(form: HTMLFormElement): void {
 /**
  * Blocking slug-collision check (R2-F12 / R2-F30) on the add-form. Reads the server-rendered slug
  * list from `[data-existing-slugs]`; mutates the inline `role="alert"` ONLY on state transition.
+ *
+ * Returns the `evaluate` callback so the title-autofill handler can re-run the check after it
+ * programmatically writes the slug (R2-F12 — an auto-generated colliding slug must warn too).
+ * Returns `null` when there is no usable slug input to wire.
  */
-function initSlugCollision(doc: Document, form: HTMLFormElement): void {
+function initSlugCollision(doc: Document, form: HTMLFormElement): (() => void) | null {
   const slug = form.querySelector(`[name="${BLOG_FORM_FIELDS.slug}"]`);
-  if (!(slug instanceof HTMLInputElement)) return;
+  if (!(slug instanceof HTMLInputElement)) return null;
 
   const listContainer = doc.querySelector('[data-existing-slugs]');
   let existing: string[] = [];
@@ -157,6 +166,8 @@ function initSlugCollision(doc: Document, form: HTMLFormElement): void {
 
   slug.addEventListener('input', evaluate);
   evaluate();
+
+  return evaluate;
 }
 
 /**
@@ -189,8 +200,9 @@ export function initBlogAdmin(doc: Document = document): void {
     if (!(form instanceof HTMLFormElement)) return;
     initConditionalRequired(form);
     if (form.hasAttribute('data-new-blog-form')) {
-      initSlugAutofill(form);
-      initSlugCollision(doc, form);
+      // Wire collision first so autofill can re-run the check after writing the slug (R2-F12).
+      const evaluateCollision = initSlugCollision(doc, form);
+      initSlugAutofill(form, evaluateCollision ?? undefined);
     }
   });
 

--- a/app/src/lib/blog-form-fields.ts
+++ b/app/src/lib/blog-form-fields.ts
@@ -1,0 +1,29 @@
+/**
+ * Single source of truth for the `/admin/blog` form field `name` strings (R1-F42).
+ *
+ * No runtime logic, no imports. Consumed by `blog.astro` (renders `name` attributes from it),
+ * `blog-admin-client.ts` (resolves field references), and `content.blog.test.ts` (builds FormData).
+ *
+ * The `data.`-prefix and the literal `_raw` suffix on body/excerpt are load-bearing: the endpoint
+ * routes `data.*` keys into the JSONB payload and the `_raw` suffix skips the parser's coercion+trim
+ * (see `parseFormDataPayload` in `content.ts`). Changing a string here without changing the markup
+ * and handler in lockstep silently breaks the save path.
+ */
+export const BLOG_FORM_FIELDS = {
+  collection: 'collection',
+  slug: 'slug',
+  title: 'title',
+  status: 'status',
+  createOnly: 'createOnly',
+  redirectTo: 'redirectTo',
+  baseDataJson: 'baseDataJson',
+  action: 'action',
+  date: 'data.date',
+  author: 'data.author',
+  excerptRaw: 'data.excerpt_raw',
+  bodyRaw: 'data.body_raw',
+  image: 'data.image',
+  imageAlt: 'data.imageAlt',
+  seoTitle: 'data.seoTitle',
+  seoDescription: 'data.seoDescription'
+} as const;

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -1,0 +1,851 @@
+---
+import AdminLayout from '@layouts/AdminLayout.astro';
+import { getManagedBlogPosts, renderPostBody, type BlogPost } from '@lib/blog-content';
+import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+
+const posts = await getManagedBlogPosts(); // uncached, no status filter, pre-sorted
+const errorMessage = Astro.url.searchParams.get('error');
+const savedSlug = errorMessage ? null : Astro.url.searchParams.get('saved'); // success never shows alongside an error (R1-F15)
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD default for the date input
+
+// Split into groups; comparator already applied inside getManagedBlogPosts (do NOT re-sort).
+const publishedPosts = posts.filter(p => p.status === 'published');
+const draftPosts = posts.filter(p => p.status !== 'published'); // every other/stray status under Drafts (R1-F9)
+
+// Existing-slug list for the client collision check (server-rendered into a data- attribute).
+const existingSlugs = posts.map(p => p.slug);
+
+// State-specific saved copy (R4-F12): resolve the saved slug's status.
+const savedPost =
+  savedSlug && savedSlug !== 'new' && savedSlug !== 'deleted'
+    ? (posts.find(p => p.slug === savedSlug) ?? null)
+    : null;
+
+// Resolve the success-flash copy.
+let savedMessage: string | null = null;
+if (savedSlug === 'deleted') {
+  savedMessage = 'Post deleted.';
+} else if (savedSlug === 'new') {
+  // KNOWN, DELIBERATE deviation from R4-F12 for saved=new (see PR description): the add-form
+  // redirect carries the STATIC literal /admin/blog?saved=new (R1-F15) and BlogPost has no
+  // timestamp, so the just-created row cannot be identified to resolve its status. Use the
+  // two-state copy that names BOTH states (the safety goal — owners must not think a draft is live).
+  savedMessage =
+    'Saved. If you set status to Published it is now live at its link. If you saved it as a draft it is NOT yet visible to the public — set status to Published when ready.';
+} else if (savedPost) {
+  savedMessage =
+    savedPost.status === 'published'
+      ? 'Published — now live at its link.'
+      : 'Saved as a draft — NOT yet visible to the public. Set status to Published when ready.';
+}
+
+const statusBadgeClass = (post: BlogPost): string =>
+  post.status === 'published'
+    ? 'bg-green-50 text-green-800 border border-green-200'
+    : 'bg-amber-50 text-amber-800 border border-amber-200';
+const statusBadgeLabel = (post: BlogPost): string =>
+  post.status === 'published' ? 'Published' : 'Draft';
+
+// `baseDataJson` for an edit form: carry the blog data.* fields reconstructable from `post`.
+const baseDataFor = (post: BlogPost): string =>
+  JSON.stringify({
+    title: post.title,
+    date: post.date,
+    author: post.author,
+    excerpt: post.excerpt,
+    body: post.body,
+    image: post.image,
+    imageAlt: post.imageAlt,
+    seoTitle: post.seoTitle,
+    seoDescription: post.seoDescription,
+    status: post.status
+  });
+---
+
+<AdminLayout title="Manage Blog">
+  {
+    /* PR-2 deviation 5 (R1-F33/R2-F28/R3-F22): success flash is role=status with a manual Dismiss button and NO data-admin-alert (no 6s auto-hide — WCAG 2.2.1). faq.astro:100-108 DOES carry data-admin-alert; this must not. */
+  }
+  {
+    savedMessage && (
+      <div
+        role="status"
+        class="mb-4 flex items-start justify-between gap-3 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-800"
+      >
+        <span>{savedMessage}</span>
+        <button
+          type="button"
+          data-dismiss-flash
+          class="shrink-0 rounded-md border border-green-300 px-2 py-0.5 text-xs font-semibold text-green-800 hover:bg-green-100"
+        >
+          Dismiss
+        </button>
+      </div>
+    )
+  }
+
+  {
+    /* PR-2 deviation 5 (R2-F28/R3-F22): error flash is role=alert + tabindex=-1 + data-error-flash, NO data-admin-alert. Focus is driven by the client module init, not by ARIA. */
+  }
+  {
+    errorMessage && (
+      <p
+        role="alert"
+        tabindex="-1"
+        data-error-flash
+        class="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800"
+      >
+        {errorMessage}
+      </p>
+    )
+  }
+
+  <div class="space-y-6" data-existing-slugs={JSON.stringify(existingSlugs)}>
+    <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+      <h2 class="mb-2 text-lg font-semibold">Blog Manager</h2>
+      <p class="text-sm text-earth-brown/80">
+        Write a post, save it as a draft to keep it private, or publish it to make it live. Drafts
+        are listed below the published posts. The blog index, and edits to already-published posts,
+        can take up to 5 minutes to update.
+      </p>
+    </section>
+
+    <section class="space-y-4">
+      <details class="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <summary class="cursor-pointer px-5 py-4 text-base font-semibold text-earth-brown"
+          >Add new post</summary
+        >
+        <div class="space-y-4 border-t border-gray-200 p-5">
+          <form
+            method="post"
+            action="/api/admin/content"
+            class="space-y-4"
+            data-blog-form
+            data-new-blog-form
+          >
+            <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+            <input type="hidden" name={BLOG_FORM_FIELDS.createOnly} value="true" />
+            {
+              /* R1-F15: static literal redirect (no slug) — do NOT rewrite to carry the new slug. */
+            }
+            <input type="hidden" name={BLOG_FORM_FIELDS.redirectTo} value="/admin/blog?saved=new" />
+
+            <div class="grid gap-3 md:grid-cols-2">
+              <label class="block text-sm font-medium md:col-span-2">
+                Title
+                <input
+                  type="text"
+                  name={BLOG_FORM_FIELDS.title}
+                  required
+                  maxlength="300"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+              </label>
+
+              <label class="block text-sm font-medium md:col-span-2">
+                Web address (slug)
+                <input
+                  type="text"
+                  name={BLOG_FORM_FIELDS.slug}
+                  required
+                  maxlength="100"
+                  pattern="[a-z0-9-_]+"
+                  aria-describedby="add-slug-help"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+                <span id="add-slug-help" class="mt-1 block text-xs text-earth-brown/70">
+                  This becomes the post's web address and can't be changed later — don't start it
+                  with a date, dates are added automatically on the page.
+                </span>
+              </label>
+
+              {
+                /* PR-2 deviation 1 (R2-F14): status select renders TOP-LEVEL, never inside a collapsed <details>. */
+              }
+              {
+                /* PR-2 deviation 6 absent here — add-form defaults to Draft (R4-F11, add-form only). */
+              }
+              <label class="block text-sm font-medium">
+                Status
+                <select
+                  name={BLOG_FORM_FIELDS.status}
+                  aria-describedby="add-status-help"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                >
+                  <option value="draft" selected>Draft</option>
+                  <option value="published">Published</option>
+                </select>
+                <span id="add-status-help" class="mt-1 block text-xs text-earth-brown/70">
+                  Title is always required. To publish you also need an excerpt, a body, and a date;
+                  if you set a featured image you also need an image description. New posts appear
+                  at their link immediately after publishing. The blog index, and edits to
+                  already-published posts, can take up to 5 minutes to update.
+                </span>
+              </label>
+
+              <label class="block text-sm font-medium">
+                Date (required to publish)
+                <input
+                  type="date"
+                  name={BLOG_FORM_FIELDS.date}
+                  value={today}
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+              </label>
+
+              <label class="block text-sm font-medium md:col-span-2">
+                Author
+                <input
+                  type="text"
+                  name={BLOG_FORM_FIELDS.author}
+                  value="Spicebush Team"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+              </label>
+
+              <label class="block text-sm font-medium md:col-span-2">
+                Excerpt (required to publish)
+                {
+                  /* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore. Empty for the add-form. */
+                }
+                {/* prettier-ignore */}
+                <textarea
+                  name={BLOG_FORM_FIELDS.excerptRaw}
+                  rows="3"
+                  maxlength="1000"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"></textarea>
+              </label>
+
+              <label class="block text-sm font-medium md:col-span-2">
+                Body (required to publish)
+                {/* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore. */}
+                {/* prettier-ignore */}
+                <textarea
+                  name={BLOG_FORM_FIELDS.bodyRaw}
+                  rows="16"
+                  maxlength="200000"
+                  aria-describedby="add-body-help"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"></textarea>
+                <span id="add-body-help" class="mt-1 block text-xs text-earth-brown/70">
+                  Write in Markdown. See the formatting guide below.
+                </span>
+              </label>
+            </div>
+
+            {
+              /* PR-2 deviation 3 (R2-F11) + R1-F38/F19/F20 + R2-F11 + R4-F6: Markdown help, immediately after the body. */
+            }
+            <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <summary class="cursor-pointer text-sm font-semibold text-earth-brown"
+                >Markdown formatting guide</summary
+              >
+              <div class="mt-3 space-y-2 text-xs text-earth-brown/80">
+                <ul class="list-disc space-y-1 pl-5">
+                  <li><strong>Headings:</strong> <code>## Heading</code></li>
+                  <li>
+                    <strong>Bold:</strong>
+                    <code>**bold**</code> · <em>Italic:</em>
+                    <code>*italic*</code>
+                  </li>
+                  <li><strong>Lists:</strong> <code>- item</code> or <code>1. item</code></li>
+                  <li><strong>Links:</strong> <code>[text](https://example.com)</code></li>
+                  <li><strong>Images:</strong> <code>![description](address)</code></li>
+                </ul>
+                <p>
+                  Link addresses must start with <code>https://</code> (or <code>/</code> for pages on
+                  this site). Addresses starting with <code>www.</code> are fixed automatically.
+                </p>
+                <p>
+                  Every image inside your post needs a description in the square brackets:
+                  <code>![description](address)</code> — a post can't be published with an empty or one-word
+                  image description.
+                </p>
+                <p>
+                  To add more images inside your post: upload them at
+                  <a
+                    href="/admin/media"
+                    target="_blank"
+                    rel="noopener"
+                    class="font-medium text-forest-canopy hover:underline"
+                  >
+                    Media (opens in a new tab)
+                  </a>, copy the image's address, and use <code>![description](address)</code>.
+                </p>
+              </div>
+            </details>
+
+            {/* Featured-image widget — PR-2 §3.4 (mirror staff.astro). */}
+            <div
+              class="rounded-lg border border-gray-200 bg-gray-50 p-3"
+              data-blog-upload
+              data-upload-context="add"
+            >
+              <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-earth-brown/70">
+                Featured image (optional)
+              </p>
+              <label class="block text-sm font-medium">
+                Featured image address
+                <input
+                  type="text"
+                  name={BLOG_FORM_FIELDS.image}
+                  data-photo-url-input
+                  pattern="(/(?![/\\]).*|https://.*)"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+              </label>
+              <div class="mt-2 flex flex-wrap items-center gap-2">
+                <input
+                  type="file"
+                  accept="image/*"
+                  data-upload-file
+                  aria-label="Choose an image file to upload"
+                  class="max-w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+                />
+                <button
+                  type="button"
+                  data-upload-button
+                  class="rounded-lg bg-forest-canopy px-3 py-2 text-xs font-semibold text-white hover:bg-moss-green"
+                >
+                  Upload
+                </button>
+                <a
+                  href="/admin/media"
+                  data-upload-crop-link
+                  target="_blank"
+                  rel="noopener"
+                  class="hidden rounded-lg border border-forest-canopy bg-white px-3 py-2 text-xs font-semibold text-forest-canopy hover:bg-forest-canopy hover:text-white"
+                >
+                  Crop &amp; focal editor (opens in a new tab)
+                </a>
+              </div>
+              {/* R1-F20 + R2-F30: copy-address affordance. */}
+              <div class="mt-2 hidden" data-copy-row>
+                <label class="block text-xs font-medium text-earth-brown/80">
+                  Image address
+                  <input
+                    type="text"
+                    data-copy-source
+                    readonly
+                    aria-label="Uploaded image address"
+                    class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+                  />
+                </label>
+                <button
+                  type="button"
+                  data-copy-button
+                  class="mt-1 rounded-lg border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-earth-brown hover:bg-gray-50"
+                >
+                  Copy address
+                </button>
+                <span class="mt-1 block text-xs text-earth-brown/70">
+                  To put this image inside your post, copy this address into
+                  <code>![description](address)</code>.
+                </span>
+              </div>
+              {
+                /* PR-2 deviation 7 (R4-F14): live region is PERMANENTLY RENDERED + visually empty — NO hidden/display:none (staff.astro:451 has `hidden`; that suppresses announcements). */
+              }
+              <p
+                data-upload-status
+                aria-live="polite"
+                class="mt-2 min-h-[1.25rem] text-xs text-earth-brown/80"
+              >
+              </p>
+            </div>
+
+            <label class="block text-sm font-medium md:col-span-2">
+              Image description (required to publish when an image is set)
+              <input
+                type="text"
+                name={BLOG_FORM_FIELDS.imageAlt}
+                minlength="6"
+                aria-describedby="add-imagealt-help"
+                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+              />
+              <span id="add-imagealt-help" class="mt-1 block text-xs text-earth-brown/70">
+                At least 6 characters describing what's in the picture — not a file name, and not
+                just "photo" or "picture". E.g. "Children planting seedlings in the school garden".
+              </span>
+            </label>
+
+            <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <summary class="cursor-pointer text-sm font-semibold text-earth-brown"
+                >SEO (optional)</summary
+              >
+              <div class="mt-3 grid gap-3 md:grid-cols-2">
+                <label class="block text-sm font-medium md:col-span-2">
+                  SEO title
+                  <input
+                    type="text"
+                    name={BLOG_FORM_FIELDS.seoTitle}
+                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                  />
+                </label>
+                <label class="block text-sm font-medium md:col-span-2">
+                  SEO description
+                  <input
+                    type="text"
+                    name={BLOG_FORM_FIELDS.seoDescription}
+                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                  />
+                </label>
+              </div>
+            </details>
+
+            <button
+              type="submit"
+              class="rounded-lg bg-forest-canopy px-4 py-2 font-semibold text-white hover:bg-moss-green"
+            >
+              Save post
+            </button>
+          </form>
+        </div>
+      </details>
+    </section>
+
+    {
+      [
+        { heading: 'Published posts', group: publishedPosts },
+        { heading: 'Drafts', group: draftPosts }
+      ].map(({ heading, group }) => (
+        <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <h2 class="mb-3 text-lg font-semibold">{heading}</h2>
+          {group.length === 0 ? (
+            <p class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-earth-brown/80">
+              No posts here yet.
+            </p>
+          ) : (
+            <div class="space-y-3">
+              {group.map(post => (
+                <details
+                  open={post.slug === savedSlug}
+                  class="rounded-lg border border-gray-200 bg-white"
+                >
+                  <summary class="cursor-pointer px-4 py-3">
+                    <span class="flex flex-wrap items-center justify-between gap-2">
+                      <span class="font-semibold text-earth-brown">{post.title}</span>
+                      <span class="flex items-center gap-2 text-xs">
+                        <span class={`rounded-full px-2 py-1 ${statusBadgeClass(post)}`}>
+                          {statusBadgeLabel(post)}
+                        </span>
+                        {post.date && <span class="text-earth-brown/70">{post.date}</span>}
+                      </span>
+                    </span>
+                  </summary>
+
+                  <div class="border-t border-gray-200 p-4">
+                    {/* Edit form — NO createOnly (R deviation 6 status select below). */}
+                    <form
+                      method="post"
+                      action="/api/admin/content"
+                      class="space-y-4"
+                      data-blog-form
+                    >
+                      <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+                      <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
+                      <input
+                        type="hidden"
+                        name={BLOG_FORM_FIELDS.redirectTo}
+                        value={`/admin/blog?saved=${encodeURIComponent(post.slug)}`}
+                      />
+                      <input
+                        type="hidden"
+                        name={BLOG_FORM_FIELDS.baseDataJson}
+                        value={baseDataFor(post)}
+                      />
+
+                      <div class="grid gap-3 md:grid-cols-2">
+                        <label class="block text-sm font-medium md:col-span-2">
+                          Title
+                          <input
+                            type="text"
+                            name={BLOG_FORM_FIELDS.title}
+                            required
+                            maxlength="300"
+                            value={post.title}
+                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                          />
+                        </label>
+
+                        <label class="block text-sm font-medium md:col-span-2">
+                          Web address (slug)
+                          <input
+                            type="text"
+                            value={post.slug}
+                            readonly
+                            class="mt-1 w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 text-earth-brown/80"
+                          />
+                          <span class="mt-1 block text-xs text-earth-brown/70">
+                            Need to change a post's address? Create a new post, copy the content
+                            over, publish it, then delete the old one.
+                          </span>
+                        </label>
+
+                        {/* PR-2 deviation 1 (R2-F14): status select top-level. */}
+                        {/* PR-2 deviation 6 (R4-F11): selected={post.status} so an untouched edit re-submits the current status (no silent unpublish). */}
+                        <label class="block text-sm font-medium">
+                          Status
+                          <select
+                            name={BLOG_FORM_FIELDS.status}
+                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                          >
+                            <option value="published" selected={post.status !== 'draft'}>
+                              Published
+                            </option>
+                            <option value="draft" selected={post.status === 'draft'}>
+                              Draft
+                            </option>
+                          </select>
+                        </label>
+
+                        <label class="block text-sm font-medium">
+                          Date (required to publish)
+                          <input
+                            type="date"
+                            name={BLOG_FORM_FIELDS.date}
+                            value={post.date}
+                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                          />
+                        </label>
+
+                        <label class="block text-sm font-medium md:col-span-2">
+                          Author
+                          <input
+                            type="text"
+                            name={BLOG_FORM_FIELDS.author}
+                            value={post.author}
+                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                          />
+                        </label>
+
+                        <label class="block text-sm font-medium md:col-span-2">
+                          Excerpt (required to publish)
+                          {/* prettier-ignore */}
+                          <textarea name={BLOG_FORM_FIELDS.excerptRaw} rows="3" maxlength="1000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2">{post.excerpt}</textarea>
+                        </label>
+
+                        <label class="block text-sm font-medium md:col-span-2">
+                          Body (required to publish)
+                          {/* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore — the _raw path skips trim, so a reflowed indented textarea would prepend "\n  " on every save. */}
+                          {/* prettier-ignore */}
+                          <textarea name={BLOG_FORM_FIELDS.bodyRaw} rows="16" maxlength="200000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2">{post.body}</textarea>
+                        </label>
+                      </div>
+
+                      <div
+                        class="rounded-lg border border-gray-200 bg-gray-50 p-3"
+                        data-blog-upload
+                        data-upload-context="edit"
+                      >
+                        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-earth-brown/70">
+                          Featured image (optional)
+                        </p>
+                        <label class="block text-sm font-medium">
+                          Featured image address
+                          <input
+                            type="text"
+                            name={BLOG_FORM_FIELDS.image}
+                            data-photo-url-input
+                            pattern="(/(?![/\\]).*|https://.*)"
+                            value={post.image}
+                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                          />
+                        </label>
+                        <div class="mt-2 flex flex-wrap items-center gap-2">
+                          <input
+                            type="file"
+                            accept="image/*"
+                            data-upload-file
+                            aria-label="Choose an image file to upload"
+                            class="max-w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+                          />
+                          <button
+                            type="button"
+                            data-upload-button
+                            class="rounded-lg bg-forest-canopy px-3 py-2 text-xs font-semibold text-white hover:bg-moss-green"
+                          >
+                            Upload
+                          </button>
+                          <a
+                            href="/admin/media"
+                            data-upload-crop-link
+                            target="_blank"
+                            rel="noopener"
+                            class="hidden rounded-lg border border-forest-canopy bg-white px-3 py-2 text-xs font-semibold text-forest-canopy hover:bg-forest-canopy hover:text-white"
+                          >
+                            Crop &amp; focal editor (opens in a new tab)
+                          </a>
+                        </div>
+                        <div class="mt-2 hidden" data-copy-row>
+                          <label class="block text-xs font-medium text-earth-brown/80">
+                            Image address
+                            <input
+                              type="text"
+                              data-copy-source
+                              readonly
+                              aria-label="Uploaded image address"
+                              class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            data-copy-button
+                            class="mt-1 rounded-lg border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-earth-brown hover:bg-gray-50"
+                          >
+                            Copy address
+                          </button>
+                          <span class="mt-1 block text-xs text-earth-brown/70">
+                            To put this image inside your post, copy this address into
+                            <code>![description](address)</code>.
+                          </span>
+                        </div>
+                        {/* PR-2 deviation 7 (R4-F14): permanently rendered, visually-empty live region (no hidden/display:none). */}
+                        <p
+                          data-upload-status
+                          aria-live="polite"
+                          class="mt-2 min-h-[1.25rem] text-xs text-earth-brown/80"
+                        />
+                      </div>
+
+                      <label class="block text-sm font-medium md:col-span-2">
+                        Image description (required to publish when an image is set)
+                        <input
+                          type="text"
+                          name={BLOG_FORM_FIELDS.imageAlt}
+                          minlength="6"
+                          value={post.imageAlt}
+                          class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                        />
+                        <span class="mt-1 block text-xs text-earth-brown/70">
+                          At least 6 characters describing what's in the picture — not a file name,
+                          and not just "photo" or "picture".
+                        </span>
+                      </label>
+
+                      <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                        <summary class="cursor-pointer text-sm font-semibold text-earth-brown">
+                          SEO (optional)
+                        </summary>
+                        <div class="mt-3 grid gap-3 md:grid-cols-2">
+                          <label class="block text-sm font-medium md:col-span-2">
+                            SEO title
+                            <input
+                              type="text"
+                              name={BLOG_FORM_FIELDS.seoTitle}
+                              value={post.seoTitle}
+                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                            />
+                          </label>
+                          <label class="block text-sm font-medium md:col-span-2">
+                            SEO description
+                            <input
+                              type="text"
+                              name={BLOG_FORM_FIELDS.seoDescription}
+                              value={post.seoDescription}
+                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                            />
+                          </label>
+                        </div>
+                      </details>
+
+                      <button
+                        type="submit"
+                        class="rounded-lg bg-forest-canopy px-4 py-2 font-semibold text-white hover:bg-moss-green"
+                      >
+                        Save post
+                      </button>
+                    </form>
+
+                    {/* Preview — server-rendered through the public pipeline. */}
+                    {/* render previews lazily via ?preview={slug} if the collection exceeds ~30 posts */}
+                    <details open={post.slug === savedSlug} class="mt-4">
+                      <summary class="cursor-pointer text-sm font-semibold text-earth-brown">
+                        Preview
+                      </summary>
+                      <p class="mt-2 text-xs text-earth-brown/70">
+                        Save first — the preview shows your last saved version.
+                      </p>
+                      <div
+                        class="prose mt-2 max-w-none text-sm"
+                        set:html={renderPostBody(post.body)}
+                      />
+                    </details>
+
+                    <div class="mt-4 flex flex-wrap items-center gap-3">
+                      {post.status === 'published' && (
+                        <a
+                          href={`/blog/${post.slug}`}
+                          target="_blank"
+                          rel="noopener"
+                          class="text-sm font-medium text-forest-canopy hover:underline"
+                        >
+                          View on site ↗
+                        </a>
+                      )}
+
+                      <form
+                        method="post"
+                        action="/api/admin/content"
+                        data-confirm="Delete this post? If you are renaming its address, make sure the new copy is saved first. This cannot be undone."
+                      >
+                        <input type="hidden" name={BLOG_FORM_FIELDS.action} value="delete" />
+                        <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+                        <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
+                        <input
+                          type="hidden"
+                          name={BLOG_FORM_FIELDS.redirectTo}
+                          value="/admin/blog?saved=deleted"
+                        />
+                        <button
+                          type="submit"
+                          class="rounded-lg border border-red-300 bg-white px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50"
+                        >
+                          Delete post
+                        </button>
+                      </form>
+                    </div>
+                  </div>
+                </details>
+              ))}
+            </div>
+          )}
+        </section>
+      ))
+    }
+  </div>
+</AdminLayout>
+
+{
+  /* The processed script imports the client module so its @lib import resolves at bundle time (builder-verify 24). */
+}
+<script>
+  import { initBlogAdmin } from '@lib/blog-admin-client';
+
+  const slugify = (value: string): string =>
+    String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  function initBlogUploads(): void {
+    document.querySelectorAll('[data-blog-upload]').forEach(card => {
+      if (!(card instanceof HTMLElement)) return;
+      const form = card.closest('form');
+      if (!(form instanceof HTMLFormElement)) return;
+
+      const fileInput = card.querySelector('[data-upload-file]');
+      const uploadButton = card.querySelector('[data-upload-button]');
+      const statusNode = card.querySelector('[data-upload-status]');
+      const cropLink = card.querySelector('[data-upload-crop-link]');
+      const photoInput = card.querySelector('[data-photo-url-input]');
+      const copyRow = card.querySelector('[data-copy-row]');
+      const copySource = card.querySelector('[data-copy-source]');
+      const copyButton = card.querySelector('[data-copy-button]');
+      const titleInput = form.querySelector('[name="title"]');
+
+      if (
+        !(fileInput instanceof HTMLInputElement) ||
+        !(uploadButton instanceof HTMLButtonElement) ||
+        !(statusNode instanceof HTMLElement) ||
+        !(photoInput instanceof HTMLInputElement)
+      ) {
+        return;
+      }
+
+      const announce = (message: string): void => {
+        statusNode.textContent = message;
+      };
+
+      uploadButton.addEventListener('click', async () => {
+        const selectedFile = fileInput.files && fileInput.files[0];
+        if (!selectedFile) {
+          announce('Please choose an image file first.');
+          return;
+        }
+
+        const titleValue = titleInput instanceof HTMLInputElement ? titleInput.value.trim() : '';
+        const requestedSlug = slugify(`blog-${titleValue || selectedFile.name}`);
+
+        const requestData = new FormData();
+        requestData.append('file', selectedFile);
+        requestData.append('createPhotoEntry', 'true');
+        requestData.append('category', 'blog');
+        requestData.append('title', titleValue ? `${titleValue} image` : 'Blog image');
+        if (requestedSlug) requestData.append('slug', requestedSlug);
+
+        uploadButton.setAttribute('disabled', 'disabled');
+        uploadButton.classList.add('opacity-60', 'cursor-not-allowed');
+        announce('Uploading…');
+
+        try {
+          const response = await fetch('/api/media/upload', { method: 'POST', body: requestData });
+          const payload = await response.json().catch(() => ({}));
+
+          if (!response.ok || payload.success !== true) {
+            const message =
+              typeof payload.error === 'string'
+                ? payload.error
+                : 'Upload failed — please try again.';
+            announce(message);
+            return;
+          }
+
+          const uploadedUrl = typeof payload.url === 'string' ? payload.url : '';
+          const photoSlug = typeof payload.photoSlug === 'string' ? payload.photoSlug : '';
+
+          if (uploadedUrl) {
+            photoInput.value = uploadedUrl;
+            // Re-evaluate the conditional imageAlt requirement (R1-F18).
+            photoInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+            if (copyRow instanceof HTMLElement) copyRow.classList.remove('hidden');
+            if (copySource instanceof HTMLInputElement) copySource.value = uploadedUrl;
+          }
+
+          if (cropLink instanceof HTMLAnchorElement && photoSlug) {
+            cropLink.href = `/admin/media?slug=${encodeURIComponent(photoSlug)}`;
+            cropLink.classList.remove('hidden');
+          }
+
+          announce('Image attached — save the post to keep it.');
+        } catch {
+          announce('Upload failed — please try again.');
+        } finally {
+          uploadButton.removeAttribute('disabled');
+          uploadButton.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+      });
+
+      if (copyButton instanceof HTMLButtonElement && copySource instanceof HTMLInputElement) {
+        copyButton.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(copySource.value);
+            announce('Address copied.');
+          } catch {
+            copySource.select();
+            announce('Press Ctrl/Cmd+C to copy the selected address.');
+          }
+        });
+      }
+    });
+  }
+
+  function initDismissFlash(): void {
+    document.querySelectorAll('[data-dismiss-flash]').forEach(button => {
+      if (!(button instanceof HTMLElement)) return;
+      button.addEventListener('click', () => {
+        button.closest('[role="status"]')?.remove();
+      });
+    });
+  }
+
+  function init(): void {
+    initBlogAdmin();
+    initBlogUploads();
+    initDismissFlash();
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -487,6 +487,7 @@ const baseDataFor = (post: BlogPost): string =>
                           Status
                           <select
                             name={BLOG_FORM_FIELDS.status}
+                            aria-describedby={`edit-status-help-${post.slug}`}
                             class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
                           >
                             <option value="published" selected={post.status !== 'draft'}>
@@ -496,6 +497,15 @@ const baseDataFor = (post: BlogPost): string =>
                               Draft
                             </option>
                           </select>
+                          {/* PR-2 R1-F38: staleness helper text linked to the edit-form status control. */}
+                          <span
+                            id={`edit-status-help-${post.slug}`}
+                            class="mt-1 block text-xs text-earth-brown/70"
+                          >
+                            New posts appear at their link immediately after publishing. The blog
+                            index, and edits to already-published posts, can take up to 5 minutes to
+                            update.
+                          </span>
                         </label>
 
                         <label class="block text-sm font-medium">

--- a/app/src/pages/api/admin/content.blog.test.ts
+++ b/app/src/pages/api/admin/content.blog.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// DISTINCT filename from PR-1's content.test.ts (no collision). Mock set is CORRECTED vs.
+// entries.test.ts: content.ts uses `query` + `db.cache`, NOT queryFirst/queryRows (VERIFIED).
+vi.mock('@lib/admin-auth-check', () => ({ checkAdminAuth: vi.fn() }));
+vi.mock('@lib/db/client', () => ({ query: vi.fn() }));
+vi.mock('@lib/db', () => ({ db: { cache: { invalidateCollection: vi.fn() } } }));
+
+import { checkAdminAuth } from '@lib/admin-auth-check';
+import { query } from '@lib/db/client';
+import { db } from '@lib/db';
+import { POST } from './content';
+import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+
+const F = BLOG_FORM_FIELDS;
+
+/** Build a POST Context whose request carries a real FormData body. */
+const makeContext = (fields: Record<string, string>) => {
+  const body = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    body.append(key, value);
+  }
+  const request = new Request('http://localhost/api/admin/content', { method: 'POST', body });
+  return { request, locals: {} } as unknown as Parameters<typeof POST>[0];
+};
+
+/** Pull the params array from the upsert/delete `query` call (skips any non-SQL noise). */
+const upsertParams = (): unknown[] => {
+  const call = vi.mocked(query).mock.calls.find(([sql]) => String(sql).includes('INSERT INTO'));
+  if (!call) throw new Error('no upsert query call recorded');
+  return call[1] as unknown[];
+};
+
+// Param order in content.ts upsert: [collection, slug, title, JSON.stringify(data), status, email, updatedAt]
+const PARAM_COLLECTION = 0;
+const PARAM_SLUG = 1;
+const PARAM_TITLE = 2;
+const PARAM_DATA = 3;
+const PARAM_STATUS = 4;
+
+const validPublishedFields = (overrides: Record<string, string> = {}): Record<string, string> => ({
+  [F.collection]: 'blog',
+  [F.slug]: 'a-real-post',
+  [F.title]: 'A Real Post',
+  [F.status]: 'published',
+  [F.date]: '2026-06-01',
+  [F.author]: 'Spicebush Team',
+  [F.excerptRaw]: 'A short summary of the post.',
+  [F.bodyRaw]: 'Hello world body content.',
+  ...overrides
+});
+
+describe('POST /api/admin/content — blog path (§12.16 + §12.18)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkAdminAuth).mockResolvedValue({
+      isAuthenticated: true,
+      isAdmin: true,
+      session: { userEmail: 'admin@spicebush.example' } as never,
+      user: null
+    });
+    vi.mocked(query).mockResolvedValue({ rows: [{ id: '1' }], rowCount: 1 } as never);
+  });
+
+  it('writes a valid published blog post and invalidates the blog cache', async () => {
+    const response = await POST(makeContext(validPublishedFields()));
+    expect(response.status).toBe(200);
+
+    const params = upsertParams();
+    expect(params[PARAM_COLLECTION]).toBe('blog');
+    expect(params[PARAM_SLUG]).toBe('a-real-post');
+    expect(params[PARAM_TITLE]).toBe('A Real Post');
+    expect(params[PARAM_STATUS]).toBe('published');
+
+    const data = JSON.parse(params[PARAM_DATA] as string) as Record<string, unknown>;
+    expect(data.body).toBe('Hello world body content.');
+    expect(data.excerpt).toBe('A short summary of the post.');
+
+    expect(db.cache.invalidateCollection).toHaveBeenCalledWith('blog');
+  });
+
+  it('passes _raw body/excerpt through as strings without JSON coercion', async () => {
+    await POST(
+      makeContext(
+        validPublishedFields({
+          [F.bodyRaw]: '{"a":1}',
+          [F.excerptRaw]: '2024'
+        })
+      )
+    );
+
+    const data = JSON.parse(upsertParams()[PARAM_DATA] as string) as Record<string, unknown>;
+    expect(data.body).toBe('{"a":1}');
+    expect(typeof data.body).toBe('string');
+    expect(data.excerpt).toBe('2024');
+    expect(typeof data.excerpt).toBe('string');
+  });
+
+  it('trims whitespace-padded body via normalizeBlogData (R2-F8)', async () => {
+    await POST(
+      makeContext(
+        validPublishedFields({
+          [F.bodyRaw]: '\n   Hello world\n  '
+        })
+      )
+    );
+
+    const data = JSON.parse(upsertParams()[PARAM_DATA] as string) as Record<string, unknown>;
+    expect(data.body).toBe('Hello world');
+  });
+
+  it('returns 400 and writes NO row when status is omitted (R2-F2)', async () => {
+    const fields = validPublishedFields();
+    delete fields[F.status];
+    const response = await POST(makeContext(fields));
+
+    expect(response.status).toBe(400);
+    const upsertCalled = vi
+      .mocked(query)
+      .mock.calls.some(([sql]) => String(sql).includes('INSERT INTO'));
+    expect(upsertCalled).toBe(false);
+  });
+
+  it('§12.18: an edit of a published post submitting status=published stores published', async () => {
+    // Edit form (NO createOnly) — the page renders selected={post.status} so this resubmits published.
+    const fields = validPublishedFields({
+      [F.baseDataJson]: JSON.stringify({
+        title: 'A Real Post',
+        date: '2026-06-01',
+        author: 'Spicebush Team',
+        excerpt: 'A short summary of the post.',
+        body: 'Hello world body content.',
+        status: 'published'
+      })
+    });
+    await POST(makeContext(fields));
+    expect(upsertParams()[PARAM_STATUS]).toBe('published');
+  });
+
+  it('§12.18 control: a draft-defaulted add stores draft', async () => {
+    const fields = validPublishedFields({
+      [F.status]: 'draft',
+      [F.createOnly]: 'true'
+    });
+    await POST(makeContext(fields));
+    expect(upsertParams()[PARAM_STATUS]).toBe('draft');
+  });
+
+  it('createOnly conflict (rowCount 0) returns 400', async () => {
+    vi.mocked(query).mockResolvedValue({ rows: [], rowCount: 0 } as never);
+    const response = await POST(
+      makeContext(validPublishedFields({ [F.status]: 'draft', [F.createOnly]: 'true' }))
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('runs the form-based delete branch and invalidates the cache', async () => {
+    const response = await POST(
+      makeContext({
+        [F.collection]: 'blog',
+        [F.slug]: 'a-real-post',
+        [F.action]: 'delete'
+      })
+    );
+    expect(response.status).toBe(200);
+    const deleteCalled = vi
+      .mocked(query)
+      .mock.calls.some(([sql]) => String(sql).includes('DELETE FROM content'));
+    expect(deleteCalled).toBe(true);
+    expect(db.cache.invalidateCollection).toHaveBeenCalledWith('blog');
+  });
+});
+
+describe('POST /api/admin/content — existing-collection regression (R4-F32, header-absent fail-open)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkAdminAuth).mockResolvedValue({
+      isAuthenticated: true,
+      isAdmin: true,
+      session: { userEmail: 'admin@spicebush.example' } as never,
+      user: null
+    });
+    vi.mocked(query).mockResolvedValue({ rows: [{ id: '1' }], rowCount: 1 } as never);
+  });
+
+  it('still saves a faq entry with no Origin / Sec-Fetch-Site headers (fail-open)', async () => {
+    const response = await POST(
+      makeContext({
+        [F.collection]: 'faq',
+        [F.slug]: 'faq-existing',
+        [F.status]: 'published',
+        'data.section_title': 'General FAQs',
+        'data.question': 'A question?',
+        'data.answer': 'An answer.'
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(upsertParams()[PARAM_COLLECTION]).toBe('faq');
+    expect(db.cache.invalidateCollection).toHaveBeenCalledWith('faq');
+  });
+
+  it('still deletes a staff entry through the modified handler', async () => {
+    const response = await POST(
+      makeContext({
+        [F.collection]: 'staff',
+        [F.slug]: 'jane-doe',
+        [F.action]: 'delete'
+      })
+    );
+    expect(response.status).toBe(200);
+    const deleteCalled = vi
+      .mocked(query)
+      .mock.calls.some(([sql]) => String(sql).includes('DELETE FROM content'));
+    expect(deleteCalled).toBe(true);
+    expect(db.cache.invalidateCollection).toHaveBeenCalledWith('staff');
+  });
+});

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -202,6 +202,14 @@ crop link to `/admin/media`. Inline post images are added by the owner via Markd
 (`![description](address)`), using addresses copied from the media system. The photo category
 `'blog'` already exists in `app/src/types/photo.ts`.
 
+- **New-tab editor links (R2-F11).** The crop/focal link and the in-body-image Media link both
+  carry `target="_blank" rel="noopener"` and a visible "(opens in a new tab)" suffix, so the owner
+  never loses an unsaved draft by navigating away in the same tab.
+- **Rendered-but-empty live region (R4-F14).** The upload announcement node is a
+  permanently-rendered, visually-empty `<p aria-live="polite">` — it does NOT carry staff.astro's
+  `hidden` class (content injected into a `display:none` live region is not announced). Upload
+  success, upload failure, and copy-address success all write into this same polite node.
+
 ### Client-side validation
 
 All client validation lives in `app/src/lib/blog-admin-client.ts` (an importable module called from
@@ -230,11 +238,30 @@ are enforced **server-side** at publish (the client does not mirror those).
 - Saved copy is **state-specific** (the page already loads every row, so it resolves the saved slug's
   status): a published save → "Published — now live at its link."; a draft save → "Saved as a draft —
   NOT yet visible to the public…"; `saved=deleted` → "Post deleted."
+- The add-form save (`saved=new`) uses a **two-state copy that names both outcomes** ("Saved. If you
+  set status to Published it is now live… If you saved it as a draft it is NOT yet visible…"). This
+  is a deliberate deviation from R4-F12's "saved=new state-specific" ask: the add-form `redirectTo`
+  is the static literal `/admin/blog?saved=new` (R1-F15, no slug) and `BlogPost` carries no
+  timestamp, so the just-created row cannot be identified to resolve its status. The edit-save case
+  carries the slug and fully resolves the state-specific copy.
 - The saved flash carries `role="status"` + a manual Dismiss button and must NOT carry
   `data-admin-alert` (avoiding AdminLayout's 6-second auto-hide). It gets no focus steal.
 - The error flash carries `role="alert"` + `tabindex="-1"` + `data-error-flash`, is focused once by
   an init script when present, then strips `?error=` from the URL; it must NOT carry
   `data-admin-alert` and is never auto-dismissed.
+
+### Accepted residuals (admin authoring)
+
+- **Slug-collision is a client convenience, not a guarantee (R2-F12).** The add-form's inline
+  collision check reads a server-rendered snapshot of existing slugs; the authoritative guard is the
+  endpoint's `createOnly` insert (`ON CONFLICT … DO NOTHING` → `400`). A genuine collision is
+  therefore only possible under concurrent creation of the same slug between page render and submit,
+  and the server rejects it.
+- **Body-image alt quality is enforced server-side at publish (R4-F7).** The client module does NOT
+  scan body Markdown for image alt text; a publish with a weak or empty in-body image description is
+  blocked by `validateBlogData` with a `400`. For a single author this surfaces as a publish-time
+  error rather than an inline warning — an accepted residual that keeps the client at faq.astro's
+  complexity class.
 
 ## Admin API
 


### PR DESCRIPTION
Closes #69. Stacked on PR-1 (#68) — **retarget base to main after PR-1 merges.** Parent #66.

**Adds** `admin/blog.astro` (add + per-post edit forms, drafts/published sections, server-rendered sanitized preview with open-on-save, status select top-level, accessible flashes: `role=alert` errors never auto-dismissed and suppressing the success flash), `blog-form-fields.ts`, `blog-admin-client.ts` (native validation mirrors + conditional-required + blocking slug-collision check — trimmed per R4-F7, no autosave) with jsdom unit tests, AdminNav link, endpoint-integration tests, spec §5 updates.

**Gates:** lint (jsx-a11y) 0 warnings · typecheck 0 errors · vitest green · format:check clean (tight-interpolation textareas survive `prettier --write`, R2-F8).
**Review fixes in `61097aa`:** edit-form staleness helper text (R1-F38), +1. **Rollout note (R2-F21):** seed-row freeze — no owner edits to imported posts between 015 apply and this PR's verification window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Blog Manager admin page for creating and editing blog posts with comprehensive field controls.
  * Implemented featured image upload functionality with real-time status announcements.
  * Added slug collision detection to prevent duplicate post identifiers.
  * Form fields conditionally enforce input based on publication status and image presence.

* **Documentation**
  * Updated blog specification for admin UX/accessibility behaviors and flash message semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->