### PR TITLE
feat(blog): public /blog + SEO — the launch PR (PR-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ npx netlify deploy --prod --dir=app/dist
 - We use Tailwind CSS 3, not CSS modules or styled-components
 - We use React islands selectively (TuitionCalculator), not as the primary renderer
 - Email providers: SendGrid + Unione (via REST). Resend/Postmark are Rollup externals but not active.
-- Out of scope: Stripe/payments, newsletter, public blog features
+- Blog: DB-backed via /admin/blog; posts are content rows with type='blog'
+- Out of scope: Stripe/payments, newsletter
 
 ## Path Aliases
 
@@ -55,17 +56,19 @@ npx netlify deploy --prod --dir=app/dist
 ## Database Access
 
 All DB access through the facade at `@lib/db`:
+
 ```typescript
-import { db } from '@lib/db';
+import { db } from "@lib/db";
 // db.content, db.camp, db.analytics, db.announcements,
 // db.communications, db.contact, db.adSpend, db.cache, db.raw
 ```
+
 Low-level: `queryFirst()` and `queryRows()` from `@lib/db/client`.
 
 ## Gotchas
 
 - **CSS `* { max-width: 100% }`** in `global.css` clamps ALL elements. Override with `max-width: none` when needed.
-- **Deploy from repo root, not `app/`.** `netlify.toml` has `base=app`, so deploying from `app/` causes path doubling.
+- **Deploy from repo root, not `app/`.** Deploying from repo root with `--dir=app/dist` is the working, current path; there is no `base=app` in the committed `netlify.toml`. The repo-root deploy empirically uploads the SSR function and prod serves SSR.
 - **SVGs with `preserveAspectRatio="none"`** need explicit width values (`width: auto` won't work).
 - **Email packages are Rollup externals** in `astro.config.mjs` — they resolve at runtime on Netlify, not at build.
 
@@ -74,11 +77,12 @@ Low-level: `queryFirst()` and `queryRows()` from `@lib/db/client`.
 - Components: PascalCase. Pages: kebab-case. Utilities: camelCase.
 - Commit prefixes: `feat(scope):`, `fix(scope):`, `[BUILD-FIX]`
 - Fonts: Nunito (body), Poppins (headings)
-- Brand colors are in `tailwind.config.cjs` under `forest-canopy`, `moss-green`, `sunlight-gold`, `earth-brown`, `stone-beige`, `cloud-gray`
+- Brand colors are in `tailwind.config.mjs` under `forest-canopy`, `moss-green`, `sunlight-gold`, `earth-brown`, `stone-beige`, `cloud-gray`
 
 ## Documentation
 
 Canonical docs live in `docs/`:
+
 - **PRD**: `docs/PRD.md`
 - **Roadmap**: `docs/ROADMAP.md`
 - **Specs**: `docs/specs/` (architecture, data-model, auth, camp-system, email, api)
@@ -92,6 +96,7 @@ Canonical docs live in `docs/`:
 ## Compact Instructions
 
 When compacting, preserve:
+
 - Current task description and acceptance criteria
 - List of files modified in this session
 - Unresolved blockers or open questions

--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -11,7 +11,18 @@ export default defineConfig({
   site: process.env.PUBLIC_SITE_URL || 'https://spicebushmontessori.org',
   integrations: [
     tailwind(),
-    sitemap(),
+    sitemap({
+      // Exclude routes that are owned by the dynamic blog sitemap, are redirect-only,
+      // or are admin/auth surfaces that should not be advertised to crawlers (R3-F8/R4-F4).
+      filter: (page) => {
+        const { pathname } = new URL(page);
+        if (pathname === '/blog' || pathname.startsWith('/blog/')) return false;
+        if (pathname === '/resources/blog' || pathname.startsWith('/resources/blog/')) return false;
+        if (pathname === '/admin' || pathname.startsWith('/admin/')) return false;
+        if (pathname.startsWith('/auth/')) return false;
+        return true;
+      }
+    }),
     react()
   ],
   output: 'server',

--- a/app/e2e/accessibility-compliance-test.spec.ts
+++ b/app/e2e/accessibility-compliance-test.spec.ts
@@ -10,7 +10,20 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
-  
+  // Precondition: the blog post route added to the alt-text and heading-hierarchy lists requires
+  // the 6 published posts to exist (migration 015 applied). If they are absent (e.g. pre-rollout),
+  // fail loudly on the precondition rather than producing a misleading absolute-gate failure.
+  // NOTE: like blog.spec.ts, this precondition is only satisfiable post-rollout (015 + prod).
+  test.beforeAll(async ({ request }) => {
+    const res = await request.get('/blog');
+    const html = await res.text();
+    const postLinks = [...html.matchAll(/href=["']\/blog\/[a-z0-9-_]+["']/g)];
+    expect(
+      postLinks.length,
+      'Accessibility suite precondition: expected ≥6 published posts on /blog (migration 015 applied)'
+    ).toBeGreaterThanOrEqual(6);
+  });
+
   test.describe('Bug 036: Contact Form Validation Accessibility', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/contact');
@@ -19,26 +32,26 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
     test('should announce validation errors to screen readers with aria-live', async ({ page }) => {
       // Submit form without filling required fields to trigger validation
       await page.click('#submit-btn');
-      
+
       // Check for aria-live regions that announce errors
       const ariaLiveRegions = await page.locator('[aria-live]').all();
       expect(ariaLiveRegions.length).toBeGreaterThan(0);
-      
+
       // Verify error messages are associated with form fields via aria-describedby
       const nameField = page.locator('#name');
       await expect(nameField).toHaveAttribute('aria-invalid', 'true');
-      
+
       const nameErrorId = await nameField.getAttribute('aria-describedby');
       if (nameErrorId) {
         const errorElement = page.locator(`#${nameErrorId}`);
         await expect(errorElement).toBeVisible();
       }
-      
+
       // Check email field validation
       const emailField = page.locator('#email');
       await page.fill('#email', 'invalid-email');
       await page.blur('#email');
-      
+
       await expect(emailField).toHaveAttribute('aria-invalid', 'true');
       const emailErrorId = await emailField.getAttribute('aria-describedby');
       if (emailErrorId) {
@@ -52,17 +65,17 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
       // Test name field validation
       await page.focus('#name');
       await page.blur('#name');
-      
+
       const nameErrorMessage = await page.locator('[id*="name-error"]').textContent();
       if (nameErrorMessage) {
         expect(nameErrorMessage).toMatch(/required|enter|provide/i);
         expect(nameErrorMessage).not.toMatch(/^Error:|Invalid/i);
       }
-      
+
       // Test email field validation
       await page.fill('#email', 'invalid');
       await page.blur('#email');
-      
+
       const emailErrorMessage = await page.locator('[id*="email-error"]').textContent();
       if (emailErrorMessage) {
         expect(emailErrorMessage).toMatch(/valid email|email address/i);
@@ -74,11 +87,11 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
       // Fill form partially and submit to trigger validation
       await page.fill('#name', 'Test User');
       await page.click('#submit-btn');
-      
+
       // Verify focus moves to first error field or stays on submit button
       const focusedElement = await page.evaluate(() => document.activeElement?.id);
       expect(focusedElement).toBeTruthy();
-      
+
       // Test that error fields remain focusable
       const emailField = page.locator('#email');
       await emailField.focus();
@@ -94,7 +107,7 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
     test('should hide honeypot field from screen readers with aria-hidden', async ({ page }) => {
       const honeypotContainer = page.locator('[style*="display: none"]');
       await expect(honeypotContainer).toHaveAttribute('aria-hidden', 'true');
-      
+
       const honeypotField = page.locator('input[name="bot-field"]');
       await expect(honeypotField).toHaveAttribute('tabindex', '-1');
       await expect(honeypotField).toHaveAttribute('autocomplete', 'off');
@@ -102,8 +115,10 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should not be discoverable by keyboard navigation', async ({ page }) => {
       // Tab through form fields and ensure honeypot is not reachable
-      const focusableElements = await page.locator('input:not([tabindex="-1"]), select, textarea, button').all();
-      
+      const focusableElements = await page
+        .locator('input:not([tabindex="-1"]), select, textarea, button')
+        .all();
+
       for (const element of focusableElements) {
         await element.focus();
         const elementName = await element.getAttribute('name');
@@ -114,7 +129,7 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
     test('should remain invisible visually', async ({ page }) => {
       const honeypotContainer = page.locator('[style*="display: none"]');
       await expect(honeypotContainer).toHaveCSS('display', 'none');
-      
+
       const honeypotField = page.locator('input[name="bot-field"]');
       const isVisible = await honeypotField.isVisible();
       expect(isVisible).toBe(false);
@@ -125,34 +140,37 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
     const pagesToTest = [
       '/',
       '/about',
-      '/programs', 
+      '/programs',
       '/admissions',
       '/contact',
-      '/blog'
+      '/blog',
+      '/blog/nurturing-growth-gardening-program'
     ];
 
     for (const pagePath of pagesToTest) {
       test(`should have descriptive alt text for all images on ${pagePath}`, async ({ page }) => {
         await page.goto(pagePath);
-        
+
         const images = await page.locator('img').all();
-        
+
         for (const img of images) {
           const altText = await img.getAttribute('alt');
           expect(altText).toBeTruthy();
-          
+
           if (altText) {
             // Alt text should be descriptive (more than just filename)
             expect(altText.length).toBeGreaterThan(5);
             expect(altText).not.toMatch(/\.(jpg|jpeg|png|gif|webp)$/i);
             expect(altText).not.toMatch(/^image|photo|picture$/i);
-            
+
             // Should describe the educational/contextual content
             if (pagePath === '/programs') {
               expect(altText.toLowerCase()).toMatch(/montessori|child|learn|material|activity/);
             }
             if (pagePath === '/about') {
-              expect(altText.toLowerCase()).toMatch(/montessori|child|learn|development|environment/);
+              expect(altText.toLowerCase()).toMatch(
+                /montessori|child|learn|development|environment/
+              );
             }
           }
         }
@@ -161,14 +179,14 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should not have missing alt attributes on any images', async ({ page }) => {
       const allPages = ['/', '/about', '/programs', '/admissions', '/contact'];
-      
+
       for (const pagePath of allPages) {
         await page.goto(pagePath);
-        
+
         // Check that no images are missing alt attributes entirely
         const imagesWithoutAlt = await page.locator('img:not([alt])').count();
         expect(imagesWithoutAlt).toBe(0);
-        
+
         // Check that no images have empty alt on content images (decorative images can have alt="")
         const contentImages = await page.locator('img[src*="/images/"]').all();
         for (const img of contentImages) {
@@ -181,39 +199,43 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
   });
 
   test.describe('Bug 017: Heading Hierarchy Structure', () => {
+    // NOTE: /blog (index) is deliberately NOT in this list — its empty-state 1→3 heading skip
+    // would fail the absolute hierarchy gate (R4-F20). /blog's heading order is asserted in
+    // blog.spec.ts behind the posts-exist precondition instead.
     const pagesToTest = [
       { path: '/', title: 'Homepage' },
       { path: '/about', title: 'About Page' },
       { path: '/programs', title: 'Programs Page' },
       { path: '/admissions', title: 'Admissions Page' },
-      { path: '/contact', title: 'Contact Page' }
+      { path: '/contact', title: 'Contact Page' },
+      { path: '/blog/nurturing-growth-gardening-program', title: 'Blog Post Page' }
     ];
 
     for (const pageInfo of pagesToTest) {
       test(`should have proper heading hierarchy on ${pageInfo.title}`, async ({ page }) => {
         await page.goto(pageInfo.path);
-        
+
         // Check that there's exactly one H1 per page
         const h1Count = await page.locator('h1').count();
         expect(h1Count).toBe(1);
-        
+
         // Get all headings in order
         const headings = await page.locator('h1, h2, h3, h4, h5, h6').all();
         const headingLevels = [];
-        
+
         for (const heading of headings) {
           const tagName = await heading.evaluate(el => el.tagName.toLowerCase());
           const level = parseInt(tagName.charAt(1));
           headingLevels.push(level);
         }
-        
+
         // Verify heading hierarchy (no skipping levels)
         expect(headingLevels[0]).toBe(1); // First heading should be H1
-        
+
         for (let i = 1; i < headingLevels.length; i++) {
           const currentLevel = headingLevels[i];
           const previousLevel = headingLevels[i - 1];
-          
+
           // Current level should not skip more than one level from previous
           expect(currentLevel).toBeLessThanOrEqual(previousLevel + 1);
         }
@@ -221,14 +243,14 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
       test(`should have meaningful heading content on ${pageInfo.title}`, async ({ page }) => {
         await page.goto(pageInfo.path);
-        
+
         const headings = await page.locator('h1, h2, h3, h4, h5, h6').all();
-        
+
         for (const heading of headings) {
           const headingText = await heading.textContent();
           expect(headingText).toBeTruthy();
           expect(headingText!.trim().length).toBeGreaterThan(2);
-          
+
           // Headings should not be just numbers or single words (unless appropriate)
           if (headingText!.trim().length > 0) {
             expect(headingText!.trim()).not.toMatch(/^[0-9]+$/);
@@ -241,20 +263,22 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
   test.describe('WCAG 2.1 Level A Compliance', () => {
     test('should support keyboard navigation throughout the site', async ({ page }) => {
       await page.goto('/');
-      
+
       // Test that all interactive elements are keyboard accessible
-      const interactiveElements = await page.locator('a, button, input, select, textarea, [role="button"], [tabindex="0"]').all();
-      
+      const interactiveElements = await page
+        .locator('a, button, input, select, textarea, [role="button"], [tabindex="0"]')
+        .all();
+
       for (const element of interactiveElements) {
         await element.focus();
         await expect(element).toBeFocused();
-        
+
         // Check that focused elements have visible focus indicators
         const focusOutline = await element.evaluate(el => {
           const styles = window.getComputedStyle(el);
           return styles.outline !== 'none' || styles.boxShadow !== 'none';
         });
-        
+
         // Either should have outline or box-shadow for focus indication
         // expect(focusOutline).toBe(true);
       }
@@ -262,10 +286,10 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should have proper color contrast ratios', async ({ page }) => {
       await page.goto('/');
-      
+
       // Test high contrast elements (headers, buttons, links)
       const textElements = await page.locator('h1, h2, h3, a, button, p').all();
-      
+
       for (const element of textElements) {
         const isVisible = await element.isVisible();
         if (isVisible) {
@@ -277,7 +301,7 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
               fontSize: computed.fontSize
             };
           });
-          
+
           // Basic check that text is not transparent or same as background
           expect(styles.color).not.toBe('rgba(0, 0, 0, 0)');
           expect(styles.color).not.toBe(styles.backgroundColor);
@@ -287,21 +311,24 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should have proper form labels and associations', async ({ page }) => {
       await page.goto('/contact');
-      
+
       // Check that all form inputs have proper labels
-      const formInputs = await page.locator('input[type="text"], input[type="email"], input[type="tel"], select, textarea').all();
-      
+      const formInputs = await page
+        .locator('input[type="text"], input[type="email"], input[type="tel"], select, textarea')
+        .all();
+
       for (const input of formInputs) {
         const inputId = await input.getAttribute('id');
         const inputName = await input.getAttribute('name');
-        
-        if (inputName !== 'bot-field') { // Skip honeypot field
+
+        if (inputName !== 'bot-field') {
+          // Skip honeypot field
           expect(inputId).toBeTruthy();
-          
+
           // Check for associated label
           const label = page.locator(`label[for="${inputId}"]`);
           await expect(label).toBeVisible();
-          
+
           const labelText = await label.textContent();
           expect(labelText).toBeTruthy();
           expect(labelText!.trim().length).toBeGreaterThan(1);
@@ -315,16 +342,18 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
         { path: '/about', expectedTitlePattern: /about|spicebush|montessori/i },
         { path: '/contact', expectedTitlePattern: /contact|spicebush|montessori/i }
       ];
-      
+
       for (const pageInfo of pagesToTest) {
         await page.goto(pageInfo.path);
-        
+
         const title = await page.title();
         expect(title).toBeTruthy();
         expect(title).toMatch(pageInfo.expectedTitlePattern);
-        
+
         // Check for meta description
-        const metaDescription = await page.locator('meta[name="description"]').getAttribute('content');
+        const metaDescription = await page
+          .locator('meta[name="description"]')
+          .getAttribute('content');
         expect(metaDescription).toBeTruthy();
         expect(metaDescription!.length).toBeGreaterThan(50);
         expect(metaDescription!.length).toBeLessThan(160);
@@ -335,15 +364,15 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
   test.describe('Screen Reader Compatibility Tests', () => {
     test('should have proper landmark roles', async ({ page }) => {
       await page.goto('/');
-      
+
       // Check for main content landmark
       const main = page.locator('main, [role="main"]');
       await expect(main).toBeVisible();
-      
-      // Check for navigation landmark  
+
+      // Check for navigation landmark
       const nav = page.locator('nav, [role="navigation"]');
       await expect(nav).toBeVisible();
-      
+
       // Check for contentinfo (footer) landmark
       const footer = page.locator('footer, [role="contentinfo"]');
       await expect(footer).toBeVisible();
@@ -351,14 +380,14 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should provide skip links for keyboard users', async ({ page }) => {
       await page.goto('/');
-      
+
       // Tab to first element and check if skip link appears
       await page.keyboard.press('Tab');
-      
+
       const skipLink = page.locator('a[href="#main-content"], a[href="#content"], .skip-link');
       // Skip link might exist but be visually hidden until focused
-      const skipLinkExists = await skipLink.count() > 0;
-      
+      const skipLinkExists = (await skipLink.count()) > 0;
+
       if (skipLinkExists) {
         await expect(skipLink.first()).toContainText(/skip|main|content/i);
       }
@@ -366,17 +395,17 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
 
     test('should announce form status changes', async ({ page }) => {
       await page.goto('/contact');
-      
+
       // Check for aria-live regions for form feedback
       const ariaLiveRegions = await page.locator('[aria-live]').count();
       expect(ariaLiveRegions).toBeGreaterThan(0);
-      
+
       // Test form submission status announcements
       const successAlert = page.locator('#form-success');
       const errorAlert = page.locator('#form-error');
-      
+
       await expect(successAlert).toHaveAttribute('aria-live', /.+/); // Should have aria-live attribute
-      await expect(errorAlert).toHaveAttribute('aria-live', /.+/);   // Should have aria-live attribute
+      await expect(errorAlert).toHaveAttribute('aria-live', /.+/); // Should have aria-live attribute
     });
   });
 
@@ -385,10 +414,10 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
       // Set mobile viewport
       await page.setViewportSize({ width: 375, height: 667 });
       await page.goto('/contact');
-      
+
       // Check that touch targets are large enough (at least 44px)
       const buttons = await page.locator('button, a, input[type="submit"]').all();
-      
+
       for (const button of buttons) {
         const isVisible = await button.isVisible();
         if (isVisible) {
@@ -399,26 +428,26 @@ test.describe('Accessibility Compliance Tests - Critical Fixes', () => {
           }
         }
       }
-      
+
       // Check that form inputs have appropriate input types for mobile keyboards
       const emailInput = page.locator('input[type="email"]');
       await expect(emailInput).toBeVisible();
-      
+
       const telInput = page.locator('input[type="tel"]');
       await expect(telInput).toBeVisible();
     });
 
     test('should handle zoom up to 200% without horizontal scrolling', async ({ page }) => {
       await page.goto('/');
-      
+
       // Simulate 200% zoom by setting viewport to half size
       await page.setViewportSize({ width: 640, height: 400 });
-      
+
       // Check that no horizontal scrollbar appears
       const hasHorizontalScroll = await page.evaluate(() => {
         return document.documentElement.scrollWidth > document.documentElement.clientWidth;
       });
-      
+
       expect(hasHorizontalScroll).toBe(false);
     });
   });

--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -241,8 +241,8 @@ test.describe('Blog V1 — public routes + SEO', () => {
         title: 'E2E Flow Draft',
         status: 'draft',
         createOnly: 'true',
-        body_raw: bodyRaw,
-        excerpt: 'An E2E draft excerpt.'
+        'data.body_raw': bodyRaw,
+        'data.excerpt_raw': 'An E2E draft excerpt.'
       });
       expect([200, 303]).toContain(create.status());
 
@@ -262,7 +262,7 @@ test.describe('Blog V1 — public routes + SEO', () => {
       const adminPage1 = await (
         await request.get('/admin/blog', { headers: { Cookie: sessionCookie } })
       ).text();
-      const extracted1 = extractTextareaValue(adminPage1, slug, 'body_raw');
+      const extracted1 = extractTextareaValue(adminPage1, slug, 'data.body_raw');
       expect(extracted1, 'posted body round-trips byte-identical').toBe(bodyRaw);
 
       await postContent({
@@ -270,14 +270,14 @@ test.describe('Blog V1 — public routes + SEO', () => {
         slug,
         title: 'E2E Flow Draft',
         status: 'draft',
-        body_raw: extracted1 ?? bodyRaw,
-        excerpt: 'An E2E draft excerpt.'
+        'data.body_raw': extracted1 ?? bodyRaw,
+        'data.excerpt_raw': 'An E2E draft excerpt.'
       });
 
       const adminPage2 = await (
         await request.get('/admin/blog', { headers: { Cookie: sessionCookie } })
       ).text();
-      const extracted2 = extractTextareaValue(adminPage2, slug, 'body_raw');
+      const extracted2 = extractTextareaValue(adminPage2, slug, 'data.body_raw');
       expect(extracted2, 're-submit must not accrete whitespace').toBe(extracted1);
 
       // 3. publish→200 transition: asserted ONLY in the post-deploy (rollout) run (R4-F24).
@@ -289,9 +289,9 @@ test.describe('Blog V1 — public routes + SEO', () => {
           slug,
           title: 'E2E Flow Draft',
           status: 'published',
-          body_raw: bodyRaw,
-          excerpt: 'An E2E draft excerpt.',
-          date: '2099-01-01'
+          'data.body_raw': bodyRaw,
+          'data.excerpt_raw': 'An E2E draft excerpt.',
+          'data.date': '2099-01-01'
         });
         const published = await request.get(`/blog/${slug}`, { maxRedirects: 0 });
         expect(published.status()).toBe(200);

--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * Blog V1 — public `/blog` + SEO E2E spec (plan §12 tests 18-24, 26, 27).
+ *
+ * Gate command (PINNED): `npx playwright test e2e/blog.spec.ts --project=chromium`.
+ * The repo defines 7 projects with `fullyParallel: true` and no `webServer`; an unpinned
+ * run executes the authoring-flow test 7× against the single DB. Pin to chromium AND
+ * `test.skip` test 24 for non-chromium projects.
+ *
+ * ROLLOUT NOTE: clean-slug rows (`nurturing-growth-gardening-program`, …) exist only after
+ * migration 015 is applied at rollout, and prod-origin canonical/OG assertions require
+ * `PUBLIC_SITE_URL=https://spicebushmontessori.org` in the build env (also a rollout step).
+ * Tests 18/19/22/27, the legacy→clean 301 in 20, and 24's clean-slug paths are therefore the
+ * ROLLOUT/manual gate — they are written so they compile and run, but go green only post-rollout.
+ * DB/origin-independent tests (21, 23, 26, the bad-slug/date-miss branches of 20) pass locally.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const PINNED_SLUG = 'nurturing-growth-gardening-program';
+const PINNED_LEGACY_SLUG = '2024-05-20-nurturing-growth-gardening-program';
+const PINNED_IMAGE = '/images/blog/feature-image-wf-flame-lily-1.webp';
+
+// The AA-passing non-link metadata color is `text-earth-brown/80`. earth-brown = #2E2E2E
+// (rgb 46,46,46) per tailwind.config.mjs; the `/80` opacity makes getComputedStyle().color
+// compute to exactly `rgba(46, 46, 46, 0.8)` (~6.4:1 on white). A POSITIVE assertion against
+// this value catches a regression to a failing token (e.g. text-earth-brown/70 → rgba(...,0.7),
+// or text-gray-400 → rgb(156,163,175)), which a denylist-only check would silently pass.
+const EARTH_BROWN_80_COLOR = 'rgba(46, 46, 46, 0.8)';
+
+// `.blog-body a` pinned link color: forest-canopy #3E6D51 = rgb(62, 109, 81), 5.98:1 on white.
+const PINNED_LINK_COLOR = 'rgb(62, 109, 81)';
+
+/** Resolve the origin asserted in canonical/OG/sitemap `<loc>` strings. */
+function resolveExpectedOrigin(): string {
+  const base = process.env.E2E_BASE_URL || 'https://spicebush-testing.netlify.app';
+  return new URL(base).origin;
+}
+
+/** Extract a single meta tag's `content` from an HTML string. */
+function metaContent(
+  html: string,
+  key: string,
+  attr: 'name' | 'property' = 'property'
+): string | null {
+  const re = new RegExp(`<meta[^>]*${attr}=["']${key}["'][^>]*content=["']([^"']*)["']`, 'i');
+  const alt = new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*${attr}=["']${key}["']`, 'i');
+  const m = html.match(re) ?? html.match(alt);
+  return m ? m[1] : null;
+}
+
+test.describe('Blog V1 — public routes + SEO', () => {
+  // Test 18 — GET /blog
+  test('18: GET /blog returns 200 with H1 "Blog" and ≥6 post links (AA metadata contrast)', async ({
+    page
+  }) => {
+    const response = await page.goto('/blog');
+    expect(response?.status(), 'GET /blog must be 200 (not redirected to /contact)').toBe(200);
+    expect(page.url(), 'must stay on /blog, not land on /contact').toContain('/blog');
+
+    await expect(page.locator('h1')).toHaveText('Blog');
+
+    const postLinks = page.locator('a[href^="/blog/"]');
+    expect(await postLinks.count(), 'at least 6 published posts').toBeGreaterThanOrEqual(6);
+    await expect(
+      page.locator(`a[href="/blog/${PINNED_SLUG}"]`),
+      'pinned gardening post link present'
+    ).toHaveCount(1);
+
+    // R4-F18 metadata-contrast pin (POSITIVE assertion): the date/byline/excerpt text must compute
+    // to text-earth-brown/80 (rgba(46,46,46,0.8), ~6.4:1), NOT a failing token. The byline <p>
+    // (parent of <time>) carries the text-earth-brown/80 class.
+    const metaText = page.locator('article p:has(time)').first();
+    const color = await metaText.evaluate(el => window.getComputedStyle(el).color);
+    expect(color, `metadata color must be the AA earth-brown/80 token, got ${color}`).toBe(
+      EARTH_BROWN_80_COLOR
+    );
+  });
+
+  // Test 19 — GET /blog/{clean slug}
+  test('19: GET /blog/<clean slug> renders post + full per-post SEO meta', async ({ request }) => {
+    const origin = resolveExpectedOrigin();
+    const res = await request.get(`/blog/${PINNED_SLUG}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    expect(html, 'post title present').toContain('Gardening Program');
+    expect(html.length, 'body content present').toBeGreaterThan(1000);
+
+    const description = metaContent(html, 'description', 'name');
+    expect(description, 'meta description non-empty').toBeTruthy();
+    expect((description ?? '').length).toBeGreaterThan(0);
+
+    expect(metaContent(html, 'og:type')).toBe('article');
+
+    // Prod-origin assertions (ROLLOUT-gated when PUBLIC_SITE_URL!=prod).
+    const canonical = html.match(/<link[^>]*rel=["']canonical["'][^>]*href=["']([^"']*)["']/i)?.[1];
+    expect(canonical?.startsWith(origin), `canonical ${canonical} on expected origin`).toBe(true);
+    expect(metaContent(html, 'og:url')?.startsWith(origin)).toBe(true);
+
+    const ogImage = metaContent(html, 'og:image');
+    expect(ogImage?.startsWith(origin)).toBe(true);
+    expect(ogImage).toContain(PINNED_IMAGE);
+
+    // twitter:image must be the post's featured image (prod origin), NOT the global default.
+    const twitterImage = metaContent(html, 'twitter:image');
+    expect(twitterImage).toContain(PINNED_IMAGE);
+    expect(twitterImage).not.toContain('SpicebushLogo');
+
+    expect(metaContent(html, 'og:image:alt'), 'og:image:alt present').toBeTruthy();
+    expect(
+      metaContent(html, 'twitter:image:alt', 'name'),
+      'twitter:image:alt present'
+    ).toBeTruthy();
+    expect(metaContent(html, 'article:published_time'), 'article:published_time ISO').toMatch(
+      /^\d{4}-\d{2}-\d{2}T/
+    );
+
+    // R2-F16: robots = index,follow on the post AND no googlebot-noindex tag.
+    expect(metaContent(html, 'robots', 'name')?.toLowerCase()).toContain('index');
+    expect(/<meta[^>]*name=["']googlebot["'][^>]*noindex/i.test(html)).toBe(false);
+
+    // Same robots discipline on /blog index.
+    const indexHtml = await (await request.get('/blog')).text();
+    expect(metaContent(indexHtml, 'robots', 'name')?.toLowerCase()).toContain('index');
+    expect(/<meta[^>]*name=["']googlebot["'][^>]*noindex/i.test(indexHtml)).toBe(false);
+  });
+
+  // Test 20 — 404 / legacy-redirect matrix
+  test('20: 404 + legacy-redirect matrix', async ({ request }) => {
+    // Unknown slug → branded 404 (builder-verify of §2.2 step 4).
+    const missing = await request.get('/blog/this-does-not-exist', { maxRedirects: 0 });
+    expect(missing.status()).toBe(404);
+    const missingHtml = await missing.text();
+    expect(missingHtml, 'branded 404 markup renders').toContain('Page Not Found');
+
+    // Date-prefixed legacy slug → 301 → clean slug (ROLLOUT-gated: needs the clean target row).
+    const legacy = await request.get(`/blog/${PINNED_LEGACY_SLUG}`, { maxRedirects: 0 });
+    expect(legacy.status()).toBe(301);
+    expect(legacy.headers()['location']).toBe(`/blog/${PINNED_SLUG}`);
+
+    // Date-prefixed unknown slug → 404, NOT a redirect (pins the fallback miss branch).
+    const dateMiss = await request.get('/blog/2024-01-01-nonexistent', { maxRedirects: 0 });
+    expect(dateMiss.status(), 'date-prefixed miss must 404, not redirect').toBe(404);
+  });
+
+  // Test 21 — resources 301s
+  test('21: /resources/blog and /resources/blog/<slug> 301 to canonical paths', async ({
+    request
+  }) => {
+    const idx = await request.get('/resources/blog', { maxRedirects: 0 });
+    expect(idx.status()).toBe(301);
+    expect(idx.headers()['location']).toBe('/blog');
+
+    const post = await request.get(`/resources/blog/${PINNED_SLUG}`, { maxRedirects: 0 });
+    expect(post.status()).toBe(301);
+    // Assert the 301 only — no "no intermediate hop" assertion (dropped with the page revert).
+    expect(post.headers()['location']).toBe(`/blog/${PINNED_SLUG}`);
+  });
+
+  // Test 22 — GET /sitemap-blog.xml
+  test('22: /sitemap-blog.xml returns XML with exact slashless <loc> forms, no drafts', async ({
+    request
+  }) => {
+    const origin = resolveExpectedOrigin();
+    const res = await request.get('/sitemap-blog.xml');
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toContain('application/xml');
+    const xml = await res.text();
+
+    // EXACT slashless <loc> strings (assert exact, not substring-with-slash).
+    expect(xml).toContain(`<loc>${origin}/blog</loc>`);
+    expect(xml).toContain(`<loc>${origin}/blog/${PINNED_SLUG}</loc>`);
+
+    const locs = [...xml.matchAll(/<loc>([^<]*)<\/loc>/g)].map(m => m[1]);
+    const postLocs = locs.filter(l => l.startsWith(`${origin}/blog/`));
+    expect(postLocs.length, '≥6 post URLs').toBeGreaterThanOrEqual(6);
+    for (const loc of locs) {
+      expect(loc.startsWith(origin), `loc ${loc} on expected origin`).toBe(true);
+      expect(loc.endsWith('/'), `no trailing-slash variant in ${loc}`).toBe(false);
+    }
+    // No draft slug present (drafts never reach the published read path).
+    expect(xml).not.toContain('e2e-flow-');
+  });
+
+  // Test 23 — footer + robots
+  test('23: footer link navigates to /blog and robots.txt advertises the blog sitemap', async ({
+    page,
+    request
+  }) => {
+    const origin = resolveExpectedOrigin();
+    await page.goto('/');
+    const footerBlogLink = page.locator('footer a[href="/blog"]').first();
+    await expect(footerBlogLink).toHaveCount(1);
+    await footerBlogLink.click();
+    await expect(page).toHaveURL(/\/blog$/);
+
+    const robots = await request.get('/robots.txt');
+    expect(robots.status()).toBe(200);
+    const body = await robots.text();
+    expect(body).toContain(`Sitemap: ${origin}/sitemap-blog.xml`);
+  });
+
+  // Test 24 — Authoring flow (request-context, authenticated, chromium-only)
+  test('24: admin authoring flow — draft invisibility, no-op round-trip, delete', async ({
+    request
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'chromium',
+      'authoring flow is chromium-only (single shared DB)'
+    );
+    test.skip(
+      !process.env.E2E_ADMIN_SESSION,
+      'E2E_ADMIN_SESSION required for the authenticated authoring flow'
+    );
+
+    const sessionCookie = `sbms-admin-session=${process.env.E2E_ADMIN_SESSION}`;
+    const origin = resolveExpectedOrigin();
+    const projectName = testInfo.project.name;
+    const slug = `e2e-flow-${projectName}-${testInfo.workerIndex}-${Date.now()}`;
+    const bodyRaw =
+      '## E2E heading\n\nA paragraph with **bold** text and a [link](https://example.com).';
+
+    const postContent = (form: Record<string, string>, accept = 'text/html') =>
+      request.post('/api/admin/content', {
+        headers: { Cookie: sessionCookie, Accept: accept, Origin: origin },
+        form
+      });
+
+    // Pre-step: orphan-sweep any leftover e2e-flow-% drafts from prior interrupted runs.
+    const sweep = await request.get('/admin/blog', { headers: { Cookie: sessionCookie } });
+    const sweepHtml = await sweep.text();
+    for (const m of sweepHtml.matchAll(/e2e-flow-[a-z0-9-]+/g)) {
+      await postContent({ collection: 'blog', slug: m[0], action: 'delete' });
+    }
+
+    try {
+      // 1. Create a DRAFT (createOnly) and assert it is invisible to every public surface.
+      const create = await postContent({
+        collection: 'blog',
+        slug,
+        title: 'E2E Flow Draft',
+        status: 'draft',
+        createOnly: 'true',
+        body_raw: bodyRaw,
+        excerpt: 'An E2E draft excerpt.'
+      });
+      expect([200, 303]).toContain(create.status());
+
+      const draftView = await request.get(`/blog/${slug}`, { maxRedirects: 0 });
+      expect(draftView.status(), 'draft must 404 on the public post page').toBe(404);
+
+      const indexHtml = await (await request.get('/blog')).text();
+      expect(indexHtml, 'draft slug absent from /blog index').not.toContain(slug);
+
+      const sitemapXml = await (await request.get('/sitemap-blog.xml')).text();
+      expect(sitemapXml, 'draft slug absent from sitemap').not.toContain(slug);
+
+      const draftDateView = await request.get(`/blog/2099-01-01-${slug}`, { maxRedirects: 0 });
+      expect(draftDateView.status(), 'date-prefixed draft target must 404, not redirect').toBe(404);
+
+      // 2. No-op edit round-trip (R2-F8): re-extract the rendered body_raw, assert byte-identity.
+      const adminPage1 = await (
+        await request.get('/admin/blog', { headers: { Cookie: sessionCookie } })
+      ).text();
+      const extracted1 = extractTextareaValue(adminPage1, slug, 'body_raw');
+      expect(extracted1, 'posted body round-trips byte-identical').toBe(bodyRaw);
+
+      await postContent({
+        collection: 'blog',
+        slug,
+        title: 'E2E Flow Draft',
+        status: 'draft',
+        body_raw: extracted1 ?? bodyRaw,
+        excerpt: 'An E2E draft excerpt.'
+      });
+
+      const adminPage2 = await (
+        await request.get('/admin/blog', { headers: { Cookie: sessionCookie } })
+      ).text();
+      const extracted2 = extractTextareaValue(adminPage2, slug, 'body_raw');
+      expect(extracted2, 're-submit must not accrete whitespace').toBe(extracted1);
+
+      // 3. publish→200 transition: asserted ONLY in the post-deploy (rollout) run (R4-F24).
+      // Gated on E2E_POST_DEPLOY so a crash between publish and cleanup can't strand a public
+      // published row during the pre-merge build context.
+      if (process.env.E2E_POST_DEPLOY === '1') {
+        await postContent({
+          collection: 'blog',
+          slug,
+          title: 'E2E Flow Draft',
+          status: 'published',
+          body_raw: bodyRaw,
+          excerpt: 'An E2E draft excerpt.',
+          date: '2099-01-01'
+        });
+        const published = await request.get(`/blog/${slug}`, { maxRedirects: 0 });
+        expect(published.status()).toBe(200);
+      }
+    } finally {
+      // Delete and verify removal via the UNCACHED admin surface (R4-F25), NOT the public 404.
+      const del = await postContent({ collection: 'blog', slug, action: 'delete' });
+      expect([200, 303]).toContain(del.status());
+      const adminAfter = await (
+        await request.get('/admin/blog', { headers: { Cookie: sessionCookie } })
+      ).text();
+      expect(adminAfter, 'slug removed per the uncached admin surface').not.toContain(slug);
+    }
+  });
+
+  // Test 26 — auth gates
+  test('26: admin/blog + content endpoint auth gates (real middleware)', async ({ request }) => {
+    // Unauthenticated GET /admin/blog → redirect to sign-in.
+    const adminGet = await request.get('/admin/blog', {
+      maxRedirects: 0,
+      headers: { Accept: 'text/html' }
+    });
+    expect([301, 302, 303, 307, 308]).toContain(adminGet.status());
+    expect(adminGet.headers()['location']).toContain('/auth/sign-in');
+
+    // POST /api/admin/content with NO cookie, JSON → 401 (middleware runs first).
+    const jsonPost = await request.post('/api/admin/content', {
+      maxRedirects: 0,
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      data: { collection: 'blog', slug: 'unauthed' }
+    });
+    expect(jsonPost.status()).toBe(401);
+
+    // Same POST with Accept: text/html → 302 to /auth/sign-in.
+    // NOTE: middleware's toSignInRedirect uses context.redirect() with no status → Astro
+    // default 302 (verified), NOT 303 as the work-order prose states.
+    const htmlPost = await request.post('/api/admin/content', {
+      maxRedirects: 0,
+      headers: { Accept: 'text/html' },
+      form: { collection: 'blog', slug: 'unauthed' }
+    });
+    expect(htmlPost.status()).toBe(302);
+    expect(htmlPost.headers()['location']).toContain('/auth/sign-in');
+  });
+
+  // Test 27 — .blog-body a deterministic pin
+  test('27: .blog-body a computed color is forest-canopy with underline', async ({ page }) => {
+    await page.goto(`/blog/${PINNED_SLUG}`);
+    const bodyLinks = page.locator('.blog-body a');
+    expect(await bodyLinks.count(), 'at least one body link').toBeGreaterThan(0);
+
+    const link = bodyLinks.first();
+    const color = await link.evaluate(el => window.getComputedStyle(el).color);
+    expect(color).toBe(PINNED_LINK_COLOR);
+
+    const decoration = await link.evaluate(el =>
+      window.getComputedStyle(el).getPropertyValue('text-decoration-line')
+    );
+    expect(decoration).toContain('underline');
+  });
+});
+
+/**
+ * Extract a named field's textarea value for a given slug from the rendered /admin/blog HTML,
+ * HTML-unescaping the content so the comparison is against the raw posted body.
+ * Returns null when the field is not found (so the caller's assertion fails loudly).
+ */
+function extractTextareaValue(html: string, slug: string, field: string): string | null {
+  // The admin page renders one editor block per post; scope the search to the slug's block.
+  const slugIdx = html.indexOf(slug);
+  if (slugIdx === -1) return null;
+  const block = html.slice(Math.max(0, slugIdx - 4000), slugIdx + 8000);
+  const re = new RegExp(`<textarea[^>]*name=["']${field}["'][^>]*>([\\s\\S]*?)</textarea>`, 'i');
+  const m = block.match(re);
+  if (!m) return null;
+  return htmlUnescape(m[1]);
+}
+
+function htmlUnescape(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'");
+}

--- a/app/e2e/content-db-direct.spec.ts
+++ b/app/e2e/content-db-direct.spec.ts
@@ -1,59 +1,20 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Direct Database Content Access', () => {
-  test('should load blog posts from database', async ({ page }) => {
-    await page.goto('/blog');
-    
-    // Wait for content to load
-    await page.waitForLoadState('networkidle');
-    
-    // Check that blog posts container exists
-    const blogContainer = page.locator('[data-testid="blog-posts"], .blog-posts, main');
-    await expect(blogContainer).toBeVisible();
-    
-    // Verify that at least one blog post is rendered
-    const blogPosts = page.locator('article, [class*="blog-post"], [class*="post-card"]');
-    const postCount = await blogPosts.count();
-    
-    expect(postCount).toBeGreaterThan(0);
-  });
-
-  test('should load individual blog post', async ({ page }) => {
-    // First, navigate to blog page to get a valid slug
-    await page.goto('/blog');
-    await page.waitForLoadState('networkidle');
-    
-    // Click on the first blog post link
-    const firstPostLink = page.locator('a[href^="/blog/"]').first();
-    const postHref = await firstPostLink.getAttribute('href');
-    
-    if (postHref) {
-      await firstPostLink.click();
-      await page.waitForLoadState('networkidle');
-      
-      // Verify we're on a blog post page
-      expect(page.url()).toContain('/blog/');
-      
-      // Check for blog post content
-      const postTitle = page.locator('h1, [class*="title"]').first();
-      await expect(postTitle).toBeVisible();
-      
-      const postContent = page.locator('article, [class*="content"], .prose');
-      await expect(postContent).toBeVisible();
-    }
-  });
-
+  // NOTE: the two former blog-only tests were removed — blog read-path coverage now lives in
+  // blog.spec.ts, which asserts the new SSR markup (the old selectors `[data-testid="blog-posts"]`
+  // / `.blog-posts` are not emitted by the V1 pages).
   test('should display hours information', async ({ page }) => {
     await page.goto('/');
-    
+
     // Look for hours widget or navigate to a page with hours
     const hoursSection = page.locator('[class*="hours"], [data-testid="hours-info"]');
-    
+
     if (await hoursSection.isVisible()) {
       // Verify hours are displayed
       const dayElements = hoursSection.locator('[class*="day"]');
       const dayCount = await dayElements.count();
-      
+
       expect(dayCount).toBeGreaterThan(0);
     }
   });
@@ -62,32 +23,32 @@ test.describe('Direct Database Content Access', () => {
     // Navigate to about page or homepage where teachers might be shown
     await page.goto('/about');
     await page.waitForLoadState('networkidle');
-    
+
     // Look for teachers section
     const teachersSection = page.locator('[class*="teacher"], [data-testid="teachers"]');
-    
-    if (await teachersSection.count() > 0) {
+
+    if ((await teachersSection.count()) > 0) {
       // Verify teacher cards are displayed
       const teacherCards = teachersSection.locator('[class*="teacher-card"], [class*="staff"]');
       const teacherCount = await teacherCards.count();
-      
+
       expect(teacherCount).toBeGreaterThan(0);
     }
   });
 
   test('should handle database errors gracefully', async ({ page }) => {
     // Navigate to test page that might trigger DB errors
-    const response = await page.goto('/test-direct-db', { 
-      waitUntil: 'networkidle' 
+    const response = await page.goto('/test-direct-db', {
+      waitUntil: 'networkidle'
     });
-    
+
     // Page should load even if database has issues
     expect(response?.status()).toBeLessThan(500);
-    
+
     // Check for any error messages
     const errorMessages = page.locator('[class*="error"], [role="alert"]');
     const errorCount = await errorMessages.count();
-    
+
     // If errors are shown, they should be user-friendly
     if (errorCount > 0) {
       const errorText = await errorMessages.first().textContent();
@@ -98,11 +59,11 @@ test.describe('Direct Database Content Access', () => {
 
   test('should load settings-based content', async ({ page }) => {
     await page.goto('/');
-    
+
     // Check if coming soon mode is active
     const comingSoonElements = page.locator('[class*="coming-soon"], [data-testid="coming-soon"]');
-    const isComingSoon = await comingSoonElements.count() > 0;
-    
+    const isComingSoon = (await comingSoonElements.count()) > 0;
+
     if (isComingSoon) {
       // Verify coming soon page elements
       const heading = page.locator('h1, h2').first();
@@ -119,22 +80,22 @@ test.describe('Content Type Specific Tests', () => {
   test('should load photo gallery if photos exist', async ({ page }) => {
     // Try both gallery and homepage for photos
     const pagesToCheck = ['/', '/about', '/gallery'];
-    
+
     for (const path of pagesToCheck) {
       await page.goto(path);
-      
+
       const images = page.locator('img[src*="/images/"], img[src*="/optimized/"]');
       const imageCount = await images.count();
-      
+
       if (imageCount > 0) {
         // Verify images load properly
         const firstImage = images.first();
         await expect(firstImage).toBeVisible();
-        
+
         // Check image has valid src
         const src = await firstImage.getAttribute('src');
         expect(src).toBeTruthy();
-        
+
         break; // Found images, no need to check other pages
       }
     }
@@ -142,16 +103,16 @@ test.describe('Content Type Specific Tests', () => {
 
   test('should load testimonials if they exist', async ({ page }) => {
     await page.goto('/');
-    
+
     const testimonials = page.locator('[class*="testimonial"], [data-testid="testimonials"]');
-    
-    if (await testimonials.count() > 0) {
+
+    if ((await testimonials.count()) > 0) {
       // Verify testimonial content
       const testimonialText = testimonials.locator('[class*="quote"], blockquote');
       const textCount = await testimonialText.count();
-      
+
       expect(textCount).toBeGreaterThan(0);
-      
+
       // Check for author attribution
       const authors = testimonials.locator('[class*="author"], cite');
       expect(await authors.count()).toBeGreaterThan(0);
@@ -161,14 +122,14 @@ test.describe('Content Type Specific Tests', () => {
   test('should load tuition information', async ({ page }) => {
     // Navigate to admissions or tuition calculator
     await page.goto('/admissions/tuition-calculator');
-    
+
     // Wait for page to load
     await page.waitForLoadState('networkidle');
-    
+
     // Check if tuition data is loaded
     const tuitionElements = page.locator('[class*="tuition"], [data-testid="tuition"]');
-    
-    if (await tuitionElements.count() > 0) {
+
+    if ((await tuitionElements.count()) > 0) {
       // Verify tuition rates or calculator is present
       const priceElements = page.locator('[class*="price"], [class*="rate"], [class*="cost"]');
       expect(await priceElements.count()).toBeGreaterThan(0);
@@ -180,27 +141,27 @@ test.describe('Database Connection Monitoring', () => {
   test('test page shows successful connection', async ({ page }) => {
     await page.goto('/test-direct-db');
     await page.waitForLoadState('networkidle');
-    
+
     // Look for success indicators
     const successElements = page.locator('text=/connected|success|✓/i');
     const successCount = await successElements.count();
-    
+
     expect(successCount).toBeGreaterThan(0);
-    
+
     // Verify data sections are shown
     const dataSections = page.locator('h2, h3, [class*="section"]');
     const sectionCount = await dataSections.count();
-    
+
     expect(sectionCount).toBeGreaterThan(0);
   });
 
   test('verifies all content types can be accessed', async ({ page }) => {
     await page.goto('/test-direct-db');
     await page.waitForLoadState('networkidle');
-    
-    // Expected content types
-    const contentTypes = ['blog', 'events', 'staff', 'settings'];
-    
+
+    // Expected content types (blog removed — blog read-path coverage lives in blog.spec.ts).
+    const contentTypes = ['events', 'staff', 'settings'];
+
     for (const contentType of contentTypes) {
       const typeElement = page.locator(`text=/${contentType}/i`);
       await expect(typeElement).toBeVisible();

--- a/app/src/layouts/Layout.astro
+++ b/app/src/layouts/Layout.astro
@@ -12,13 +12,21 @@ export interface Props {
   description?: string;
   keywords?: string;
   preloadImages?: boolean;
+  ogImage?: string;
+  ogImageAlt?: string;
+  ogType?: string;
+  publishedTime?: string;
 }
 
-const { 
-  title, 
-  description = 'Spicebush Montessori School provides individualized, inclusive Montessori education for children ages 3-6. Welcoming all learners with accessible tuition and neurodiversity support.', 
+const {
+  title,
+  description = 'Spicebush Montessori School provides individualized, inclusive Montessori education for children ages 3-6. Welcoming all learners with accessible tuition and neurodiversity support.',
   keywords = 'Montessori school, inclusive preschool, neurodiversity education, accessible tuition, early childhood education',
-  preloadImages = false
+  preloadImages = false,
+  ogImage,
+  ogImageAlt,
+  ogType = 'website',
+  publishedTime
 } = Astro.props;
 
 const seoMetadata = await resolveSeoMetadata({
@@ -30,6 +38,7 @@ const seoMetadata = await resolveSeoMetadata({
 });
 
 const canonicalURL = seoMetadata.canonicalUrl;
+const resolvedOgImage = ogImage ?? seoMetadata.ogImageUrl;
 const analyticsConfig = await getAnalyticsConfig();
 const analyticsEnabled = analyticsConfig.enabled;
 const gaMeasurementId = analyticsConfig.measurementId;
@@ -57,19 +66,22 @@ const preloadLinks = preloadImages ? generatePreloadLinks(CRITICAL_IMAGES) : '';
     {seoMetadata.noIndex && <meta name="googlebot" content="noindex, nofollow" />}
     
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={seoMetadata.title} />
     <meta property="og:description" content={seoMetadata.description} />
-    <meta property="og:image" content={seoMetadata.ogImageUrl} />
-    
+    <meta property="og:image" content={resolvedOgImage} />
+    {ogImage && ogImageAlt && <meta property="og:image:alt" content={ogImageAlt} />}
+    {ogType === 'article' && publishedTime && <meta property="article:published_time" content={publishedTime} />}
+
     <!-- Twitter -->
     <meta property="twitter:card" content={seoMetadata.twitterCard} />
     <meta property="twitter:url" content={canonicalURL} />
     <meta property="twitter:title" content={seoMetadata.title} />
     <meta property="twitter:description" content={seoMetadata.description} />
-    <meta property="twitter:image" content={seoMetadata.ogImageUrl} />
-    
+    <meta property="twitter:image" content={resolvedOgImage} />
+    {ogImage && ogImageAlt && <meta name="twitter:image:alt" content={ogImageAlt} />}
+
     <!-- Performance Optimization: Resource Hints -->
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">

--- a/app/src/lib/seo-config.ts
+++ b/app/src/lib/seo-config.ts
@@ -38,6 +38,7 @@ export const SEO_MANAGED_PAGES: SeoManagedPage[] = [
   { path: '/resources/faq', label: 'FAQ' },
   { path: '/resources/events', label: 'Events' },
   { path: '/resources/parent-resources', label: 'Parent Resources' },
+  { path: '/blog', label: 'Blog' },
   {
     path: '/coming-soon',
     label: 'Coming Soon',

--- a/app/src/pages/blog.astro
+++ b/app/src/pages/blog.astro
@@ -1,3 +1,80 @@
 ---
-return Astro.redirect('/contact', 301);
+import Layout from '@layouts/Layout.astro';
+import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
+import { getPublishedPosts } from '@lib/blog-content';
+
+const posts = await getPublishedPosts();
+
+const formatDate = (date: string | undefined): string | null => {
+  if (!date) return null;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC'
+  });
+};
 ---
+
+<Layout title="Blog">
+  <Header />
+
+  <main id="main-content" class="container mx-auto px-4 py-12">
+    <h1 class="text-4xl lg:text-5xl font-heading font-bold text-earth-brown mb-10 tracking-tight">
+      Blog
+    </h1>
+
+    {
+      posts.length === 0 ? (
+        <div class="max-w-2xl">
+          <p class="text-lg text-earth-brown/80 mb-6">
+            We're growing new stories. Check back soon for news, reflections, and updates from the
+            Spicebush Montessori community.
+          </p>
+          <h3 class="text-xl font-heading font-semibold text-earth-brown mb-3">In the meantime</h3>
+          <p class="text-earth-brown/80">
+            Have a question or want to learn more about our school?{' '}
+            <a href="/contact" class="text-forest-canopy underline hover:text-moss-green">
+              Get in touch with us
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <div class="space-y-12 max-w-3xl">
+          {posts.map(post => {
+            const formattedDate = formatDate(post.date);
+            return (
+              <article>
+                {post.image && (
+                  <img
+                    loading="lazy"
+                    alt={post.imageAlt}
+                    src={post.image}
+                    class="w-full rounded-lg mb-4"
+                  />
+                )}
+                <h2 class="text-2xl lg:text-3xl font-heading font-semibold mb-2">
+                  <a href={`/blog/${post.slug}`} class="text-forest-canopy hover:text-moss-green">
+                    {post.title}
+                  </a>
+                </h2>
+                <p class="text-sm text-earth-brown/80 mb-3">
+                  {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
+                  {formattedDate && <span class="mx-2">·</span>}
+                  <span>By {post.author}</span>
+                </p>
+                <p class="text-earth-brown/80">{post.excerpt}</p>
+              </article>
+            );
+          })}
+        </div>
+      )
+    }
+  </main>
+
+  <Footer />
+</Layout>

--- a/app/src/pages/blog/[slug].astro
+++ b/app/src/pages/blog/[slug].astro
@@ -1,3 +1,204 @@
 ---
-return Astro.redirect('/contact', 301);
+import Layout from '@layouts/Layout.astro';
+import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
+import { getPublishedPost, resolveLegacyBlogRedirect, renderPostBody } from '@lib/blog-content';
+import { resolveSiteOrigin } from '@lib/site-origin';
+
+const slug = Astro.params.slug ?? '';
+
+// Slug-param hygiene: reject anything outside the slug charset BEFORE querying.
+if (!/^[a-z0-9-_]{1,100}$/.test(slug)) {
+  return new Response(null, { status: 404 });
+}
+
+const post = await getPublishedPost(slug);
+
+if (!post) {
+  // Legacy date-prefix fallback: only redirects when the stripped slug resolves to a published post.
+  const target = await resolveLegacyBlogRedirect(slug);
+  if (target) {
+    return Astro.redirect(`/blog/${target}`, 301);
+  }
+  // Still missing (or a draft): render the branded 404.
+  return new Response(null, { status: 404 });
+}
+
+const formatDate = (date: string | undefined): string | null => {
+  if (!date) return null;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC'
+  });
+};
+
+const formattedDate = formatDate(post.date);
+const bodyHtml = renderPostBody(post.body);
 ---
+
+<Layout
+  title={post.seoTitle || post.title}
+  description={post.seoDescription || post.excerpt}
+  ogType="article"
+  ogImage={post.image ? new URL(post.image, resolveSiteOrigin(Astro.site)).href : undefined}
+  ogImageAlt={post.imageAlt}
+  publishedTime={post.date ? `${post.date}T12:00:00Z` : undefined}
+>
+  <Header />
+
+  <main id="main-content" class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto">
+      <h1 class="text-4xl lg:text-5xl font-heading font-bold text-earth-brown mb-4 tracking-tight">
+        {post.title}
+      </h1>
+
+      <p class="text-sm text-earth-brown/80 mb-6">
+        {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
+        {formattedDate && <span class="mx-2">·</span>}
+        <span>By {post.author}</span>
+      </p>
+
+      {
+        post.image && (
+          <img
+            src={post.image}
+            alt={post.imageAlt}
+            class="w-full rounded-lg mb-8"
+            loading="eager"
+          />
+        )
+      }
+
+      <div class="blog-body" set:html={bodyHtml} />
+
+      <p class="mt-12">
+        <a href="/blog" class="text-forest-canopy underline hover:text-moss-green">
+          ← Back to blog
+        </a>
+      </p>
+    </article>
+  </main>
+
+  <Footer />
+</Layout>
+
+<style is:global>
+  .blog-body {
+    font-family: 'Nunito', sans-serif;
+    line-height: 1.7;
+    color: #4b3a2f;
+  }
+
+  .blog-body h2,
+  .blog-body h3,
+  .blog-body h4,
+  .blog-body h5,
+  .blog-body h6 {
+    font-family: 'Poppins', sans-serif;
+    font-weight: 600;
+    color: #4b3a2f;
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.3;
+  }
+
+  .blog-body h2 {
+    font-size: 1.75rem;
+  }
+  .blog-body h3 {
+    font-size: 1.4rem;
+  }
+  .blog-body h4 {
+    font-size: 1.2rem;
+  }
+
+  .blog-body p {
+    margin-bottom: 1.1rem;
+  }
+
+  /* Pinned AA link style (R1-F35): forest-canopy, 5.98:1 on white. */
+  .blog-body a {
+    color: #3e6d51;
+    text-decoration: underline;
+  }
+
+  .blog-body ul,
+  .blog-body ol {
+    margin: 0 0 1.1rem 1.5rem;
+  }
+  .blog-body ul {
+    list-style: disc;
+  }
+  .blog-body ol {
+    list-style: decimal;
+  }
+  .blog-body li {
+    margin-bottom: 0.4rem;
+  }
+
+  /* Minimal block CSS (R4-F19 — WCAG 1.3.1): restore semantics lost to Preflight. */
+  .blog-body blockquote {
+    border-left: 4px solid #5a8065;
+    padding-left: 1rem;
+    margin: 0 0 1.1rem 0;
+    font-style: italic;
+    color: #5b4a3f;
+  }
+
+  .blog-body code {
+    font-family: 'Courier New', Courier, monospace;
+    background-color: #f1efe9;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.9em;
+  }
+
+  .blog-body pre {
+    font-family: 'Courier New', Courier, monospace;
+    background-color: #f1efe9;
+    padding: 1rem;
+    border-radius: 0.4rem;
+    overflow-x: auto;
+    margin-bottom: 1.1rem;
+  }
+
+  .blog-body pre code {
+    background-color: transparent;
+    padding: 0;
+  }
+
+  .blog-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1.1rem;
+  }
+
+  .blog-body th,
+  .blog-body td {
+    border: 1px solid #d6cfc2;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .blog-body th {
+    background-color: #f1efe9;
+    font-weight: 600;
+  }
+
+  .blog-body img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.4rem;
+    margin: 1.1rem 0;
+  }
+
+  .blog-body hr {
+    border: 0;
+    border-top: 1px solid #d6cfc2;
+    margin: 2rem 0;
+  }
+</style>

--- a/app/src/pages/resources/blog.astro
+++ b/app/src/pages/resources/blog.astro
@@ -1,3 +1,3 @@
 ---
-return Astro.redirect('/contact', 301);
+return Astro.redirect('/blog', 301);
 ---

--- a/app/src/pages/resources/blog/[slug].astro
+++ b/app/src/pages/resources/blog/[slug].astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect(`/blog/${Astro.params.slug}`, 301);
+---

--- a/app/src/pages/robots.txt.ts
+++ b/app/src/pages/robots.txt.ts
@@ -22,6 +22,7 @@ export const GET: APIRoute = async ({ site }) => {
   }
 
   lines.push(`Sitemap: ${new URL('/sitemap-index.xml', siteOrigin).toString()}`);
+  lines.push(`Sitemap: ${new URL('/sitemap-blog.xml', siteOrigin).toString()}`);
 
   return new Response(`${lines.join('\n')}\n`, {
     headers: {

--- a/app/src/pages/sitemap-blog.xml.ts
+++ b/app/src/pages/sitemap-blog.xml.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getPublishedPosts, renderBlogSitemapXml } from '@lib/blog-content';
+import { resolveSiteOrigin } from '@lib/site-origin';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ site }) => {
+  const posts = await getPublishedPosts();
+  const body = renderBlogSitemapXml(posts, resolveSiteOrigin(site));
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=300'
+    }
+  });
+};

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Product Requirements Document — Spicebush Montessori Website
 
-*Canonical source of truth for what this product is, who it serves, and what it does.*
-*Last verified against codebase: April 5, 2026*
+_Canonical source of truth for what this product is, who it serves, and what it does._
+_Last verified against codebase: April 5, 2026_
 
 ---
 
@@ -16,6 +16,7 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 ## 2. Users
 
 ### Parents & Prospective Families (Public)
+
 - Browse school information (programs, philosophy, staff, policies)
 - View school hours and schedule exceptions
 - Use the tuition calculator to estimate costs
@@ -25,6 +26,7 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 - Start enrollment via external link (Transparent Classroom)
 
 ### School Administrators (Authenticated)
+
 - Manage all CMS content (pages, settings, SEO metadata)
 - Manage staff profiles, hours, tuition settings, and FAQs
 - Manage summer camp seasons, weeks, seat availability, and mode
@@ -42,6 +44,7 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 ### 3.1 Public Website
 
 #### Homepage
+
 - Hero section with school branding
 - Value propositions and trust indicators
 - Featured teachers section
@@ -51,6 +54,7 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 - Announcement bar (for active school announcements)
 
 #### Informational Pages
+
 - **About** — school philosophy and history
 - **Programs** — program descriptions and age groups
 - **Our Principles** — Montessori educational approach
@@ -59,24 +63,28 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 - **Privacy Policy**, **Non-Discrimination Policy**, **Accessibility** — compliance pages
 
 #### Contact & Tours
+
 - Contact form with multi-layered bot protection (honeypot, timing check, Turnstile CAPTCHA, rate limiting)
 - Tour scheduling request form
 - Contact success confirmation page
 - All form submissions stored in database with attribution tracking (UTM, referrer, session)
 
 #### Hours Widget
+
 - Displays current school hours by day of week
 - Highlights today's hours
 - Shows Friday early closing (3 PM)
 - Respects schedule exceptions (closures, modified hours)
 
 #### Tuition Calculator
+
 - React interactive island component
 - Calculates estimated tuition based on program type and household income
 - Uses sliding-scale discount tiers from database
 - Admin-configurable base rates and discount brackets
 
 #### Summer Camp (`/camp`)
+
 - Camp landing page with season info, week cards, and seat availability
 - Per-week status chips: Open, Limited, Full, Waitlist, Closed
 - Enrollment links to Transparent Classroom (per-week)
@@ -84,16 +92,19 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 - Sitewide promotional modules when camp promotions are enabled
 
 #### Donations & Enrollment
+
 - External link placeholders managed via admin settings
 - Currently redirect to `/contact` if external links are not yet configured
 - Intended to link to external donation platform and Transparent Classroom enrollment
 
 #### Coming-Soon Mode
+
 - Full-site coming-soon gate controlled by database setting or environment variable
 - Admin bypass via authenticated session
 - Preview mode for admins to see the site while public sees coming-soon page
 
 #### SEO
+
 - Per-page SEO metadata (title, description, OG tags) managed via admin
 - Robots.txt dynamically generated
 - Camp pages indexed only when camp mode is active
@@ -102,29 +113,31 @@ The Spicebush Montessori website is the public-facing web presence for Spicebush
 
 All admin pages are auth-gated via magic-link session authentication.
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| Dashboard | `/admin` | Overview and quick links |
-| Hours | `/admin/hours` | Manage school hours by day of week |
-| Staff | `/admin/staff` | Manage teacher/staff profiles |
-| Tuition | `/admin/tuition` | Manage base rates and discount brackets |
-| Camp | `/admin/camp` | Manage camp seasons, weeks, seats, mode |
-| Announcements | `/admin/announcements` | School announcements and schedule exceptions |
-| Settings | `/admin/settings` | Site-wide settings (coming-soon, external links, camp mode, etc.) |
-| SEO | `/admin/seo` | Per-page SEO metadata management |
-| FAQ | `/admin/faq` | Manage FAQ content |
-| Contact Submissions | `/admin/contact-submissions` | View and export contact form entries |
-| Donations | `/admin/donations` | View donation records |
-| Media | `/admin/media` | Upload and manage images/media |
-| Testimonials | `/admin/testimonials` | Manage parent testimonials |
+| Module              | Path                         | Purpose                                                           |
+| ------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| Dashboard           | `/admin`                     | Overview and quick links                                          |
+| Hours               | `/admin/hours`               | Manage school hours by day of week                                |
+| Staff               | `/admin/staff`               | Manage teacher/staff profiles                                     |
+| Tuition             | `/admin/tuition`             | Manage base rates and discount brackets                           |
+| Camp                | `/admin/camp`                | Manage camp seasons, weeks, seats, mode                           |
+| Announcements       | `/admin/announcements`       | School announcements and schedule exceptions                      |
+| Settings            | `/admin/settings`            | Site-wide settings (coming-soon, external links, camp mode, etc.) |
+| SEO                 | `/admin/seo`                 | Per-page SEO metadata management                                  |
+| FAQ                 | `/admin/faq`                 | Manage FAQ content                                                |
+| Contact Submissions | `/admin/contact-submissions` | View and export contact form entries                              |
+| Donations           | `/admin/donations`           | View donation records                                             |
+| Media               | `/admin/media`               | Upload and manage images/media                                    |
+| Testimonials        | `/admin/testimonials`        | Manage parent testimonials                                        |
 
 ### 3.3 Analytics & Tracking
+
 - Custom analytics event tracking (page views, form submissions, camp clicks)
 - Ad spend tracking and campaign value reporting
 - GA4 reporting integration
 - Attribution data captured on contact form submissions
 
 ### 3.4 Email System
+
 - Magic-link delivery for admin authentication
 - Contact form confirmation emails
 - Donation thank-you emails
@@ -139,19 +152,22 @@ All admin pages are auth-gated via magic-link session authentication.
 Camp mode is a central product concept that controls seasonal camp visibility across the entire site.
 
 ### Mode States
-| Mode | Public Behavior | Admin Behavior |
-|------|----------------|----------------|
-| `on` | Camp pages visible, promotions active | Full access |
-| `off` | Camp pages redirect to coming-soon | Full access |
-| `prep` | Camp pages redirect to coming-soon | Full access (preview) |
-| `auto` | Active only within configured date window | Full access |
+
+| Mode   | Public Behavior                           | Admin Behavior        |
+| ------ | ----------------------------------------- | --------------------- |
+| `on`   | Camp pages visible, promotions active     | Full access           |
+| `off`  | Camp pages redirect to coming-soon        | Full access           |
+| `prep` | Camp pages redirect to coming-soon        | Full access (preview) |
+| `auto` | Active only within configured date window | Full access           |
 
 ### Seat Status Logic
+
 Each camp week computes availability: `available = capacity_total - seats_confirmed - seats_held`
 
 Status precedence: closed > waitlist > full > limited > open
 
 ### Promotion Zones
+
 When camp promotions are enabled, promotional content appears on: announcement bar, homepage, programs page, tuition page, and contact page.
 
 ---
@@ -160,10 +176,16 @@ When camp promotions are enabled, promotional content appears on: announcement b
 
 These features are explicitly deferred and not part of active development:
 
-- **Public blog** — content may exist in DB but blog UI is removed/redirected
 - **Newsletter / mailing list capture** — removed from active scope
 - **Stripe / payment processing** — deferred; donation and enrollment use external links
 - **On-site enrollment checkout** — Transparent Classroom is the system of record
+
+**Blog scope shipped in V1** (previously out of scope): a DB-backed `/blog` index plus
+`/blog/[slug]` post pages (content rows with `type='blog'`), draft/published states, per-post SEO
+(canonical / Open Graph / Twitter / `article:published_time` meta), a dynamic `/sitemap-blog.xml`,
+and admin CRUD via `/admin/blog`. Still deferred within blog (out of scope for V1): heading anchors
+/ fragment links, rich-text/WYSIWYG editor, categories/tags UI, RSS, pagination, scheduled
+publishing, related posts, search, comments, and newsletter.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,12 +15,12 @@ This is the living roadmap for the Spicebush Montessori website (spicebushmontes
 
 Key merged work:
 
-| Commit | Description |
-|--------|-------------|
+| Commit    | Description                                                                             |
+| --------- | --------------------------------------------------------------------------------------- |
 | `7a5d150` | P0+P1 re-audit fixes -- slug sort, photo picker, export cap, error display, SVG headers |
-| `c6e13e5` | Merge of P0+P1 fixes branch |
-| `4133012` | P1+P2 audit fixes |
-| `d48ed0b` | Merge of P1+P2 fixes branch |
+| `c6e13e5` | Merge of P0+P1 fixes branch                                                             |
+| `4133012` | P1+P2 audit fixes                                                                       |
+| `d48ed0b` | Merge of P1+P2 fixes branch                                                             |
 
 ---
 
@@ -29,6 +29,7 @@ Key merged work:
 **Goal:** Strip the codebase to what is actively used, fix critical issues, establish a stable baseline.
 
 ### Kept
+
 - Hours widget
 - Staff management
 - Tuition calculator
@@ -36,16 +37,24 @@ Key merged work:
 - Camp mode system
 
 ### Removed or Deferred
-- Blog UI
+
 - Newsletter
 - Stripe / payments integration
 
 ### Completed
+
 - Documentation consolidation
 - Archive stale plans
 - P0+P1 security fixes
 - P1+P2 security fixes
 - All open issues migrated to GitHub Issues
+- **Blog V1 (shipped)** — DB-backed `/blog` index + `/blog/[slug]` posts, draft/published states,
+  per-post SEO (canonical/OG/Twitter/`article` meta), dynamic `/sitemap-blog.xml`, admin CRUD via
+  `/admin/blog`. The Phase-3 prerequisite gates were met: (1) security review — no new P1+ findings;
+  (2) maintainability — no regression; (3) full coverage for new code; (4) lint/typecheck/E2E green.
+  **Gates 3 (full coverage) and 4 (E2E green) are satisfied via RECORDED MANUAL RUNS WITH ATTACHED
+  ARTIFACTS, not automated CI** (R4-F23 — CI runs no Playwright; coverage is a recorded manual
+  `npm run test:coverage` step with a json-summary artifact).
 
 ---
 
@@ -54,19 +63,23 @@ Key merged work:
 **Goal:** Make the admin panel production-solid, expand test coverage, and close remaining security findings.
 
 ### Authentication
+
 - [ ] Apply admin auth migration in all environments
 - [ ] Verify production email delivery for admin login magic links
 - [ ] Decide on magic-link auth long-term vs. Auth0
 
 ### Configuration-Driven Redirects
+
 - [ ] Replace `/donate` redirect with DB-configured `donation_external_link`
 - [ ] Replace `/enrollment` redirect with DB-configured `enrollment_external_link`
 
 ### Admin UX
+
 - [ ] Improve admin UX for core modules (camp, content, media, settings)
 - [ ] Remove remaining newsletter-specific references from admin UI and API routes
 
 ### Test Coverage
+
 - [ ] Expand automated test coverage from 9.5% to 25%+ target
 - [ ] Add tests for error branches in existing API routes
 - [ ] Add E2E coverage for admin authentication flow
@@ -78,13 +91,19 @@ Key merged work:
 **Goal:** Selectively re-add features that were stripped in Phase 1, only after they pass quality gates.
 
 ### Candidates (all optional, evaluated individually)
+
 - Media management refactor
-- Blog
 - Newsletter
 - Payments / Stripe
 
+> Blog shipped as V1 (see Phase 1 → Completed). Remaining blog enhancements (categories/tags UI,
+> RSS, pagination, scheduled publishing, related posts, search, comments, rich-text editor) stay
+> deferred and are evaluated individually if reintroduced.
+
 ### Prerequisites
+
 Each feature must pass before merge:
+
 1. Security review (no new P1+ findings)
 2. Maintainability review (no regression below current score)
 3. Full test coverage for new code
@@ -96,12 +115,12 @@ Each feature must pass before merge:
 
 Audit completed March 17, 2026.
 
-| Severity | Count | Status |
-|----------|-------|--------|
-| P0 | 0 | N/A |
-| P1 | 4 | All resolved (commits `7a5d150`, `4133012`) |
-| P2 | 9 | Most resolved; remaining tracked in GitHub Issues |
-| P3 | 16 | Tracked in GitHub Issues |
+| Severity | Count | Status                                            |
+| -------- | ----- | ------------------------------------------------- |
+| P0       | 0     | N/A                                               |
+| P1       | 4     | All resolved (commits `7a5d150`, `4133012`)       |
+| P2       | 9     | Most resolved; remaining tracked in GitHub Issues |
+| P3       | 16    | Tracked in GitHub Issues                          |
 
 All findings are now tracked as GitHub Issues with `P0`--`P3` labels.
 

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -359,4 +359,10 @@ Coverage is likewise a recorded manual `npm run test:coverage` step with a json-
   authoring flow creates a DRAFT only — the publish→200 transition is asserted ONLY in the
   post-deploy run (set `E2E_POST_DEPLOY=1` and point `E2E_BASE_URL` at prod). A crash between
   publish and cleanup must not strand a public published row pre-merge.
+- **Baseline honesty at PR creation (R1-F45):** record the current `npm run test:e2e` pass/fail
+  counts in the PR description; if the suite is red at baseline, scope the PR-4 E2E gate to the
+  named green set (`blog.spec.ts` + the a11y additions) and file a GitHub issue tracking the
+  pre-existing failures, linked from the PR (track, do not fix here). The baseline cannot be taken
+  during the build (the default Playwright config targets the live `testing` site — a rollout-only
+  surface per §9.1); take it at PR creation against that recorded gate.
 - **Search Console:** submit `sitemap-blog.xml` after launch (recovery for the unwound 301s).

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -1,6 +1,6 @@
 # Production Deployment Runbook
 
-*Spicebush Montessori -- Astro 5 SSR on Netlify + Neon PostgreSQL*
+_Spicebush Montessori -- Astro 5 SSR on Netlify + Neon PostgreSQL_
 
 ---
 
@@ -68,12 +68,14 @@ SELECT type, slug, status, author_email, created_at, updated_at,
 ```
 
 **STOP and reconcile manually** if either is true:
+
 - Any `type='blog'` row no longer matches the seed shape (the expected state is **6 rows**, all `author_email='seed@spicebushmontessori.org'`, all date-prefixed slugs); OR
 - Any **clean-slug** `type='blog'` row exists (an owner-created row matching one of the six clean slugs would be silently skipped by `ON CONFLICT DO NOTHING`, leaving a stale body). Reconcile that row's body against the markdown source before applying.
 
 #### Step 3 — PR-2 edit-window remediation
 
 Once the `/admin/blog` authoring page (PR-2) is live, the owner/tester can see the 6 seed rows with date-prefixed slugs. **A single admin edit sets `author_email` to the admin's session email**, which removes that row from 015's `DELETE` predicate — the clean-slug `INSERT` then lands alongside the edited row (7 rows, one duplicate). The PR-2 freeze note ("do not edit or delete the legacy seed rows until the PR-3 import is verified") is intended to prevent this. If it happened anyway:
+
 - Compare the edited date-prefixed row against its markdown source.
 - Confirm the clean-slug imported row supersedes it (carry over any divergent admin edits into the clean-slug row).
 - Delete the date-prefixed row manually.
@@ -135,6 +137,7 @@ DELETE FROM content WHERE type='blog'
 ```
 
 **Caveats:**
+
 - The `author_email IS NULL` guard ensures owner-edited posts (whose `author_email` is the admin's email) are **never** deleted.
 - Rollback does **not** resurrect the seed rows 015 deleted — the markdown source remains in git, so a re-apply re-imports cleanly.
 - Fixes ship as a corrected **016**, never by editing an already-applied 015.
@@ -213,18 +216,22 @@ curl -I https://<preview-url>/enrollment
 ### Automatic (CI/CD — standard path)
 
 Merging a PR to `main` triggers the `deploy.yml` GitHub Actions workflow, which:
+
 1. Builds the app (`cd app && npm run build`)
 2. Deploys to Netlify via CLI (`npx netlify deploy --prod --dir=app/dist`)
 
 No Netlify git integration is used — GitHub Actions owns the build and deploy pipeline.
 
+> **Verified:** the repo-root `npx netlify deploy --prod --dir=app/dist` empirically uploads the SSR function and prod serves SSR (probed 2026-06-06: `/contact` → 200, `/admin` → 302). The workflow is correct as-is — no deploy-command patch and no SSR-function-upload verification-deploy gate are needed.
+
 **Required GitHub secrets:**
+
 - `NETLIFY_SITE_ID` — Netlify site UUID
 - `NETLIFY_AUTH_TOKEN` — Netlify personal access token
 
 ### Manual CLI Deploy (emergency or ad-hoc)
 
-**CRITICAL: Run from the repository root, NOT from `app/`.** The `netlify.toml` has `base=app`, so deploying from `app/` causes path doubling.
+**CRITICAL: Run from the repository root, NOT from `app/`.** Deploying from the repo root with `--dir=app/dist` is the working, current path; the committed `netlify.toml` has **no `base` key** (`[build] command="npm run build"`, `publish="dist"`).
 
 ```bash
 # Build first
@@ -254,12 +261,12 @@ Complete each item against the live production URL.
 
 These settings must match in the Netlify dashboard (Site Settings > Build & Deploy):
 
-| Setting           | Value          |
-|-------------------|----------------|
-| Base directory    | `app`          |
-| Build command     | `npm run build`|
-| Publish directory | `dist`         |
-| Node version      | `20`           |
+| Setting           | Value           |
+| ----------------- | --------------- |
+| Base directory    | `app`           |
+| Build command     | `npm run build` |
+| Publish directory | `dist`          |
+| Node version      | `20`            |
 
 Environment variables required in Netlify:
 
@@ -270,3 +277,86 @@ Environment variables required in Netlify:
 - `ADMIN_DOMAINS` -- (optional) domain-based admin access
 - `COMING_SOON_MODE` -- (optional) override for coming-soon gate
 - One email provider key: `UNIONE_API_KEY`, `RESEND_API_KEY`, `SENDGRID_API_KEY`, or `POSTMARK_SERVER_TOKEN`
+
+---
+
+## 9. Blog V1 Launch (rollout boundary — supervised, performed at launch)
+
+The blog code, pages, sitemap, SEO meta, and tests ship in PR-4, but the public switch is
+flipped only at the supervised launch. The PR build does **not** execute any of the steps in
+§9.1. Apply migrations 014 + 015 (the migration procedure and seed defusal are in §2 above)
+**before** the launch deploy so the 6 clean-slug rows exist when `/blog` goes live.
+
+### 9.1 Rollout-boundary actions (NOT performed by the build — execute supervised at launch)
+
+1. **Set the canonical origin (build-env requirement, R4-F31).** The static `@astrojs/sitemap`
+   origin and per-post canonical/OG origins are baked from `PUBLIC_SITE_URL` at `astro build`
+   time. The production build **must** run with `PUBLIC_SITE_URL=https://spicebushmontessori.org`:
+   ```bash
+   npx netlify env:set PUBLIC_SITE_URL https://spicebushmontessori.org
+   ```
+   (all contexts; currently the production context is `https://spicebush-testing.netlify.app`,
+   which is the confirmed canonicals bug.)
+2. **Neutralize the competing git-CI deploy path.** The Netlify production branch is `testing`
+   (a live competing deploy path). Set `stop_builds=true` so the authoritative `deploy.yml`
+   (repo-root `npx netlify deploy --prod --dir=app/dist`) is the only deploy path:
+   ```
+   build_settings.stop_builds = true
+   ```
+   The existing `deploy.yml` is the working, authoritative deploy mechanism — do **not** add a
+   deploy-command patch or an SSR-function-upload verification-deploy gate.
+3. **Apply migrations 014 + 015** to prod (review 014 first — prod `schema_migrations` tops out
+   at 013; 014 is on disk but unapplied). Run the mandatory pre-flight re-audit (§2) immediately
+   before applying.
+4. Deploy via `deploy.yml`, then run §9.2 and the manual E2E gate (§9.3).
+
+### 9.2 Launch-verification curl checklist (against `https://spicebushmontessori.org`)
+
+```bash
+SITE=https://spicebushmontessori.org
+
+# Status matrix
+curl -sI "$SITE/blog"                                            # 200
+curl -sI "$SITE/blog/nurturing-growth-gardening-program"        # 200 (repeat for each clean slug)
+curl -sI "$SITE/blog/2024-05-20-nurturing-growth-gardening-program"  # 301 → /blog/<clean>
+curl -sI "$SITE/blog/2024-01-01-nonexistent"                    # 404 (date-prefixed miss, NOT a redirect)
+curl -sI "$SITE/resources/blog"                                 # 301 → /blog
+curl -sI "$SITE/resources/blog/nurturing-growth-gardening-program"  # 301 → /blog/<slug>
+curl -sI "$SITE/blog/this-does-not-exist"                       # 404 (branded)
+
+# Per-post SEO meta (prod origin; twitter:image = the post's featured image, NOT the default logo)
+curl -s "$SITE/blog/nurturing-growth-gardening-program" \
+  | grep -E 'rel="canonical"|og:url|og:image|twitter:image|og:image:alt|twitter:image:alt|article:published_time|name="robots"'
+#   - canonical / og:url / og:image start with https://spicebushmontessori.org
+#   - twitter:image contains /images/blog/feature-image-wf-flame-lily-1.webp (NOT SpicebushLogo)
+#   - twitter:image:alt present; og:image:alt present; article:published_time is ISO
+#   - robots = "index, follow"; no <meta name="googlebot" ... noindex> (also check /blog)
+curl -s "$SITE/blog" | grep -E 'name="robots"|googlebot'        # index,follow; no googlebot-noindex
+
+# Sitemap + robots (prod origin, exact slashless <loc>, draft-free)
+curl -s "$SITE/sitemap-blog.xml"                                # 200, XML; <loc>$SITE/blog</loc> and <loc>$SITE/blog/<slug></loc>; ≥6 posts; no drafts
+curl -s "$SITE/robots.txt" | grep sitemap-blog                  # Sitemap: $SITE/sitemap-blog.xml
+
+# Static sitemap must EXCLUDE blog / resources-blog / admin / auth
+curl -s "$SITE/sitemap-0.xml" | grep -E '/blog|/resources/blog|/admin|/auth'   # expect NO matches
+```
+
+### 9.3 Manual E2E gate (CI runs no Playwright — R4-F23)
+
+E2E green is a **recorded manual step with attached artifacts** (json/html report), not a CI gate.
+Coverage is likewise a recorded manual `npm run test:coverage` step with a json-summary artifact.
+
+- **Pinned gate command:** `npx playwright test e2e/blog.spec.ts --project=chromium`
+  (the repo has 7 projects, `fullyParallel: true`, no `webServer`; an unpinned run executes the
+  authoring flow 7× against the single DB).
+- **`E2E_ADMIN_SESSION` secret lifecycle:** provision a fresh admin session cookie immediately
+  before the run; **NEVER record the cookie value** in the PR, issues, or any committed file
+  (use `read -s` / an env file outside the repo); revoke it after the run (or accept the 12h-TTL
+  expiry). The origin check is exercised by unit tests, not this flow.
+- **`e2e-flow-%` orphan-sweep pre-step:** the authoring flow sweeps leftover `e2e-flow-%` drafts
+  before creating its own; keep that pre-step so an interrupted prior run cannot strand rows.
+- **Draft-only pre-merge / publish-only post-deploy (R4-F24):** in the pre-merge/build context the
+  authoring flow creates a DRAFT only — the publish→200 transition is asserted ONLY in the
+  post-deploy run (set `E2E_POST_DEPLOY=1` and point `E2E_BASE_URL` at prod). A crash between
+  publish and cleanup must not strand a public published row pre-merge.
+- **Search Console:** submit `sitemap-blog.xml` after launch (recovery for the unwound 301s).

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -35,23 +35,23 @@ allowlist but is unused; all blog rows use `type = 'blog'`.
 
 ### Row shape for a blog post
 
-| Column / JSONB key             | Value                                                                                                                                                                                     |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                         | `'blog'`                                                                                                                                                                                  |
-| `slug`                         | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI |
-| `title` (column)               | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`)                                                                                                            |
-| `status`                       | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish              |
-| `data.date`                    | `'YYYY-MM-DD'` string — display and sort date                                                                                                                                             |
-| `data.author`                  | string, default `'Spicebush Team'`                                                                                                                                                        |
-| `data.excerpt`                 | string, ≤ 1,000 chars, trimmed                                                                                                                                                            |
-| `data.body`                    | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML                                                                                    |
-| `data.image`                   | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)`                                                                               |
-| `data.imageAlt`                | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word                                                                |
-| `data.seoTitle`                | optional per-post `<title>` / OG override                                                                                                                                                 |
-| `data.seoDescription`          | optional per-post meta-description / OG override                                                                                                                                          |
-| `data.categories`, `data.tags` | legacy import keys, carried **opaquely** by the generic `baseDataJson` edit passthrough; no blog code reads, validates, or reshapes them                                                  |
-| `author_email`                 | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator)                                                                       |
-| `created_at` / `updated_at`    | imported rows use `{date}T12:00:00Z`; auto-managed otherwise                                                                                                                              |
+| Column / JSONB key | Value |
+|---|---|
+| `type` | `'blog'` |
+| `slug` | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI |
+| `title` (column) | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`) |
+| `status` | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish |
+| `data.date` | `'YYYY-MM-DD'` string — display and sort date |
+| `data.author` | string, default `'Spicebush Team'` |
+| `data.excerpt` | string, ≤ 1,000 chars, trimmed |
+| `data.body` | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML |
+| `data.image` | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)` |
+| `data.imageAlt` | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word |
+| `data.seoTitle` | optional per-post `<title>` / OG override |
+| `data.seoDescription` | optional per-post meta-description / OG override |
+| `data.categories`, `data.tags` | legacy import keys, carried **opaquely** by the generic `baseDataJson` edit passthrough; no blog code reads, validates, or reshapes them |
+| `author_email` | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator) |
+| `created_at` / `updated_at` | imported rows use `{date}T12:00:00Z`; auto-managed otherwise |
 
 ### Empty-string semantics
 
@@ -99,7 +99,7 @@ seed-created blog rows.
 Migration 015 **reconciles then imports**, all in one transaction:
 
 1. **Reconcile** — `DELETE` the seed-pipeline rows (targets only `author_email =
-'seed@spicebushmontessori.org'` AND date-prefixed slugs).
+   'seed@spicebushmontessori.org'` AND date-prefixed slugs).
 2. **Import** — six `INSERT … ON CONFLICT (type, slug) DO NOTHING`, using the **clean** slugs (file
    name with the date prefix stripped, or the explicit frontmatter `slug`), `author_email = NULL`,
    and `created_at`/`updated_at` of `{date}T12:00:00Z`.
@@ -114,12 +114,12 @@ content remains recoverable via git history.
 
 ## Public Routes
 
-| Route                    | Description                                                                                                                                                                                 |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/blog`                  | Blog index — vertical list of published posts (featured image, title link, date, author, excerpt). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
-| `/blog/[slug]`           | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro`                                                                                                         |
-| `/resources/blog`        | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro`                                                                                                                         |
-| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro`                                                                                                   |
+| Route | Description |
+|-------|-------------|
+| `/blog` | Blog index — vertical list of published posts (featured image, title link, date, author, excerpt). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
+| `/blog/[slug]` | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro` |
+| `/resources/blog` | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro` |
+| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro` |
 
 ### Post page behavior
 
@@ -139,10 +139,10 @@ real fixes the previously-broken link that 301'd to `/contact`.
 
 ## Admin Routes
 
-| Route                     | Description                                                                                                                                    |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/admin/blog`             | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
-| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts`                       |
+| Route | Description |
+|-------|-------------|
+| `/admin/blog` | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
+| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts` |
 
 The admin page is a structural clone of `app/src/pages/admin/faq.astro` (AdminLayout wrapper,
 `?saved=` / `?error=` flash params, `<details>` add-form + collapsible per-item edit forms). A link
@@ -270,25 +270,25 @@ The blog uses the existing generic content endpoint `POST /api/admin/content` (w
 enter the request path of all existing admin collections — a regression test confirms an existing
 collection still saves and deletes (including the header-absent fail-open case).
 
-| Change                        | Behavior                                                                                                                                                                                        |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Allowlist                     | `'blog'` added to `ALLOWED_COLLECTIONS`                                                                                                                                                         |
-| Origin check                  | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense                |
-| `_raw` field suffix           | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
-| Blog normalize/validate hook  | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status                             |
-| `createOnly` guard            | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form)                         |
-| Form-based delete             | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat`                                                                    |
-| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])`                                                                                                   |
+| Change | Behavior |
+|---|---|
+| Allowlist | `'blog'` added to `ALLOWED_COLLECTIONS` |
+| Origin check | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense |
+| `_raw` field suffix | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
+| Blog normalize/validate hook | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status |
+| `createOnly` guard | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form) |
+| Form-based delete | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat` |
+| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])` |
 
 ### Auth
 
 The middleware protects `/admin` and `/api/admin` prefixes:
 
-| Request                             | Result                                                                                 |
-| ----------------------------------- | -------------------------------------------------------------------------------------- |
-| Unauthenticated JSON request        | `401`                                                                                  |
+| Request | Result |
+|---|---|
+| Unauthenticated JSON request | `401` |
 | Unauthenticated `Accept: text/html` | `302` to `/auth/sign-in` (middleware `context.redirect` default — verified; not `303`) |
-| Authenticated, non-admin session    | `403` (the endpoint's own check)                                                       |
+| Authenticated, non-admin session | `403` (the endpoint's own check) |
 
 ### Status requirement
 
@@ -319,18 +319,18 @@ All error messages use plain language and surface through the focused error flas
 Blog logic lives in one lib file. It consumes `ContentEntry` as-is and does not motivate any change
 to `ContentEntry` / `toContentEntry`. Exports:
 
-| Export                                                                 | Purpose                                                                                                                                                                                                                |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type BlogPost`                                                        | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }`                                                                                                                  |
-| `normalizeBlogEntry(entry)`                                            | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
-| `compareBlogPosts(a, b)`                                               | The single ordering implementation (date DESC, slug DESC, undated-last)                                                                                                                                                |
-| `getPublishedPosts()`                                                  | `db.content.getCollection('blog')` → normalize → sort (public index)                                                                                                                                                   |
-| `getPublishedPost(slug)`                                               | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL)                                                                                                                                                        |
-| `getManagedBlogPosts()`                                                | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached                                                                                                                                         |
-| `resolveLegacyBlogRedirect(slug)`                                      | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target)                                                                            |
-| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate                                                                                                                                                                                        |
-| `renderPostBody(markdown)`                                             | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization))                                                                                                                                   |
-| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)`                 | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell)                                                                                                                                                   |
+| Export | Purpose |
+|---|---|
+| `type BlogPost` | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }` |
+| `normalizeBlogEntry(entry)` | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
+| `compareBlogPosts(a, b)` | The single ordering implementation (date DESC, slug DESC, undated-last) |
+| `getPublishedPosts()` | `db.content.getCollection('blog')` → normalize → sort (public index) |
+| `getPublishedPost(slug)` | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL) |
+| `getManagedBlogPosts()` | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached |
+| `resolveLegacyBlogRedirect(slug)` | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target) |
+| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate |
+| `renderPostBody(markdown)` | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization)) |
+| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)` | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell) |
 
 ## Rendering & Sanitization
 
@@ -357,44 +357,18 @@ blog code (plus the admin preview call site).
 
 ```typescript
 DOMPurify.sanitize(html, {
-  ALLOWED_TAGS: [
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "p",
-    "a",
-    "ul",
-    "ol",
-    "li",
-    "strong",
-    "em",
-    "b",
-    "i",
-    "blockquote",
-    "code",
-    "pre",
-    "img",
-    "hr",
-    "br",
-    "table",
-    "thead",
-    "tbody",
-    "tr",
-    "th",
-    "td",
-    "del",
-  ],
-  ALLOWED_ATTR: ["href", "src", "alt", "title"], // NO 'id' — heading anchors are cut, so author
-  // ids must never reach the public page; DOMPurify
-  // strips every author-supplied id (no DOM-clobbering
-  // surface; resolved by removal)
-  ALLOW_DATA_ATTR: false, // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
-  ALLOW_ARIA_ATTR: false, // an authored <p data-admin-alert> survives "strict" sanitization and
-  // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
-  // screen-reader users
-  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i,
+  ALLOWED_TAGS: ['h2','h3','h4','h5','h6','p','a','ul','ol','li','strong','em','b','i',
+                 'blockquote','code','pre','img','hr','br',
+                 'table','thead','tbody','tr','th','td','del'],
+  ALLOWED_ATTR: ['href','src','alt','title'],   // NO 'id' — heading anchors are cut, so author
+                                                // ids must never reach the public page; DOMPurify
+                                                // strips every author-supplied id (no DOM-clobbering
+                                                // surface; resolved by removal)
+  ALLOW_DATA_ATTR: false,   // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
+  ALLOW_ARIA_ATTR: false,   // an authored <p data-admin-alert> survives "strict" sanitization and
+                            // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
+                            // screen-reader users
+  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i
   // HTTPS-only for body links/images (unifies the body trust boundary with the featured-image
   // policy); NO '#'/fragment alternative (heading anchors cut, so fragment links have no targets);
   // blocks javascript:, data:, vbscript:, protocol-relative, AND the backslash form '/\evil.com'
@@ -404,16 +378,16 @@ DOMPurify.sanitize(html, {
 
 ### URI policy
 
-| Form                                             | Behavior                                                                              |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| `http:` body links/images                        | **Blocked** (HTTPS-only)                                                              |
-| `https:`, `mailto:`, `tel:`                      | Allowed                                                                               |
-| Site-relative `/page`                            | Allowed                                                                               |
-| `www.`-leading                                   | Normalized to `https://` (walkTokens)                                                 |
-| Fragment-only `#section`                         | **Stripped** (no in-post id targets exist)                                            |
-| Non-slash relative `images/x.png`, `../page`     | **Blocked**                                                                           |
-| Backslash-leading `/\evil.com`                   | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
-| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked**                                                                           |
+| Form | Behavior |
+|---|---|
+| `http:` body links/images | **Blocked** (HTTPS-only) |
+| `https:`, `mailto:`, `tel:` | Allowed |
+| Site-relative `/page` | Allowed |
+| `www.`-leading | Normalized to `https://` (walkTokens) |
+| Fragment-only `#section` | **Stripped** (no in-post id targets exist) |
+| Non-slash relative `images/x.png`, `../page` | **Blocked** |
+| Backslash-leading `/\evil.com` | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
+| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked** |
 
 The featured-image URL is validated by the same backslash-aware scheme on the write path
 (`validateBlogData`) and re-checked on the read path (`normalizeBlogEntry`); the slug charset is
@@ -472,13 +446,13 @@ The post page passes `title={post.seoTitle || post.title}` and
 `description={post.seoDescription || post.excerpt}` (using `||`, not `??`). `Layout.astro` accepts
 optional props `ogImage`, `ogImageAlt`, `ogType` (default `'website'`), and `publishedTime`:
 
-| Tag                                    | Source                                                                                       |
-| -------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `og:image` and `twitter:image`         | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL)          |
+| Tag | Source |
+|---|---|
+| `og:image` and `twitter:image` | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL) |
 | `og:image:alt` and `twitter:image:alt` | `ogImageAlt` (post `imageAlt`) — Twitter/X does not read `og:image:alt`, so both are emitted |
-| `og:type`                              | `'article'` for posts                                                                        |
-| `article:published_time`               | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set                                |
-| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed)                               |
+| `og:type` | `'article'` for posts |
+| `article:published_time` | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set |
+| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed) |
 
 `/blog` is added to `SEO_MANAGED_PAGES` (owner-tunable index meta via `/admin/seo`); individual posts
 are not added. Indexability is asserted, not assumed — `meta[name=robots]` must be `index, follow`
@@ -547,21 +521,21 @@ redirect entries.
 Each item below is intentionally **out of V1**. The generic content pipeline already does ~90% of the
 work; every deferred item would add files, migrations, or UI that the maintainability gate penalizes.
 
-| Deferred                                                                                | Rationale                                                                                                                                                                   |
-| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Categories / tags UI                                                                    | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them                                                                                 |
-| RSS                                                                                     | No `@astrojs/rss` dependency; a new surface for zero current demand                                                                                                         |
-| Pagination                                                                              | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise                                                                                  |
-| Scheduled publishing                                                                    | Draft → manual publish covers the owner workflow                                                                                                                            |
-| Related posts, search, comments, newsletter integration                                 | Each is a feature in itself                                                                                                                                                 |
-| In-post heading anchors / table of contents / "back to top" fragment links              | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
-| Rich-text / WYSIWYG editor                                                              | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle                                |
-| Client-side autosave / restore                                                          | Prevention (client validation) replaces recovery; the residual loss risk is recorded below                                                                                  |
-| Body-image-alt client scanner                                                           | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish                                           |
-| Featured-image thumbnail preview in the editor                                          | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate                     |
-| `BlogPosting` JSON-LD structured data                                                   | Per-post meta + OG/Twitter tags cover V1; a V2 candidate                                                                                                                    |
-| Meta-description length capping / bespoke index meta                                    | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo`                                                                                |
-| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo)                                                                                                                     |
+| Deferred | Rationale |
+|---|---|
+| Categories / tags UI | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them |
+| RSS | No `@astrojs/rss` dependency; a new surface for zero current demand |
+| Pagination | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise |
+| Scheduled publishing | Draft → manual publish covers the owner workflow |
+| Related posts, search, comments, newsletter integration | Each is a feature in itself |
+| In-post heading anchors / table of contents / "back to top" fragment links | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
+| Rich-text / WYSIWYG editor | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle |
+| Client-side autosave / restore | Prevention (client validation) replaces recovery; the residual loss risk is recorded below |
+| Body-image-alt client scanner | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish |
+| Featured-image thumbnail preview in the editor | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate |
+| `BlogPosting` JSON-LD structured data | Per-post meta + OG/Twitter tags cover V1; a V2 candidate |
+| Meta-description length capping / bespoke index meta | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo` |
+| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo) |
 
 ## Accepted Residual Risks
 

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -35,23 +35,23 @@ allowlist but is unused; all blog rows use `type = 'blog'`.
 
 ### Row shape for a blog post
 
-| Column / JSONB key | Value |
-|---|---|
-| `type` | `'blog'` |
-| `slug` | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI |
-| `title` (column) | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`) |
-| `status` | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish |
-| `data.date` | `'YYYY-MM-DD'` string — display and sort date |
-| `data.author` | string, default `'Spicebush Team'` |
-| `data.excerpt` | string, ≤ 1,000 chars, trimmed |
-| `data.body` | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML |
-| `data.image` | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)` |
-| `data.imageAlt` | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word |
-| `data.seoTitle` | optional per-post `<title>` / OG override |
-| `data.seoDescription` | optional per-post meta-description / OG override |
-| `data.categories`, `data.tags` | legacy import keys, carried **opaquely** by the generic `baseDataJson` edit passthrough; no blog code reads, validates, or reshapes them |
-| `author_email` | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator) |
-| `created_at` / `updated_at` | imported rows use `{date}T12:00:00Z`; auto-managed otherwise |
+| Column / JSONB key             | Value                                                                                                                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                         | `'blog'`                                                                                                                                                                                  |
+| `slug`                         | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI |
+| `title` (column)               | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`)                                                                                                            |
+| `status`                       | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish              |
+| `data.date`                    | `'YYYY-MM-DD'` string — display and sort date                                                                                                                                             |
+| `data.author`                  | string, default `'Spicebush Team'`                                                                                                                                                        |
+| `data.excerpt`                 | string, ≤ 1,000 chars, trimmed                                                                                                                                                            |
+| `data.body`                    | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML                                                                                    |
+| `data.image`                   | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)`                                                                               |
+| `data.imageAlt`                | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word                                                                |
+| `data.seoTitle`                | optional per-post `<title>` / OG override                                                                                                                                                 |
+| `data.seoDescription`          | optional per-post meta-description / OG override                                                                                                                                          |
+| `data.categories`, `data.tags` | legacy import keys, carried **opaquely** by the generic `baseDataJson` edit passthrough; no blog code reads, validates, or reshapes them                                                  |
+| `author_email`                 | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator)                                                                       |
+| `created_at` / `updated_at`    | imported rows use `{date}T12:00:00Z`; auto-managed otherwise                                                                                                                              |
 
 ### Empty-string semantics
 
@@ -99,7 +99,7 @@ seed-created blog rows.
 Migration 015 **reconciles then imports**, all in one transaction:
 
 1. **Reconcile** — `DELETE` the seed-pipeline rows (targets only `author_email =
-   'seed@spicebushmontessori.org'` AND date-prefixed slugs).
+'seed@spicebushmontessori.org'` AND date-prefixed slugs).
 2. **Import** — six `INSERT … ON CONFLICT (type, slug) DO NOTHING`, using the **clean** slugs (file
    name with the date prefix stripped, or the explicit frontmatter `slug`), `author_email = NULL`,
    and `created_at`/`updated_at` of `{date}T12:00:00Z`.
@@ -114,12 +114,12 @@ content remains recoverable via git history.
 
 ## Public Routes
 
-| Route | Description |
-|-------|-------------|
-| `/blog` | Blog index — vertical list of published posts (featured image, title link, date, author, excerpt). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
-| `/blog/[slug]` | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro` |
-| `/resources/blog` | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro` |
-| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro` |
+| Route                    | Description                                                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/blog`                  | Blog index — vertical list of published posts (featured image, title link, date, author, excerpt). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
+| `/blog/[slug]`           | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro`                                                                                                         |
+| `/resources/blog`        | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro`                                                                                                                         |
+| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro`                                                                                                   |
 
 ### Post page behavior
 
@@ -139,10 +139,10 @@ real fixes the previously-broken link that 301'd to `/contact`.
 
 ## Admin Routes
 
-| Route | Description |
-|-------|-------------|
-| `/admin/blog` | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
-| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts` |
+| Route                     | Description                                                                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/admin/blog`             | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
+| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts`                       |
 
 The admin page is a structural clone of `app/src/pages/admin/faq.astro` (AdminLayout wrapper,
 `?saved=` / `?error=` flash params, `<details>` add-form + collapsible per-item edit forms). A link
@@ -270,25 +270,25 @@ The blog uses the existing generic content endpoint `POST /api/admin/content` (w
 enter the request path of all existing admin collections — a regression test confirms an existing
 collection still saves and deletes (including the header-absent fail-open case).
 
-| Change | Behavior |
-|---|---|
-| Allowlist | `'blog'` added to `ALLOWED_COLLECTIONS` |
-| Origin check | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense |
-| `_raw` field suffix | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
-| Blog normalize/validate hook | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status |
-| `createOnly` guard | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form) |
-| Form-based delete | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat` |
-| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])` |
+| Change                        | Behavior                                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Allowlist                     | `'blog'` added to `ALLOWED_COLLECTIONS`                                                                                                                                                         |
+| Origin check                  | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense                |
+| `_raw` field suffix           | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
+| Blog normalize/validate hook  | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status                             |
+| `createOnly` guard            | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form)                         |
+| Form-based delete             | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat`                                                                    |
+| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])`                                                                                                   |
 
 ### Auth
 
 The middleware protects `/admin` and `/api/admin` prefixes:
 
-| Request | Result |
-|---|---|
-| Unauthenticated JSON request | `401` |
-| Unauthenticated `Accept: text/html` | `303` to `/auth/sign-in` |
-| Authenticated, non-admin session | `403` (the endpoint's own check) |
+| Request                             | Result                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| Unauthenticated JSON request        | `401`                                                                                  |
+| Unauthenticated `Accept: text/html` | `302` to `/auth/sign-in` (middleware `context.redirect` default — verified; not `303`) |
+| Authenticated, non-admin session    | `403` (the endpoint's own check)                                                       |
 
 ### Status requirement
 
@@ -319,18 +319,18 @@ All error messages use plain language and surface through the focused error flas
 Blog logic lives in one lib file. It consumes `ContentEntry` as-is and does not motivate any change
 to `ContentEntry` / `toContentEntry`. Exports:
 
-| Export | Purpose |
-|---|---|
-| `type BlogPost` | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }` |
-| `normalizeBlogEntry(entry)` | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
-| `compareBlogPosts(a, b)` | The single ordering implementation (date DESC, slug DESC, undated-last) |
-| `getPublishedPosts()` | `db.content.getCollection('blog')` → normalize → sort (public index) |
-| `getPublishedPost(slug)` | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL) |
-| `getManagedBlogPosts()` | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached |
-| `resolveLegacyBlogRedirect(slug)` | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target) |
-| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate |
-| `renderPostBody(markdown)` | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization)) |
-| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)` | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell) |
+| Export                                                                 | Purpose                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type BlogPost`                                                        | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }`                                                                                                                  |
+| `normalizeBlogEntry(entry)`                                            | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
+| `compareBlogPosts(a, b)`                                               | The single ordering implementation (date DESC, slug DESC, undated-last)                                                                                                                                                |
+| `getPublishedPosts()`                                                  | `db.content.getCollection('blog')` → normalize → sort (public index)                                                                                                                                                   |
+| `getPublishedPost(slug)`                                               | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL)                                                                                                                                                        |
+| `getManagedBlogPosts()`                                                | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached                                                                                                                                         |
+| `resolveLegacyBlogRedirect(slug)`                                      | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target)                                                                            |
+| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate                                                                                                                                                                                        |
+| `renderPostBody(markdown)`                                             | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization))                                                                                                                                   |
+| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)`                 | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell)                                                                                                                                                   |
 
 ## Rendering & Sanitization
 
@@ -357,18 +357,44 @@ blog code (plus the admin preview call site).
 
 ```typescript
 DOMPurify.sanitize(html, {
-  ALLOWED_TAGS: ['h2','h3','h4','h5','h6','p','a','ul','ol','li','strong','em','b','i',
-                 'blockquote','code','pre','img','hr','br',
-                 'table','thead','tbody','tr','th','td','del'],
-  ALLOWED_ATTR: ['href','src','alt','title'],   // NO 'id' — heading anchors are cut, so author
-                                                // ids must never reach the public page; DOMPurify
-                                                // strips every author-supplied id (no DOM-clobbering
-                                                // surface; resolved by removal)
-  ALLOW_DATA_ATTR: false,   // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
-  ALLOW_ARIA_ATTR: false,   // an authored <p data-admin-alert> survives "strict" sanitization and
-                            // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
-                            // screen-reader users
-  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i
+  ALLOWED_TAGS: [
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "blockquote",
+    "code",
+    "pre",
+    "img",
+    "hr",
+    "br",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "del",
+  ],
+  ALLOWED_ATTR: ["href", "src", "alt", "title"], // NO 'id' — heading anchors are cut, so author
+  // ids must never reach the public page; DOMPurify
+  // strips every author-supplied id (no DOM-clobbering
+  // surface; resolved by removal)
+  ALLOW_DATA_ATTR: false, // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
+  ALLOW_ARIA_ATTR: false, // an authored <p data-admin-alert> survives "strict" sanitization and
+  // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
+  // screen-reader users
+  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i,
   // HTTPS-only for body links/images (unifies the body trust boundary with the featured-image
   // policy); NO '#'/fragment alternative (heading anchors cut, so fragment links have no targets);
   // blocks javascript:, data:, vbscript:, protocol-relative, AND the backslash form '/\evil.com'
@@ -378,16 +404,16 @@ DOMPurify.sanitize(html, {
 
 ### URI policy
 
-| Form | Behavior |
-|---|---|
-| `http:` body links/images | **Blocked** (HTTPS-only) |
-| `https:`, `mailto:`, `tel:` | Allowed |
-| Site-relative `/page` | Allowed |
-| `www.`-leading | Normalized to `https://` (walkTokens) |
-| Fragment-only `#section` | **Stripped** (no in-post id targets exist) |
-| Non-slash relative `images/x.png`, `../page` | **Blocked** |
-| Backslash-leading `/\evil.com` | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
-| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked** |
+| Form                                             | Behavior                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `http:` body links/images                        | **Blocked** (HTTPS-only)                                                              |
+| `https:`, `mailto:`, `tel:`                      | Allowed                                                                               |
+| Site-relative `/page`                            | Allowed                                                                               |
+| `www.`-leading                                   | Normalized to `https://` (walkTokens)                                                 |
+| Fragment-only `#section`                         | **Stripped** (no in-post id targets exist)                                            |
+| Non-slash relative `images/x.png`, `../page`     | **Blocked**                                                                           |
+| Backslash-leading `/\evil.com`                   | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
+| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked**                                                                           |
 
 The featured-image URL is validated by the same backslash-aware scheme on the write path
 (`validateBlogData`) and re-checked on the read path (`normalizeBlogEntry`); the slug charset is
@@ -446,13 +472,13 @@ The post page passes `title={post.seoTitle || post.title}` and
 `description={post.seoDescription || post.excerpt}` (using `||`, not `??`). `Layout.astro` accepts
 optional props `ogImage`, `ogImageAlt`, `ogType` (default `'website'`), and `publishedTime`:
 
-| Tag | Source |
-|---|---|
-| `og:image` and `twitter:image` | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL) |
+| Tag                                    | Source                                                                                       |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `og:image` and `twitter:image`         | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL)          |
 | `og:image:alt` and `twitter:image:alt` | `ogImageAlt` (post `imageAlt`) — Twitter/X does not read `og:image:alt`, so both are emitted |
-| `og:type` | `'article'` for posts |
-| `article:published_time` | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set |
-| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed) |
+| `og:type`                              | `'article'` for posts                                                                        |
+| `article:published_time`               | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set                                |
+| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed)                               |
 
 `/blog` is added to `SEO_MANAGED_PAGES` (owner-tunable index meta via `/admin/seo`); individual posts
 are not added. Indexability is asserted, not assumed — `meta[name=robots]` must be `index, follow`
@@ -521,21 +547,21 @@ redirect entries.
 Each item below is intentionally **out of V1**. The generic content pipeline already does ~90% of the
 work; every deferred item would add files, migrations, or UI that the maintainability gate penalizes.
 
-| Deferred | Rationale |
-|---|---|
-| Categories / tags UI | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them |
-| RSS | No `@astrojs/rss` dependency; a new surface for zero current demand |
-| Pagination | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise |
-| Scheduled publishing | Draft → manual publish covers the owner workflow |
-| Related posts, search, comments, newsletter integration | Each is a feature in itself |
-| In-post heading anchors / table of contents / "back to top" fragment links | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
-| Rich-text / WYSIWYG editor | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle |
-| Client-side autosave / restore | Prevention (client validation) replaces recovery; the residual loss risk is recorded below |
-| Body-image-alt client scanner | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish |
-| Featured-image thumbnail preview in the editor | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate |
-| `BlogPosting` JSON-LD structured data | Per-post meta + OG/Twitter tags cover V1; a V2 candidate |
-| Meta-description length capping / bespoke index meta | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo` |
-| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo) |
+| Deferred                                                                                | Rationale                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Categories / tags UI                                                                    | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them                                                                                 |
+| RSS                                                                                     | No `@astrojs/rss` dependency; a new surface for zero current demand                                                                                                         |
+| Pagination                                                                              | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise                                                                                  |
+| Scheduled publishing                                                                    | Draft → manual publish covers the owner workflow                                                                                                                            |
+| Related posts, search, comments, newsletter integration                                 | Each is a feature in itself                                                                                                                                                 |
+| In-post heading anchors / table of contents / "back to top" fragment links              | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
+| Rich-text / WYSIWYG editor                                                              | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle                                |
+| Client-side autosave / restore                                                          | Prevention (client validation) replaces recovery; the residual loss risk is recorded below                                                                                  |
+| Body-image-alt client scanner                                                           | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish                                           |
+| Featured-image thumbnail preview in the editor                                          | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate                     |
+| `BlogPosting` JSON-LD structured data                                                   | Per-post meta + OG/Twitter tags cover V1; a V2 candidate                                                                                                                    |
+| Meta-description length capping / bespoke index meta                                    | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo`                                                                                |
+| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo)                                                                                                                     |
 
 ## Accepted Residual Risks
 


### PR DESCRIPTION
Closes #71. Closes #64 (footer dead link). Closes #74 (static-sitemap admin/auth disclosure — via the new sitemap filter). Stacked on PR-3 (#70). Parent #66.

**The public flip.** Rewrites `/blog` (SSR index, AA-token metadata, friendly empty state) and `/blog/[slug]` (sanitized `renderPostBody`, legacy date-prefixed-slug 301 fallback, branded 404 via `new Response(null,{status:404})`); retargets `/resources/blog` + adds `/resources/blog/[slug]` 301s; `sitemap-blog.xml` thin shell + robots line; `@astrojs/sitemap` filter excluding blog/admin/auth from the static sitemap; Layout gains `ogImage/ogImageAlt/ogType/publishedTime` (byte-stable for non-blog callers — verified); `/blog` joins SEO_MANAGED_PAGES; E2E suite `e2e/blog.spec.ts` (tests 18–27, chromium-pinned, draft-only pre-merge / publish-transition post-deploy, admin session cookie never recorded); a11y E2E lists updated (post route in alt-text + heading-hierarchy; `/blog` index kept out of hierarchy per R4-F20); doc updates incl. the **CLAUDE.md deploy-gotcha rationale correction** (netlify.toml has no `base` key; the documented command works — see #65).

**Gates:** lint 0 warnings · typecheck 0 errors · vitest green · format:check clean. **Review-fleet catch fixed in `9cfce33`:** flow-test form-field names were wrong — the no-op round-trip + publish→200 assertions could never pass (high), +2.

**🛑 HARD ROLLOUT DEPS — do not merge until ALL are done and verified:**
1. Migration 015 applied to prod + import verified in `/admin/blog` (runbook §2d; includes unapplied-014 review)
2. `PUBLIC_SITE_URL` env fix live (#73) — canonical verified via curl
3. Netlify git-CI stopped (`stop_builds=true` — competing deploy path on branch `testing`)
4. Owner has reviewed the 6 imported posts + authoring flow in `/admin/blog`
5. E2E gate run recorded (fresh `E2E_ADMIN_SESSION`, revoked after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)