### PR TITLE
fix(blog): E2E auth test sends Origin; CLAUDE.md doc-index corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ Canonical docs live in `docs/`:
 
 - **PRD**: `docs/PRD.md`
 - **Roadmap**: `docs/ROADMAP.md`
-- **Specs**: `docs/specs/` (architecture, data-model, auth, camp-system, email, api)
-- **ADRs**: `docs/adr/` (7 architecture decision records)
+- **Specs**: `docs/specs/` (architecture, data-model, auth, camp-system, email, api, blog)
+- **ADRs**: `docs/adr/` (8 architecture decision records)
 - **Runbooks**: `docs/runbooks/` (deploy, rollback)
 
 ## Agents

--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -308,7 +308,11 @@ test.describe('Blog V1 — public routes + SEO', () => {
   });
 
   // Test 26 — auth gates
-  test('26: admin/blog + content endpoint auth gates (real middleware)', async ({ request }) => {
+  test('26: admin/blog + content endpoint auth gates (real middleware)', async ({
+    request,
+    baseURL
+  }) => {
+    const siteOrigin = new URL(baseURL ?? 'http://localhost:4321').origin;
     // Unauthenticated GET /admin/blog → redirect to sign-in.
     const adminGet = await request.get('/admin/blog', {
       maxRedirects: 0,
@@ -325,16 +329,30 @@ test.describe('Blog V1 — public routes + SEO', () => {
     });
     expect(jsonPost.status()).toBe(401);
 
-    // Same POST with Accept: text/html → 302 to /auth/sign-in.
+    // Same POST with Accept: text/html and a same-site Origin → 302 to /auth/sign-in.
+    // The Origin header is REQUIRED here: browsers always send it on form POSTs, but
+    // Playwright's APIRequestContext does not — and without it Astro's built-in CSRF
+    // protection (security.checkOrigin) rejects form-content-type POSTs with a 403
+    // ("Cross-site POST form submissions are forbidden") before the middleware ever runs.
+    // Verified against prod 2026-06-06.
     // NOTE: middleware's toSignInRedirect uses context.redirect() with no status → Astro
     // default 302 (verified), NOT 303 as the work-order prose states.
     const htmlPost = await request.post('/api/admin/content', {
       maxRedirects: 0,
-      headers: { Accept: 'text/html' },
+      headers: { Accept: 'text/html', Origin: siteOrigin },
       form: { collection: 'blog', slug: 'unauthed' }
     });
     expect(htmlPost.status()).toBe(302);
     expect(htmlPost.headers()['location']).toContain('/auth/sign-in');
+
+    // Defense-in-depth pin: the same form POST with NO Origin header is rejected by Astro's
+    // built-in CSRF layer (403) before any application code runs.
+    const originlessPost = await request.post('/api/admin/content', {
+      maxRedirects: 0,
+      headers: { Accept: 'text/html' },
+      form: { collection: 'blog', slug: 'unauthed' }
+    });
+    expect(originlessPost.status()).toBe(403);
   });
 
   // Test 27 — .blog-body a deterministic pin


### PR DESCRIPTION
Follow-up from the #80 launch verification. Test 26's form POST omitted the `Origin` header browsers always send, so Astro's built-in CSRF protection 403'd it before the middleware ran (the test expected the middleware's 302). Fix sends a same-site `Origin` and adds a defense-in-depth pin asserting the 403 for Origin-less form POSTs.

**Verified against prod:** `e2e/blog.spec.ts --project=chromium` → 8 passed, 1 skipped (session-gated flow test), 0 failed.
**Also:** CLAUDE.md docs index — ADR count 7→8, specs list gains `blog`.
**Gates:** lint 0 warnings · typecheck clean · format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)