### PR TITLE
fix(blog): preserve categories/tags on post edit — Phase-1 PR0 (#84)

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -21,6 +21,7 @@ vi.mock('@lib/db/client', () => ({
 
 import type { ContentEntry } from '@lib/db/types';
 import {
+  blogPostToEditData,
   compareBlogPosts,
   escapeXml,
   getManagedBlogPosts,
@@ -175,6 +176,75 @@ describe('normalizeBlogEntry', () => {
       makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', image: '/img/x.png' })
     );
     expect(relative?.image).toBe('/img/x.png');
+  });
+
+  // #84 / R1-F15: categories & tags must be surfaced so the edit form can carry them through.
+  it('surfaces data.categories / data.tags as string arrays', () => {
+    const post = normalizeBlogEntry(
+      makeEntry('p', {
+        title: 'T',
+        date: '2024-01-01',
+        excerpt: 'E',
+        categories: ['Montessori', 'Parenting'],
+        tags: ['toddlers', 'play']
+      })
+    );
+    expect(post?.categories).toEqual(['Montessori', 'Parenting']);
+    expect(post?.tags).toEqual(['toddlers', 'play']);
+  });
+
+  it('leaves categories / tags undefined when absent, empty, or non-array', () => {
+    const absent = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E' })
+    );
+    expect(absent?.categories).toBeUndefined();
+    expect(absent?.tags).toBeUndefined();
+
+    const empty = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', categories: [], tags: [] })
+    );
+    expect(empty?.categories).toBeUndefined();
+    expect(empty?.tags).toBeUndefined();
+
+    const garbage = normalizeBlogEntry(
+      makeEntry('p', {
+        title: 'T',
+        date: '2024-01-01',
+        excerpt: 'E',
+        categories: 'not-an-array',
+        tags: [123, null]
+      } as unknown as Record<string, unknown>)
+    );
+    expect(garbage?.categories).toBeUndefined();
+    expect(garbage?.tags).toBeUndefined();
+  });
+});
+
+// #84 / R1-F15: the edit form's baseDataJson MUST carry categories/tags (no form input exists),
+// or the wholesale `data = EXCLUDED.data` upsert silently drops them on every edit.
+describe('blogPostToEditData', () => {
+  it('includes categories / tags when the post carries them', () => {
+    const data = blogPostToEditData(
+      makePost({ categories: ['Montessori', 'Parenting'], tags: ['toddlers'] })
+    );
+    expect(data.categories).toEqual(['Montessori', 'Parenting']);
+    expect(data.tags).toEqual(['toddlers']);
+  });
+
+  it('omits categories / tags (undefined → dropped by JSON.stringify) when absent', () => {
+    const data = blogPostToEditData(makePost());
+    expect(data.categories).toBeUndefined();
+    expect(data.tags).toBeUndefined();
+    const roundTripped = JSON.parse(JSON.stringify(data));
+    expect('categories' in roundTripped).toBe(false);
+    expect('tags' in roundTripped).toBe(false);
+  });
+
+  it('round-trips categories/tags through JSON without loss', () => {
+    const post = makePost({ categories: ['a', 'b', 'c'], tags: ['x'] });
+    const roundTripped = JSON.parse(JSON.stringify(blogPostToEditData(post)));
+    expect(roundTripped.categories).toEqual(['a', 'b', 'c']);
+    expect(roundTripped.tags).toEqual(['x']);
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -24,6 +24,8 @@ export type BlogPost = {
   seoTitle?: string;
   seoDescription?: string;
   status: string;
+  categories?: string[];
+  tags?: string[];
 };
 
 // Length caps — authoritative numbers per docs/specs/blog.md Data Model.
@@ -56,6 +58,15 @@ const asTrimmedString = (value: unknown): string => (typeof value === 'string' ?
 
 const emptyToUndefined = (value: string): string | undefined =>
   value.length > 0 ? value : undefined;
+
+// Faithfully surface a stored JSONB string array (categories/tags) WITHOUT mutation, so an
+// edit round-trips it unchanged (#84 / R1-F15). Non-arrays and empty arrays become `undefined`;
+// canonicalization of taxonomy values is deferred to Phase 3, not done here.
+const asStringArray = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.filter((item): item is string => typeof item === 'string');
+  return items.length > 0 ? items : undefined;
+};
 
 /**
  * Shared field mapper — builds a `BlogPost` from a stored `ContentEntry` WITHOUT the
@@ -102,7 +113,37 @@ function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
     imageAlt: emptyToUndefined(asTrimmedString(data.imageAlt)),
     seoTitle: emptyToUndefined(asTrimmedString(data.seoTitle)),
     seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
-    status: 'published'
+    status: 'published',
+    categories: asStringArray(data.categories),
+    tags: asStringArray(data.tags)
+  };
+}
+
+/**
+ * Reconstruct the `baseDataJson` payload for an edit form from a managed `BlogPost`.
+ *
+ * The admin upsert writes `data = EXCLUDED.data` wholesale (no JSONB merge), so any persisted
+ * `data.*` field the edit form does not resubmit is silently dropped on edit. `categories`/`tags`
+ * have no form input yet, so they MUST be carried here or editing any post wipes them (#84 /
+ * R1-F15). `undefined` values are omitted by `JSON.stringify`, matching the prior inline behavior.
+ *
+ * NOTE: any FUTURE persisted `data.*` key that the edit form does not surface as its own input
+ * must be added here too, or it will be lost on the next edit.
+ */
+export function blogPostToEditData(post: BlogPost): Record<string, unknown> {
+  return {
+    title: post.title,
+    date: post.date,
+    author: post.author,
+    excerpt: post.excerpt,
+    body: post.body,
+    image: post.image,
+    imageAlt: post.imageAlt,
+    seoTitle: post.seoTitle,
+    seoDescription: post.seoDescription,
+    status: post.status,
+    categories: post.categories,
+    tags: post.tags
   };
 }
 

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -1,6 +1,11 @@
 ---
 import AdminLayout from '@layouts/AdminLayout.astro';
-import { getManagedBlogPosts, renderPostBody, type BlogPost } from '@lib/blog-content';
+import {
+  getManagedBlogPosts,
+  renderPostBody,
+  blogPostToEditData,
+  type BlogPost
+} from '@lib/blog-content';
 import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
 
 const posts = await getManagedBlogPosts(); // uncached, no status filter, pre-sorted
@@ -46,20 +51,10 @@ const statusBadgeClass = (post: BlogPost): string =>
 const statusBadgeLabel = (post: BlogPost): string =>
   post.status === 'published' ? 'Published' : 'Draft';
 
-// `baseDataJson` for an edit form: carry the blog data.* fields reconstructable from `post`.
-const baseDataFor = (post: BlogPost): string =>
-  JSON.stringify({
-    title: post.title,
-    date: post.date,
-    author: post.author,
-    excerpt: post.excerpt,
-    body: post.body,
-    image: post.image,
-    imageAlt: post.imageAlt,
-    seoTitle: post.seoTitle,
-    seoDescription: post.seoDescription,
-    status: post.status
-  });
+// `baseDataJson` for an edit form: carry the blog data.* fields reconstructable from `post`,
+// including categories/tags (which have no form input) so the wholesale-replace upsert does not
+// drop them on edit (#84). The field list lives in `blogPostToEditData` so it is unit-tested.
+const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditData(post));
 ---
 
 <AdminLayout title="Manage Blog">

--- a/app/src/pages/api/admin/content.blog.test.ts
+++ b/app/src/pages/api/admin/content.blog.test.ts
@@ -137,6 +137,29 @@ describe('POST /api/admin/content — blog path (§12.16 + §12.18)', () => {
     expect(upsertParams()[PARAM_STATUS]).toBe('published');
   });
 
+  it('#84/R1-F15: preserves data.categories/data.tags carried in baseDataJson through the edit upsert', async () => {
+    // The edit form resubmits baseDataJson reconstructed by `blogPostToEditData`, which now carries
+    // categories/tags (no form input exists for them). The wholesale `data = EXCLUDED.data` upsert
+    // MUST keep them — before the fix the edit form dropped them and they were silently wiped.
+    const fields = validPublishedFields({
+      [F.baseDataJson]: JSON.stringify({
+        title: 'A Real Post',
+        date: '2026-06-01',
+        author: 'Spicebush Team',
+        excerpt: 'A short summary of the post.',
+        body: 'Hello world body content.',
+        status: 'published',
+        categories: ['Montessori', 'Parenting'],
+        tags: ['toddlers', 'play']
+      })
+    });
+    await POST(makeContext(fields));
+
+    const data = JSON.parse(upsertParams()[PARAM_DATA] as string) as Record<string, unknown>;
+    expect(data.categories).toEqual(['Montessori', 'Parenting']);
+    expect(data.tags).toEqual(['toddlers', 'play']);
+  });
+
   it('§12.18 control: a draft-defaulted add stores draft', async () => {
     const fields = validPublishedFields({
       [F.status]: 'draft',


### PR DESCRIPTION
## Phase-1 PR0 — categories/tags edit-preservation (Blog V2)

First, prerequisite PR of the Blog V2 build. Fixes the bug that blocks safe editing of the 6 live posts.

### Problem (#84)
The admin content upsert writes `data = EXCLUDED.data` **wholesale** (no JSONB merge). The blog edit form reconstructs `baseDataJson` from the `BlogPost` projection, which had no categories/tags fields and no form input for them — so **editing any post silently wiped its `data.categories`/`data.tags`** keys. The 6 imported legacy posts carry those keys.

### Fix
- Add `categories?: string[]` / `tags?: string[]` to `BlogPost`; surface them (faithfully, no mutation) in `mapEntryToBlogPost`.
- Extract a unit-tested `blogPostToEditData()` that the edit form's `baseDataFor` now uses, carrying categories/tags through `baseDataJson` → merge → upsert. (`normalizeBlogData`/`validateBlogData` already leave them untouched.)
- Taxonomy canonicalization stays deferred to Phase 3 — this PR only **preserves** existing values.

### Tests (regression gates)
- `blog-content.test.ts`: read-path surfaces categories/tags; `blogPostToEditData` includes/omits them correctly and round-trips through JSON.
- `content.blog.test.ts`: an edit whose `baseDataJson` carries categories/tags **preserves them through the endpoint upsert** (the plan's named gate, against `api/admin/content.ts` upsert).

### Gates
lint `--max-warnings=0` ✅ · typecheck ✅ · `format:check` ✅ · full vitest (317) ✅ · build ✅

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now support categories and tags metadata.
  * Admin editing interface properly preserves categories and tags when updating published posts.

* **Tests**
  * Added comprehensive test coverage for categories and tags handling in blog post editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->