### PR TITLE
feat(blog): reading time + remove dead cms_blog alias — Phase-1 PR1

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -23,6 +23,7 @@ import type { ContentEntry } from '@lib/db/types';
 import {
   blogPostToEditData,
   compareBlogPosts,
+  computeReadingTime,
   escapeXml,
   getManagedBlogPosts,
   getPublishedPosts,
@@ -89,7 +90,8 @@ describe('normalizeBlogEntry', () => {
       imageAlt: 'Children planting seedlings',
       seoTitle: 'Garden Day SEO',
       seoDescription: 'Garden Day description',
-      status: 'published'
+      status: 'published',
+      readingTime: 1
     });
   });
 
@@ -245,6 +247,52 @@ describe('blogPostToEditData', () => {
     const roundTripped = JSON.parse(JSON.stringify(blogPostToEditData(post)));
     expect(roundTripped.categories).toEqual(['a', 'b', 'c']);
     expect(roundTripped.tags).toEqual(['x']);
+  });
+});
+
+describe('computeReadingTime', () => {
+  it('returns 0 for an empty, whitespace-only, or non-string body', () => {
+    expect(computeReadingTime('')).toBe(0);
+    expect(computeReadingTime('   \n  ')).toBe(0);
+    expect(computeReadingTime(undefined)).toBe(0);
+    expect(computeReadingTime(123 as unknown as string)).toBe(0);
+  });
+
+  it('rounds up to whole minutes at 200 wpm with a floor of 1', () => {
+    expect(computeReadingTime('one two three')).toBe(1); // 3 words → 1 min
+    expect(computeReadingTime(Array.from({ length: 200 }, () => 'w').join(' '))).toBe(1); // exactly 200 → 1
+    expect(computeReadingTime(Array.from({ length: 201 }, () => 'w').join(' '))).toBe(2); // 201 → 2
+    expect(computeReadingTime(Array.from({ length: 1000 }, () => 'w').join(' '))).toBe(5); // 1000 → 5
+  });
+
+  it('strips HTML tags so markup is not counted as words', () => {
+    // 3 real words wrapped in tags → still 1 min, and the tags add no word count.
+    expect(computeReadingTime('<p><strong>hello</strong> there <em>world</em></p>')).toBe(1);
+  });
+});
+
+describe('reading time surfacing (R-readingTime)', () => {
+  it('prefers a stored data.readingTime over recomputation', () => {
+    const post = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', readingTime: 7 }, 'short body')
+    );
+    expect(post?.readingTime).toBe(7);
+  });
+
+  it('computes readingTime from the body when none is stored', () => {
+    const body = Array.from({ length: 400 }, () => 'word').join(' '); // 400 words → 2 min
+    const post = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E' }, body)
+    );
+    expect(post?.readingTime).toBe(2);
+  });
+
+  it('normalizeBlogData stores a recomputed readingTime on save', () => {
+    const out = normalizeBlogData({
+      body: Array.from({ length: 600 }, () => 'word').join(' '), // 600 words → 3 min
+      readingTime: 99 // stale incoming value is overwritten
+    });
+    expect(out.readingTime).toBe(3);
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -26,6 +26,7 @@ export type BlogPost = {
   status: string;
   categories?: string[];
   tags?: string[];
+  readingTime?: number;
 };
 
 // Length caps — authoritative numbers per docs/specs/blog.md Data Model.
@@ -115,7 +116,13 @@ function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
     seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
     status: 'published',
     categories: asStringArray(data.categories),
-    tags: asStringArray(data.tags)
+    tags: asStringArray(data.tags),
+    // Prefer the value stored on save; fall back to computing from the body so the 6 legacy posts
+    // (saved before reading time existed) still display it without a re-save.
+    readingTime:
+      typeof data.readingTime === 'number' && data.readingTime > 0
+        ? data.readingTime
+        : computeReadingTime(body)
   };
 }
 
@@ -247,6 +254,20 @@ export async function resolveLegacyBlogRedirect(slug: string): Promise<string | 
   return post ? stripped : null;
 }
 
+const WORDS_PER_MINUTE = 200;
+
+/**
+ * Estimate reading time in whole minutes. Strips HTML tags first — the body is markdown today and
+ * TipTap HTML after the Phase-1 conversion, so tag text must not be counted as words — then counts
+ * whitespace-delimited tokens at {@link WORDS_PER_MINUTE}. Returns 0 for an empty body, else ≥ 1.
+ */
+export function computeReadingTime(body: unknown): number {
+  if (typeof body !== 'string') return 0;
+  const text = body.replace(/<[^>]+>/g, ' ').trim();
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.split(/\s+/).length / WORDS_PER_MINUTE));
+}
+
 /**
  * Write-path normalizer (called by the endpoint BEFORE validation). Returns a new object.
  */
@@ -279,6 +300,10 @@ export function normalizeBlogData(data: Record<string, unknown>): Record<string,
   if (typeof normalized.author !== 'string' || normalized.author.trim().length === 0) {
     normalized.author = DEFAULT_AUTHOR;
   }
+
+  // Reading time is derived: recompute on every save from the trimmed body (markdown today,
+  // TipTap HTML after the Phase-1 conversion). 0 for an empty/missing body.
+  normalized.readingTime = computeReadingTime(normalized.body);
 
   // Leave categories / tags untouched (R1-F12).
   return normalized;

--- a/app/src/lib/db/content.ts
+++ b/app/src/lib/db/content.ts
@@ -16,7 +16,6 @@ const DATABASE_COLLECTIONS = new Set([
   'hours',
   'photos',
   'cms_hours',
-  'cms_blog',
   'cms_staff',
   'cms_announcements',
   'cms_events',

--- a/app/src/pages/blog/[slug].astro
+++ b/app/src/pages/blog/[slug].astro
@@ -60,6 +60,8 @@ const bodyHtml = renderPostBody(post.body);
         {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
         {formattedDate && <span class="mx-2">·</span>}
         <span>By {post.author}</span>
+        {post.readingTime ? <span class="mx-2">·</span> : null}
+        {post.readingTime ? <span>{post.readingTime} min read</span> : null}
       </p>
 
       {

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -30,8 +30,9 @@ intentionally out and why.
 ## Data Model
 
 The blog reuses the existing `content` table unchanged (see `docs/specs/data-model.md` →
-`content`). No DDL migration is required. The `'cms_blog'` collection alias remains in the DB read
-allowlist but is unused; all blog rows use `type = 'blog'`.
+`content`). No DDL migration is required. All blog rows use `type = 'blog'`; the unused
+`'cms_blog'` collection alias was removed from the DB read allowlist in the Blog V2 build (Phase-1
+PR1) — nothing ever read or wrote it.
 
 ### Row shape for a blog post
 


### PR DESCRIPTION
## Phase-1 PR1 — reading time + `cms_blog` cleanup (Blog V2)

### Reading time
- `computeReadingTime(body)`: strips HTML tags first (body is markdown today, TipTap HTML after the Phase-1 conversion) so markup isn't counted, then counts words at 200 wpm, `Math.ceil`, floor 1; returns 0 for an empty body.
- **Stored on save** in `normalizeBlogData` (the plan's `data.readingTime` field), and **surfaced on read** with a compute-from-body fallback so the 6 legacy posts display reading time immediately, without waiting for a re-save.
- Displayed on the public post page (`/blog/[slug]`) next to the byline (`· N min read`), hidden when 0.

### Dead-code cleanup
- Remove the unused `'cms_blog'` collection alias from `DATABASE_COLLECTIONS`. Confirmed repo-wide that nothing reads or writes it — ADR-008 and the V1 plan both explicitly call it unused; all blog rows use `type = 'blog'`.
- `docs/specs/blog.md` updated to reflect the removal.

### Tests
- `computeReadingTime`: empty/whitespace/non-string → 0; 200 wpm rounding with floor 1; HTML-tag stripping.
- Reading-time surfacing: stored value preferred; computed fallback; `normalizeBlogData` stores a recomputed value (overwriting any stale incoming one).

### Gates
lint `--max-warnings=0` ✅ · typecheck ✅ · `format:check` ✅ · full vitest (323) ✅ · build ✅

Refs #33. Part of the Blog V2 phased build (plan: `docs/plans/blog-v2-implementation-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)