### PR TITLE
feat(blog): markdown→HTML cutover — editor mount + conversion [HELD — owner approval]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npx netlify deploy --prod --dir=app/dist
 - We use Tailwind CSS 3, not CSS modules or styled-components
 - We use React islands selectively (TuitionCalculator), not as the primary renderer
 - Email providers: SendGrid + Unione (via REST). Resend/Postmark are Rollup externals but not active.
-- Blog: DB-backed via /admin/blog; posts are content rows with type='blog'
+- Blog: DB-backed via /admin/blog; posts are content rows with type='blog'. V2 authoring is a TipTap WYSIWYG editor storing sanitized HTML in data.body (ADR-009; `blog-html.ts` STRICT_CONFIG_V2 is the render-time trust boundary)
 - Out of scope: Stripe/payments, newsletter
 
 ## Path Aliases

--- a/app/scripts/convert-blog-to-html.mts
+++ b/app/scripts/convert-blog-to-html.mts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * Blog V2 cutover — one-time markdown→HTML body conversion (ADR-009 §5.4).
+ *
+ * For each `type='blog'` row whose body is still markdown:
+ *   1. compute the steady-state HTML via `convertMarkdownBodyToHtml` (V2 render of the V1 markdown
+ *      render) and verify rendered-output equivalence;
+ *   2. snapshot the original markdown into `data.bodyMarkdownBackup` (keyed by slug + updated_at);
+ *   3. overwrite `data.body` with the converted HTML.
+ * Any row that fails equivalence is SKIPPED (reported, not converted) — the gate never launders
+ * content loss. Idempotent: rows already converted (already HTML, or carrying a backup) are skipped.
+ *
+ * Usage:
+ *   --self-test     convert a fixture string and print the result (no DB); for CI/sanity
+ *   --dry-run       connect + report what WOULD change, write nothing
+ *   (default)       connect + convert + write
+ *
+ * Run against the target DB:  NETLIFY_DATABASE_URL=… npx tsx scripts/convert-blog-to-html.mts --dry-run
+ * Rollback:                   scripts/revert-blog-to-markdown.mts
+ * See docs/runbooks/blog-html-conversion.md.
+ */
+import { Client } from 'pg';
+import { convertMarkdownBodyToHtml } from '../src/lib/blog-conversion.ts';
+
+const SELF_TEST = process.argv.includes('--self-test');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const isAlreadyHtml = (body: string): boolean => /^\s*<[a-z]/i.test(body ?? '');
+
+async function selfTest(): Promise<void> {
+  const sample = '# Welcome\n\nA **warm** hello with a [link](mailto:hi@spicebush.org).';
+  const { html, equivalent } = convertMarkdownBodyToHtml(sample);
+  console.log('[self-test] equivalent:', equivalent);
+  console.log('[self-test] html:', html);
+  if (!equivalent) process.exit(1);
+}
+
+async function run(): Promise<void> {
+  const url = process.env.NETLIFY_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    console.error('Set NETLIFY_DATABASE_URL (or DATABASE_URL). Refusing to run without a target.');
+    process.exit(1);
+  }
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ id: string; slug: string; data: Record<string, unknown> }>(
+      "SELECT id, slug, data FROM content WHERE type = 'blog' ORDER BY slug"
+    );
+    let converted = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const row of rows) {
+      const data = row.data ?? {};
+      const body = typeof data.body === 'string' ? data.body : '';
+      if (!body) {
+        console.log(`  skip ${row.slug}: empty body`);
+        skipped++;
+        continue;
+      }
+      if (data.bodyMarkdownBackup || isAlreadyHtml(body)) {
+        console.log(`  skip ${row.slug}: already converted`);
+        skipped++;
+        continue;
+      }
+      const { html, equivalent, markdownRender } = convertMarkdownBodyToHtml(body);
+      if (!equivalent) {
+        console.error(`  FAIL ${row.slug}: not rendered-output-equivalent — NOT converted`);
+        console.error(`    V1: ${markdownRender.slice(0, 200)}`);
+        console.error(`    V2: ${html.slice(0, 200)}`);
+        failed++;
+        continue;
+      }
+      const nextData = {
+        ...data,
+        body: html,
+        bodyMarkdownBackup: { snapshot: body, slug: row.slug }
+      };
+      if (DRY_RUN) {
+        console.log(`  would convert ${row.slug} (${body.length}→${html.length} chars)`);
+      } else {
+        await client.query('UPDATE content SET data = $1 WHERE id = $2', [
+          JSON.stringify(nextData),
+          row.id
+        ]);
+        console.log(`  converted ${row.slug}`);
+      }
+      converted++;
+    }
+    console.log(
+      `\n${DRY_RUN ? '[dry-run] ' : ''}done: ${converted} converted, ${skipped} skipped, ${failed} failed`
+    );
+    if (failed > 0) process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+await (SELF_TEST ? selfTest() : run());
+process.exit(0);

--- a/app/scripts/revert-blog-to-markdown.mts
+++ b/app/scripts/revert-blog-to-markdown.mts
@@ -1,0 +1,60 @@
+#!/usr/bin/env tsx
+/**
+ * Blog V2 cutover ROLLBACK — restore each converted post's markdown from its `data.bodyMarkdownBackup`
+ * snapshot and remove the backup key (ADR-009 §5.4). Run TOGETHER with a code-revert of the cutover
+ * PR (the transitional `renderPostBody` already serves markdown, so order is forgiving, but the
+ * editor mount must be reverted to the textarea for authoring). Code-revert ALONE is NOT a rollback.
+ *
+ * Usage:
+ *   --dry-run    connect + report what WOULD be restored, write nothing
+ *   (default)    connect + restore + remove the backup key
+ *
+ *   NETLIFY_DATABASE_URL=… npx tsx scripts/revert-blog-to-markdown.mts --dry-run
+ * See docs/runbooks/blog-html-conversion.md.
+ */
+import { Client } from 'pg';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function run(): Promise<void> {
+  const url = process.env.NETLIFY_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    console.error('Set NETLIFY_DATABASE_URL (or DATABASE_URL). Refusing to run without a target.');
+    process.exit(1);
+  }
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ id: string; slug: string; data: Record<string, unknown> }>(
+      "SELECT id, slug, data FROM content WHERE type = 'blog' AND data ? 'bodyMarkdownBackup' ORDER BY slug"
+    );
+    let restored = 0;
+    for (const row of rows) {
+      const data = row.data ?? {};
+      const backup = data.bodyMarkdownBackup as { snapshot?: string } | undefined;
+      const snapshot = typeof backup?.snapshot === 'string' ? backup.snapshot : null;
+      if (!snapshot) {
+        console.error(`  skip ${row.slug}: backup present but snapshot missing/invalid`);
+        continue;
+      }
+      const nextData = { ...data, body: snapshot };
+      delete (nextData as Record<string, unknown>).bodyMarkdownBackup;
+      if (DRY_RUN) {
+        console.log(`  would restore ${row.slug} (→ ${snapshot.length} chars of markdown)`);
+      } else {
+        await client.query('UPDATE content SET data = $1 WHERE id = $2', [
+          JSON.stringify(nextData),
+          row.id
+        ]);
+        console.log(`  restored ${row.slug}`);
+      }
+      restored++;
+    }
+    console.log(`\n${DRY_RUN ? '[dry-run] ' : ''}done: ${restored} restored`);
+  } finally {
+    await client.end();
+  }
+}
+
+await run();
+process.exit(0);

--- a/app/src/lib/blog-admin-client.test.ts
+++ b/app/src/lib/blog-admin-client.test.ts
@@ -79,21 +79,19 @@ const field = (doc: Document, name: string): HTMLInputElement | HTMLTextAreaElem
   doc.querySelector(`[name="${name}"]`) as HTMLInputElement | HTMLTextAreaElement;
 
 describe('initBlogAdmin — conditional required', () => {
-  it('sets required on excerpt/body/date at init for a published edit-form, with NO events (R2-F9)', () => {
+  it('sets required on excerpt/date at init for a published edit-form, with NO events (R2-F9)', () => {
     const { doc } = buildDoc({ kind: 'edit', status: 'published' });
     initBlogAdmin(doc);
 
     expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(true);
-    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(true);
     expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(true);
   });
 
-  it('leaves excerpt/body/date optional at init for a draft form', () => {
+  it('leaves excerpt/date optional at init for a draft form', () => {
     const { doc } = buildDoc({ kind: 'add', status: 'draft' });
     initBlogAdmin(doc);
 
     expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(false);
-    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(false);
     expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(false);
   });
 
@@ -106,7 +104,6 @@ describe('initBlogAdmin — conditional required', () => {
     status.dispatchEvent(new Event('change'));
 
     expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(true);
-    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(true);
     expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(true);
   });
 
@@ -119,8 +116,26 @@ describe('initBlogAdmin — conditional required', () => {
     status.dispatchEvent(new Event('change'));
 
     expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(false);
-    expect(field(doc, BLOG_FORM_FIELDS.bodyRaw).required).toBe(false);
     expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(false);
+  });
+
+  it('blocks a publish submit with an empty editor body, allows a non-empty one (R3-F10 submit-time guard)', () => {
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const { doc } = buildDoc({ kind: 'edit', status: 'published' });
+    initBlogAdmin(doc);
+    const form = doc.querySelector('form[data-blog-form]') as HTMLFormElement;
+
+    // Empty editor (TipTap emits "<p></p>" for an empty doc) → submit is blocked.
+    field(doc, BLOG_FORM_FIELDS.bodyRaw).value = '<p></p>';
+    const blocked = new Event('submit', { cancelable: true });
+    form.dispatchEvent(blocked);
+    expect(blocked.defaultPrevented).toBe(true);
+
+    // Non-empty body → submit proceeds.
+    field(doc, BLOG_FORM_FIELDS.bodyRaw).value = '<p>Real content.</p>';
+    const allowed = new Event('submit', { cancelable: true });
+    form.dispatchEvent(allowed);
+    expect(allowed.defaultPrevented).toBe(false);
   });
 
   it('requires imageAlt when an image value is set, releases it when cleared', () => {

--- a/app/src/lib/blog-admin-client.ts
+++ b/app/src/lib/blog-admin-client.ts
@@ -27,7 +27,6 @@ const slugify = (value: string): string =>
 function initConditionalRequired(form: HTMLFormElement): void {
   const statusSelect = form.querySelector(`[name="${BLOG_FORM_FIELDS.status}"]`);
   const excerpt = form.querySelector(`[name="${BLOG_FORM_FIELDS.excerptRaw}"]`);
-  const body = form.querySelector(`[name="${BLOG_FORM_FIELDS.bodyRaw}"]`);
   const date = form.querySelector(`[name="${BLOG_FORM_FIELDS.date}"]`);
   const image = form.querySelector(`[name="${BLOG_FORM_FIELDS.image}"]`);
   const imageAlt = form.querySelector(`[name="${BLOG_FORM_FIELDS.imageAlt}"]`);
@@ -46,7 +45,6 @@ function initConditionalRequired(form: HTMLFormElement): void {
     const publishing =
       statusSelect instanceof HTMLSelectElement && statusSelect.value === 'published';
     setRequired(excerpt, publishing);
-    setRequired(body, publishing);
     setRequired(date, publishing);
   };
 
@@ -54,6 +52,31 @@ function initConditionalRequired(form: HTMLFormElement): void {
     const hasImage = image instanceof HTMLInputElement && image.value.trim().length > 0;
     setRequired(imageAlt, hasImage);
   };
+
+  // Body moved from a <textarea> to the TipTap island's hidden field, and `required` does NOT apply
+  // to a hidden input — so the publish-time "body required" guard moves to a SUBMIT-TIME check
+  // (R3-F10). The server (validateBlogData) stays the source of truth; this is immediate feedback.
+  // The field is queried at submit time because the island hydrates after init.
+  const isEditorEmpty = (html: string): boolean =>
+    html
+      .replace(/<p>\s*<\/p>/gi, '')
+      .replace(/<[^>]*>/g, '')
+      .trim().length === 0;
+
+  form.addEventListener('submit', event => {
+    const publishing =
+      statusSelect instanceof HTMLSelectElement && statusSelect.value === 'published';
+    if (!publishing) return;
+    const bodyField = form.querySelector(`[name="${BLOG_FORM_FIELDS.bodyRaw}"]`);
+    const value =
+      bodyField instanceof HTMLInputElement || bodyField instanceof HTMLTextAreaElement
+        ? bodyField.value
+        : '';
+    if (isEditorEmpty(value)) {
+      event.preventDefault();
+      window.alert('Body is required to publish.');
+    }
+  });
 
   if (statusSelect instanceof HTMLSelectElement) {
     statusSelect.addEventListener('change', syncPublishRequired);

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -450,6 +450,19 @@ describe('renderPostBody — URI / XSS matrix', () => {
   });
 });
 
+describe('renderPostBody — transitional HTML/markdown dispatch (Blog V2 cutover)', () => {
+  it('routes an HTML body through the V2 sanitizer (keeps <u>, which the V1 markdown path strips)', () => {
+    const out = renderPostBody('<p>before</p><p><u>underlined</u></p>');
+    expect(out).toContain('<u>underlined</u>');
+  });
+
+  it('routes a markdown body through the marked path (## → <h2>, **x** → <strong>)', () => {
+    const out = renderPostBody('## Heading\n\nSome **bold** text.');
+    expect(out).toContain('<h2>Heading</h2>');
+    expect(out).toContain('<strong>bold</strong>');
+  });
+});
+
 describe('normalizeBlogData', () => {
   it('coerces and trims short fields, defaults author', () => {
     const out = normalizeBlogData({

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -11,7 +11,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import { db } from '@lib/db';
 import { queryRows } from '@lib/db/client';
 import type { ContentEntry } from '@lib/db/types';
-import { collectHtmlImageAlts } from './blog-html';
+import { collectHtmlImageAlts, renderBodyHtml } from './blog-html';
 
 export type BlogPost = {
   slug: string;
@@ -430,15 +430,38 @@ export function validateBlogData(
 }
 
 /**
- * The ONLY place `set:html` content is produced. Pipeline: marked (walkTokens www-normalizer +
- * heading renderer override) → DOMPurify.sanitize(STRICT_CONFIG) → string.
+ * Detect a stored body that is already TipTap/sanitized HTML (vs legacy markdown): an HTML body
+ * begins with a known block tag, markdown begins with prose/markdown syntax. Used ONLY for the
+ * markdown→HTML transition so `renderPostBody` serves both representations safely; once all bodies
+ * are HTML (after the conversion is ratified) this branch and `marked` are removed from the render
+ * path — see docs/runbooks/blog-html-conversion.md.
+ */
+const isStoredHtml = (body: string): boolean =>
+  /^\s*<(?:h[2-6]|p|ul|ol|blockquote|pre|table|figure|div|img|hr|u|s|strong|em|b|i|a)\b/i.test(
+    body
+  );
+
+/**
+ * The ONLY place `set:html` content is produced. Transitional during the Blog V2 cutover: HTML
+ * bodies (TipTap / AI / converted) render through the V2 sanitizer (`renderBodyHtml`), while legacy
+ * markdown bodies keep the `marked` → `DOMPurify(STRICT_CONFIG)` pipeline (walkTokens www-normalizer
+ * + heading renderer override) until they are converted. `renderBodyHtml` is the steady-state path.
  *
  * `previousDepth` (and the `Marked` instance) are created FRESH per call (R4-F22) — module-scope
  * state would let the admin list's second post continue the first post's heading clamp.
  */
-export function renderPostBody(markdown: string): string {
-  if (typeof markdown !== 'string' || markdown.length === 0) return '';
+export function renderPostBody(body: string): string {
+  if (typeof body !== 'string' || body.length === 0) return '';
+  return isStoredHtml(body) ? renderBodyHtml(body) : renderMarkdownToHtml(body);
+}
 
+/**
+ * Render a legacy MARKDOWN body to sanitized HTML via the V1 pipeline (marked → `DOMPurify`
+ * STRICT_CONFIG). Exposed so the one-time conversion can FORCE the markdown path regardless of the
+ * body's leading character; removed from the steady-state render path once conversion is ratified.
+ */
+export function renderMarkdownToHtml(markdown: string): string {
+  if (typeof markdown !== 'string' || markdown.length === 0) return '';
   let previousDepth = 1; // the page <h1> precedes the body
   const renderer = new Marked({ gfm: true, async: false });
 

--- a/app/src/lib/blog-conversion.test.ts
+++ b/app/src/lib/blog-conversion.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+//
+// Node env (like the sanitizer matrix): renderBodyHtml runs in Netlify's node runtime in production,
+// where isomorphic-dompurify's bundled jsdom sanitizes faithfully; vitest's default jsdom differs.
+import { describe, it, expect } from 'vitest';
+import { convertMarkdownBodyToHtml, normalizeForEquivalence } from './blog-conversion';
+import { renderBodyHtml } from './blog-html';
+
+// Representative V1 markdown constructs. Each must convert with rendered-output equivalence (the V2
+// render of the converted HTML byte-equals the V1 markdown render after the §5.4 normalization).
+const FIXTURES: Record<string, string> = {
+  headings: '# Title\n\n## Section\n\nSome body text here.',
+  emphasis: 'Text with **bold**, *italic*, and `inline code`.',
+  lists: '- one\n- two\n- three\n\n1. first\n2. second',
+  links:
+    '[email](mailto:hi@spicebush.org), [call](tel:+15555551234), [about](/about), [ext](https://example.com)',
+  codeblock: '```\nconst x = 1;\n```',
+  blockquote: '> A short quote from a parent.',
+  table: '| Day | Hours |\n| --- | --- |\n| Mon | 9-3 |\n| Tue | 9-3 |',
+  hardbreak: 'line one  \nline two',
+  image: '![A child planting seedlings in the garden](/media/garden.png)'
+};
+
+describe('blog markdown→HTML conversion (rendered-output equivalence, ADR-009 §5.4)', () => {
+  for (const [name, markdown] of Object.entries(FIXTURES)) {
+    it(`converts "${name}" with rendered-output equivalence`, () => {
+      const { html, equivalent, markdownRender } = convertMarkdownBodyToHtml(markdown);
+      expect(equivalent, `inequivalent:\n V1: ${markdownRender}\n V2: ${html}`).toBe(true);
+      // The converted HTML is a FIXED POINT of the steady-state render path, so the public render is
+      // stable after the cutover.
+      expect(normalizeForEquivalence(renderBodyHtml(html))).toBe(normalizeForEquivalence(html));
+    });
+  }
+
+  it('preserves a hard break as <br> (D1-F5)', () => {
+    expect(convertMarkdownBodyToHtml('line one  \nline two').html).toMatch(/<br\s*\/?>/);
+  });
+
+  it('preserves mailto/tel/site-relative links through conversion (NOT https-only, R3-F1)', () => {
+    const { html } = convertMarkdownBodyToHtml('[m](mailto:a@b.com) [t](tel:+15555551234) [r](/x)');
+    expect(html).toContain('mailto:a@b.com');
+    expect(html).toContain('tel:+15555551234');
+    expect(html).toContain('href="/x"');
+  });
+
+  it('preserves a body image and its alt through conversion', () => {
+    const { html } = convertMarkdownBodyToHtml('![Children reading together](/media/read.png)');
+    expect(html).toContain('src="/media/read.png"');
+    expect(html).toContain('alt="Children reading together"');
+  });
+
+  it('normalizeForEquivalence never adds or drops an element', () => {
+    // Only whitespace/void-form changes; tag count is invariant.
+    const input = '<h2>A</h2>\n  <p>b</p>\n<hr/>\n';
+    const out = normalizeForEquivalence(input);
+    expect(out).toBe('<h2>A</h2><p>b</p><hr>');
+    expect((out.match(/</g) || []).length).toBe((input.match(/</g) || []).length);
+  });
+});

--- a/app/src/lib/blog-conversion.ts
+++ b/app/src/lib/blog-conversion.ts
@@ -1,0 +1,47 @@
+/**
+ * One-time markdown→HTML body conversion for the Blog V2 cutover (ADR-009 §5.4).
+ *
+ * Each legacy post's markdown body is rendered through the V1 pipeline and then sanitized by the V2
+ * sanitizer to produce the steady-state HTML form. The conversion is gated by **rendered-output
+ * equivalence**: the V2 render of the converted HTML must be byte-equal (after a bounded, enumerated
+ * normalization that may NEVER add or drop an element) to the V1 markdown render — so content is
+ * preserved, not silently altered. The conversion SCRIPT (scripts/convert-blog-to-html.mjs) snapshots
+ * each row's markdown into `data.bodyMarkdownBackup` BEFORE overwriting and aborts the row on any
+ * inequivalence; rollback re-writes the backup (scripts/revert-blog-to-markdown.mjs).
+ */
+import { renderMarkdownToHtml } from './blog-content';
+import { renderBodyHtml } from './blog-html';
+
+/**
+ * The rendered-output-equivalence normalization (ADR-009 §5.4). The ONLY transforms applied to BOTH
+ * sides before byte-comparison: (1) trim trailing newlines; (2) collapse insignificant inter-tag
+ * whitespace (`>   <` → `><`); (3) normalize void-element self-closing form (`<hr/>` → `<hr>`). It
+ * MUST NEVER add or drop an element, so it cannot launder content loss.
+ */
+export function normalizeForEquivalence(html: string): string {
+  return html
+    .replace(/\n+$/g, '')
+    .replace(/>[ \t\r\n]+</g, '><')
+    .replace(/\s*\/>/g, '>');
+}
+
+export type ConversionResult = {
+  /** The steady-state HTML to store in `data.body`. */
+  html: string;
+  /** True when the V2 render of `html` is rendered-output-equivalent to the V1 markdown render. */
+  equivalent: boolean;
+  /** The V1 markdown render, retained for diffing a failed gate. */
+  markdownRender: string;
+};
+
+/**
+ * Convert a legacy markdown body to its steady-state HTML form and check rendered-output equivalence.
+ * `html` is `renderBodyHtml(renderMarkdownToHtml(markdown))` — a fixed point of the steady-state
+ * render path (`renderBodyHtml(html) === html`), so the public render is stable after the cutover.
+ */
+export function convertMarkdownBodyToHtml(markdown: string): ConversionResult {
+  const markdownRender = renderMarkdownToHtml(markdown);
+  const html = renderBodyHtml(markdownRender);
+  const equivalent = normalizeForEquivalence(html) === normalizeForEquivalence(markdownRender);
+  return { html, equivalent, markdownRender };
+}

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -7,6 +7,7 @@ import {
   type BlogPost
 } from '@lib/blog-content';
 import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+import TipTapEditor from '@components/TipTapEditor';
 
 const posts = await getManagedBlogPosts(); // uncached, no status filter, pre-sorted
 const errorMessage = Astro.url.searchParams.get('error');
@@ -211,52 +212,24 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                   class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"></textarea>
               </label>
 
-              <label class="block text-sm font-medium md:col-span-2">
-                Body (required to publish)
-                {/* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore. */}
-                {/* prettier-ignore */}
-                <textarea
-                  name={BLOG_FORM_FIELDS.bodyRaw}
-                  rows="16"
-                  maxlength="200000"
-                  aria-describedby="add-body-help"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"></textarea>
-                <span id="add-body-help" class="mt-1 block text-xs text-earth-brown/70">
-                  Write in Markdown. See the formatting guide below.
-                </span>
-              </label>
+              <div class="block text-sm font-medium md:col-span-2">
+                <span class="mb-1 block">Body (required to publish)</span>
+                <TipTapEditor client:load fieldName={BLOG_FORM_FIELDS.bodyRaw} />
+              </div>
             </div>
 
-            {
-              /* PR-2 deviation 3 (R2-F11) + R1-F38/F19/F20 + R2-F11 + R4-F6: Markdown help, immediately after the body. */
-            }
+            {/* Editor tips — the WYSIWYG toolbar replaces the old Markdown guide. */}
             <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
               <summary class="cursor-pointer text-sm font-semibold text-earth-brown"
-                >Markdown formatting guide</summary
+                >Editor tips</summary
               >
               <div class="mt-3 space-y-2 text-xs text-earth-brown/80">
-                <ul class="list-disc space-y-1 pl-5">
-                  <li><strong>Headings:</strong> <code>## Heading</code></li>
-                  <li>
-                    <strong>Bold:</strong>
-                    <code>**bold**</code> · <em>Italic:</em>
-                    <code>*italic*</code>
-                  </li>
-                  <li><strong>Lists:</strong> <code>- item</code> or <code>1. item</code></li>
-                  <li><strong>Links:</strong> <code>[text](https://example.com)</code></li>
-                  <li><strong>Images:</strong> <code>![description](address)</code></li>
-                </ul>
                 <p>
-                  Link addresses must start with <code>https://</code> (or <code>/</code> for pages on
-                  this site). Addresses starting with <code>www.</code> are fixed automatically.
+                  Use the toolbar to format. Every image inside your post needs a description (alt
+                  text) — a post can't be published with an empty or one-word image description.
                 </p>
                 <p>
-                  Every image inside your post needs a description in the square brackets:
-                  <code>![description](address)</code> — a post can't be published with an empty or one-word
-                  image description.
-                </p>
-                <p>
-                  To add more images inside your post: upload them at
+                  Upload images at
                   <a
                     href="/admin/media"
                     target="_blank"
@@ -264,7 +237,7 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                     class="font-medium text-forest-canopy hover:underline"
                   >
                     Media (opens in a new tab)
-                  </a>, copy the image's address, and use <code>![description](address)</code>.
+                  </a>, then use the image button in the editor to insert by address.
                 </p>
               </div>
             </details>
@@ -529,12 +502,16 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                           <textarea name={BLOG_FORM_FIELDS.excerptRaw} rows="3" maxlength="1000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2">{post.excerpt}</textarea>
                         </label>
 
-                        <label class="block text-sm font-medium md:col-span-2">
-                          Body (required to publish)
-                          {/* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore — the _raw path skips trim, so a reflowed indented textarea would prepend "\n  " on every save. */}
-                          {/* prettier-ignore */}
-                          <textarea name={BLOG_FORM_FIELDS.bodyRaw} rows="16" maxlength="200000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2">{post.body}</textarea>
-                        </label>
+                        <div class="block text-sm font-medium md:col-span-2">
+                          <span class="mb-1 block">Body (required to publish)</span>
+                          {/* Per-post island hydrates when the accordion opens (client:visible). initialHtml is
+                              the server render of the stored body, so markdown or HTML both load as HTML. */}
+                          <TipTapEditor
+                            client:visible
+                            fieldName={BLOG_FORM_FIELDS.bodyRaw}
+                            initialHtml={renderPostBody(post.body)}
+                          />
+                        </div>
                       </div>
 
                       <div

--- a/app/src/pages/blog/[slug].astro
+++ b/app/src/pages/blog/[slug].astro
@@ -203,4 +203,18 @@ const bodyHtml = renderPostBody(post.body);
     border-top: 1px solid #d6cfc2;
     margin: 2rem 0;
   }
+
+  /* Class-based text alignment (Blog V2 — the editor emits these classes, never inline style). */
+  .blog-body .text-left {
+    text-align: left;
+  }
+  .blog-body .text-center {
+    text-align: center;
+  }
+  .blog-body .text-right {
+    text-align: right;
+  }
+  .blog-body .text-justify {
+    text-align: justify;
+  }
 </style>

--- a/docs/runbooks/blog-html-conversion.md
+++ b/docs/runbooks/blog-html-conversion.md
@@ -1,0 +1,73 @@
+# Runbook: Blog V2 markdown→HTML cutover
+
+The Blog V2 cutover switches post bodies from **markdown** to **TipTap HTML** and mounts the WYSIWYG
+editor. It is designed so the **code deploy is safe on its own** and the **data conversion is a
+separate, reversible, owner-supervised step** — there is no moment where the editor and the public
+render are out of step.
+
+## What ships in the cutover PR (code)
+
+- `renderPostBody` becomes **transitional**: HTML bodies render through the V2 sanitizer
+  (`renderBodyHtml`), legacy **markdown bodies keep the V1 `marked` path**. So deploying this changes
+  nothing for the still-markdown 6 posts — they render byte-identically.
+- The TipTap editor island is **mounted** in the admin add/edit forms (replacing the textarea). The
+  edit form passes `initialHtml = renderPostBody(post.body)`, so a post loads as HTML whether its
+  stored body is markdown or HTML — editing it saves HTML (it converts on first edit even before the
+  batch script runs).
+- The "Write in Markdown" helptext / Markdown guide are removed; the publish "body required" guard
+  moves to a submit-time check (the server `validateBlogData` stays the source of truth).
+
+Because the render is transitional, **merging the PR is safe** — the live blog is unchanged until a
+post is edited or the batch conversion is run.
+
+## The batch conversion (data) — run AFTER the PR is merged + deployed
+
+Converts all 6 posts to HTML proactively (so the steady state is uniform), self-verifying each row.
+
+```bash
+# From app/, against the TARGET database. Dry-run first — writes nothing, reports what would change:
+NETLIFY_DATABASE_URL="<neon pooler url>" npx tsx scripts/convert-blog-to-html.mts --dry-run
+
+# Then for real:
+NETLIFY_DATABASE_URL="<neon pooler url>" npx tsx scripts/convert-blog-to-html.mts
+```
+
+Per row it: computes the steady-state HTML (`renderBodyHtml(renderMarkdownToHtml(markdown))`),
+**verifies rendered-output equivalence** (V2 render byte-equals the V1 markdown render after the
+bounded §5.4 normalization), snapshots the original markdown into `data.bodyMarkdownBackup`, then
+overwrites `data.body`. A row that is **not equivalent is SKIPPED, not converted** (reported) — the
+gate never launders content loss; handle such a post by hand. Already-converted rows (already HTML or
+carrying a backup) are skipped, so the script is idempotent.
+
+> Get the Neon pooler URL from the **repo root**: `npx netlify env:get NETLIFY_DATABASE_URL`
+> (`apply-migrations.sh` echoes the host — confirm it is the Neon pooler, not localhost).
+
+### Verify after converting
+
+1. Public blog renders correctly — open 2–3 of the 6 posts at `/blog/<slug>`; no literal `##`/`<h2>`
+   text, links/images intact, all 6 URLs unchanged (≤5-min cache lag).
+2. The editor works — at `/admin/blog`, open a post; the TipTap editor loads its content; make a
+   trivial edit, save, confirm it renders.
+
+## Rollback
+
+Code-revert alone is **NOT** a rollback — converted HTML left in `data.body` would otherwise be
+served by the reverted (markdown-only) renderer as literal tags. Restore the data, then revert the code:
+
+```bash
+# 1. Restore each converted post's markdown from its snapshot, removing the backup key:
+NETLIFY_DATABASE_URL="<neon pooler url>" npx tsx scripts/revert-blog-to-markdown.mts --dry-run
+NETLIFY_DATABASE_URL="<neon pooler url>" npx tsx scripts/revert-blog-to-markdown.mts
+
+# 2. Revert the cutover PR (restores the textarea editor + the markdown helptext).
+```
+
+The transitional render is forgiving (it serves both formats), so even a partial rollback never
+serves literal markup; but the editor mount must be reverted to the textarea for markdown authoring.
+The pre-migration snapshot in `data.bodyMarkdownBackup`, **not git history**, is the authoritative
+source — migration 015 (`ON CONFLICT DO NOTHING`) never clobbered owner-edited rows, so it is stale.
+
+## After the conversion is ratified (follow-up, not part of the cutover)
+
+Once all 6 posts are converted and stable, a follow-up removes the transitional markdown branch from
+`renderPostBody` (single HTML render path) and clears the transient `data.bodyMarkdownBackup` keys.

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -18,16 +18,14 @@ intentionally out and why.
 
 ## Authoring Model
 
-> **Blog V2 transition (in progress).** A V2 rollout is replacing this Markdown/`<textarea>` model
-> with a **TipTap WYSIWYG editor storing sanitized HTML** in `data.body` (ADR-009). The V2 sanitizer
-> (`STRICT_CONFIG_V2`, `app/src/lib/blog-html.ts`), editor island, and HTML-aware alt gate are merged
-> but **surface-inert** — the live authoring surface and the public render below remain Markdown until
-> the atomic cutover deploy (which converts the 6 posts, flips `renderPostBody`, and mounts the editor
-> together). This section describes the current live V1 model; it is rewritten at the cutover.
-
-- Posts are authored in **Markdown** in a plain `<textarea>` (not a WYSIWYG / rich-text editor).
-- Markdown is stored raw in the DB and rendered to sanitized HTML on every read (sanitize-at-render,
-  never sanitize-at-write — the stored body is always treated as untrusted on the next render).
+- Posts are authored in a **TipTap WYSIWYG editor** at `/admin/blog` (ADR-009); the editor's HTML is
+  stored in `data.body`. Bold/italic/underline/strike, H2–H4, lists, blockquote, code blocks, links,
+  images, tables, and **class-based** text alignment are first-class.
+- The body is **re-sanitized at every render** through `renderBodyHtml` (DOMPurify `STRICT_CONFIG_V2`,
+  `app/src/lib/blog-html.ts`) — sanitize-at-render is the trust boundary, never sanitize-at-write only.
+  `style` is banned (alignment is class-based; tables `resizable:false`). During the markdown→HTML
+  cutover, `renderPostBody` is **transitional**: HTML bodies use `renderBodyHtml`, any not-yet-converted
+  legacy markdown still uses the V1 `marked` path (see `docs/runbooks/blog-html-conversion.md`).
 - Each post has a **status** of `published` or `draft`. Drafts are excluded from every public read
   by the SQL `status = 'published'` filter and are visible only in the admin list.
 - Owners publish, edit, unpublish (flip to draft), and delete posts from `/admin/blog` with no


### PR DESCRIPTION
## Phase-1 PR5 — the cutover (⚠️ HELD: do not merge until owner approves)

This is the **only** step that changes the live blog and migrates production post content. Opened as a **draft** per your "build + hold for OK" choice. Full procedure + rollback: `docs/runbooks/blog-html-conversion.md`.

### Why it's safe to merge (when you're ready)
The code deploy and the data conversion are **decoupled**, and `renderPostBody` is **transitional**:
- **HTML** bodies → V2 sanitizer (`renderBodyHtml`); **legacy markdown** → V1 `marked` path. So deploying this **changes nothing** for the still-markdown 6 posts — they render byte-identically. The editor and the public render are never out of step.
- The editor is **mounted** in the admin forms; edit forms pass `initialHtml = renderPostBody(post.body)`, so a post loads as HTML whether stored as markdown or HTML (it converts on first edit even before the batch script runs).

### The conversion (run AFTER merge, owner-supervised)
`scripts/convert-blog-to-html.mts` (+ `--dry-run`): per row, computes the steady-state HTML, **verifies rendered-output equivalence** (V2 render byte-equals the V1 markdown render after the bounded §5.4 normalization), **snapshots markdown to `data.bodyMarkdownBackup`**, then writes. A non-equivalent row is **skipped, not converted**. Idempotent.

### Rollback (deterministic, no data loss)
`scripts/revert-blog-to-markdown.mts` restores markdown from the snapshot; then revert this PR. Code-revert alone is *not* a rollback — the snapshot (not stale git/migration 015) is authoritative.

### What's in the diff
- Transitional `renderPostBody` + extracted `renderMarkdownToHtml`.
- TipTap editor mounted (add `client:load`, edit `client:visible`); Markdown helptext/guide removed.
- Publish "body required" → **submit-time** guard (body is now the island's hidden field; server `validateBlogData` stays the source of truth).
- Class-based text-align CSS on `.blog-body`.
- `blog-conversion.ts` + **13-test equivalence gate** (node env); convert/revert scripts (self-tested).
- Runbook + `blog.md` + CLAUDE.md.

### Residual risk
The editor **UI** can't be exercised in CI (no live `EditorView`/auth). The sanitizer and conversion ARE fully CI-verified; what's unverified is the editor's in-browser behavior — verify it at `/admin/blog` after merge (or hand me a short-lived `E2E_ADMIN_SESSION` to run the Playwright spike first).

### Gates
lint `--max-warnings=0` ✅ · typecheck ✅ · `format:check` ✅ · full vitest (358) ✅ · build (island bundles) ✅

Refs #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a WYSIWYG editor for blog post authoring, replacing the markdown textarea.
  * Added text alignment styling options (left, center, right, justify) for blog post content.

* **Documentation**
  * Updated blog specification and runbook to reflect the new WYSIWYG editor and HTML-based storage.

* **Tests**
  * Added test coverage for blog post conversion and rendering behavior across HTML and markdown formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->