### PR TITLE
feat(blog): Phase-2 PR1 — lifecycle schema/validation (scheduled + archived)

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -31,6 +31,7 @@ import {
   normalizeBlogEntry,
   renderBlogSitemapXml,
   renderPostBody,
+  resolveAuthorByline,
   resolveLegacyBlogRedirect,
   validateBlogData,
   type BlogPost
@@ -296,6 +297,96 @@ describe('reading time surfacing (R-readingTime)', () => {
   });
 });
 
+describe('resolveAuthorByline (R4-F9)', () => {
+  // The 6 live posts as they actually exist in prod: each carries only data.author ('Spicebush
+  // Team'), no author_type/author_ref. Introducing the resolver MUST NOT rewrite any byline.
+  const LIVE_POST_SLUGS = [
+    'embracing-holistic-development',
+    'embracing-neurodiversity-adhd',
+    'exploring-summer-camp',
+    'exploring-universe-within-cosmic-curriculum',
+    'nurturing-growth-gardening-program',
+    'welcome-to-our-new-blog'
+  ];
+
+  it('preserves all 6 live posts’ bylines via the data.author fallback (6-byline regression)', () => {
+    for (const slug of LIVE_POST_SLUGS) {
+      const data = { title: slug, author: 'Spicebush Team' };
+      // No author_type/author_ref → fallback to data.author, byte-for-byte, with OR without a registry.
+      expect(resolveAuthorByline(data)).toBe('Spicebush Team');
+      expect(resolveAuthorByline(data, new Map([['staff:rivera', 'Ms. Rivera']]))).toBe(
+        'Spicebush Team'
+      );
+    }
+  });
+
+  it('returns a custom data.author unchanged — never flattens to the default', () => {
+    expect(resolveAuthorByline({ author: 'Ms. Rivera' })).toBe('Ms. Rivera');
+  });
+
+  it('defaults to Spicebush Team only when no author string is present', () => {
+    expect(resolveAuthorByline({})).toBe('Spicebush Team');
+    expect(resolveAuthorByline({ author: '   ' })).toBe('Spicebush Team');
+  });
+
+  it('resolves a structured author_ref against the registry when present', () => {
+    const registry = new Map([['virtual:maria', 'Maria Montessori']]);
+    const data = {
+      author_type: 'virtual',
+      author_ref: 'virtual:maria',
+      author: 'ignored fallback'
+    };
+    expect(resolveAuthorByline(data, registry)).toBe('Maria Montessori');
+  });
+
+  it('falls back to data.author when the ref is unresolvable or no registry is supplied', () => {
+    const data = { author_type: 'virtual', author_ref: 'virtual:ghost', author: 'Spicebush Team' };
+    expect(resolveAuthorByline(data, new Map())).toBe('Spicebush Team'); // ref not in registry
+    expect(resolveAuthorByline(data)).toBe('Spicebush Team'); // no registry at all
+  });
+
+  it('mapEntryToBlogPost surfaces the resolved byline (read-path wiring)', () => {
+    const post = normalizeBlogEntry(
+      makeEntry('p', { title: 'T', date: '2024-01-01', excerpt: 'E', author: 'Ms. Rivera' })
+    );
+    expect(post?.author).toBe('Ms. Rivera');
+  });
+});
+
+describe('publishedAt surfacing + round-trip (R1-F17 / R4-F1)', () => {
+  it('normalizeBlogEntry surfaces a stored publishedAt and omits an absent one', () => {
+    const withAt = normalizeBlogEntry(
+      makeEntry('p', {
+        title: 'T',
+        date: '2024-01-01',
+        excerpt: 'E',
+        publishedAt: '2024-06-15T09:00:00Z'
+      })
+    );
+    expect(withAt?.publishedAt).toBe('2024-06-15T09:00:00Z');
+
+    const without = normalizeBlogEntry(
+      makeEntry('q', { title: 'T', date: '2024-01-01', excerpt: 'E' })
+    );
+    expect(without?.publishedAt).toBeUndefined();
+  });
+
+  it('blogPostToEditData carries publishedAt so an edit cannot wipe it', () => {
+    const data = blogPostToEditData(makePost({ publishedAt: '2024-06-15T09:00:00Z' }));
+    expect(data.publishedAt).toBe('2024-06-15T09:00:00Z');
+    // Absent → undefined → dropped by JSON.stringify (same contract as categories/tags).
+    const bare = JSON.parse(JSON.stringify(blogPostToEditData(makePost())));
+    expect('publishedAt' in bare).toBe(false);
+  });
+
+  it('normalizeBlogData trims publishedAt and drops an empty value', () => {
+    expect(normalizeBlogData({ publishedAt: '  2024-06-15T09:00:00Z  ' }).publishedAt).toBe(
+      '2024-06-15T09:00:00Z'
+    );
+    expect('publishedAt' in normalizeBlogData({ publishedAt: '   ' })).toBe(false);
+  });
+});
+
 describe('compareBlogPosts', () => {
   it('sorts date DESC, slug DESC tiebreak, undated last (R3-F18)', () => {
     const posts = [
@@ -308,6 +399,25 @@ describe('compareBlogPosts', () => {
     const sorted = [...posts].sort(compareBlogPosts).map(p => p.slug);
     // Same-date pair (mid-a, mid-b) deterministic by slug DESC → mid-b before mid-a.
     expect(sorted).toEqual(['new', 'mid-b', 'mid-a', 'old', 'undated']);
+  });
+
+  it('breaks a same-date tie by publishedAt DESC before slug (R1-F17)', () => {
+    // Same calendar date; `later` has the more recent precise instant → sorts first, ahead of the
+    // slug tiebreak that would otherwise put `aaa` before `zzz`.
+    const posts = [
+      makePost({ slug: 'aaa', date: '2024-10-29', publishedAt: '2024-10-29T08:00:00Z' }),
+      makePost({ slug: 'zzz', date: '2024-10-29', publishedAt: '2024-10-29T17:00:00Z' })
+    ];
+    expect([...posts].sort(compareBlogPosts).map(p => p.slug)).toEqual(['zzz', 'aaa']);
+  });
+
+  it('falls back to the slug tiebreak when publishedAt is absent on both (legacy no-op)', () => {
+    const posts = [
+      makePost({ slug: 'aaa', date: '2024-10-29' }),
+      makePost({ slug: 'zzz', date: '2024-10-29' })
+    ];
+    // No publishedAt on either → slug DESC, exactly as before the R1-F17 tiebreak was added.
+    expect([...posts].sort(compareBlogPosts).map(p => p.slug)).toEqual(['zzz', 'aaa']);
   });
 
   it('getPublishedPosts returns normalized + sorted output', async () => {
@@ -509,20 +619,29 @@ describe('normalizeBlogData', () => {
 describe('validateBlogData', () => {
   const validDraft = { slug: 'my-post', excerpt: 'x', body: 'y', date: '2024-01-01' };
 
+  const FOUR_STATE_ERROR = 'Status must be Draft, Published, Scheduled, or Archived';
+
   it('rejects missing/empty/whitespace-only rawStatus FIRST (R2-F2)', () => {
-    expect(validateBlogData({ ...validDraft }, 'T', undefined)).toBe(
-      'Status must be Draft or Published'
-    );
-    expect(validateBlogData({ ...validDraft }, 'T', '')).toBe('Status must be Draft or Published');
-    expect(validateBlogData({ ...validDraft }, 'T', '   ')).toBe(
-      'Status must be Draft or Published'
-    );
+    expect(validateBlogData({ ...validDraft }, 'T', undefined)).toBe(FOUR_STATE_ERROR);
+    expect(validateBlogData({ ...validDraft }, 'T', '')).toBe(FOUR_STATE_ERROR);
+    expect(validateBlogData({ ...validDraft }, 'T', '   ')).toBe(FOUR_STATE_ERROR);
   });
 
-  it('rejects an invalid status value', () => {
-    expect(validateBlogData({ ...validDraft }, 'T', 'archived')).toBe(
-      'Status must be Draft or Published'
-    );
+  it('rejects an unknown status value with the four-state error (R2-F11)', () => {
+    // R2-F11 inverts the prior `'archived'`-is-rejected assertion: the whitelist now accepts the
+    // four lifecycle states, so the rejection case uses a genuinely unknown value.
+    expect(validateBlogData({ ...validDraft }, 'T', 'bogus')).toBe(FOUR_STATE_ERROR);
+    expect(validateBlogData({ ...validDraft }, 'T', 'publish')).toBe(FOUR_STATE_ERROR);
+  });
+
+  it('accepts the four lifecycle states case-insensitively (R2-F11)', () => {
+    // Drafts/archived are exempt from publish requirements; published/scheduled meet them via the
+    // fixtures below. A bare validDraft satisfies draft + archived.
+    expect(validateBlogData({ ...validDraft }, 'T', 'draft')).toBeNull();
+    expect(validateBlogData({ ...validDraft }, 'T', 'ARCHIVED')).toBeNull();
+    expect(
+      validateBlogData({ slug: 'p', excerpt: 'x', body: 'y', date: '2024-01-01' }, 'T', 'Published')
+    ).toBeNull();
   });
 
   it('rejects missing title', () => {
@@ -649,6 +768,67 @@ describe('validateBlogData', () => {
     expect(
       validateBlogData({ slug: 'p', excerpt: 'x', body: 'y', date: '2024-01-01' }, 'T', 'published')
     ).toBeNull();
+  });
+
+  // ── Phase-2 lifecycle: scheduled-as-publishing gate (R1-F1) + publishedAt contract (R4-F1) ──
+  const NOW = Date.parse('2024-06-01T00:00:00Z');
+  const FUTURE = '2024-12-31T09:00:00Z';
+  const PAST = '2024-01-01T09:00:00Z';
+  const schedulable = { slug: 'p', excerpt: 'x', body: 'y', date: '2024-12-31' };
+
+  it('a scheduled save passes the FULL publish gate at save time (R1-F1)', () => {
+    // Missing excerpt/body/date are rejected for scheduled exactly as for published.
+    expect(
+      validateBlogData(
+        { slug: 'p', body: 'y', date: '2024-12-31', publishedAt: FUTURE },
+        'T',
+        'scheduled',
+        NOW
+      )
+    ).toMatch(/Excerpt/);
+    expect(
+      validateBlogData(
+        { slug: 'p', excerpt: 'x', date: '2024-12-31', publishedAt: FUTURE },
+        'T',
+        'scheduled',
+        NOW
+      )
+    ).toMatch(/Body/);
+  });
+
+  it('a scheduled save requires a future, well-formed publishedAt (R4-F1)', () => {
+    expect(validateBlogData({ ...schedulable }, 'T', 'scheduled', NOW)).toMatch(
+      /needs a publish date/i
+    );
+    expect(
+      validateBlogData({ ...schedulable, publishedAt: '2024-12-31' }, 'T', 'scheduled', NOW)
+    ).toMatch(/time zone/i); // date-only: no zone, no time
+    expect(
+      validateBlogData({ ...schedulable, publishedAt: '2024-12-31T09:00' }, 'T', 'scheduled', NOW)
+    ).toMatch(/time zone/i); // datetime-local with NO zone is rejected (UTC contract)
+    expect(validateBlogData({ ...schedulable, publishedAt: PAST }, 'T', 'scheduled', NOW)).toMatch(
+      /in the future/i
+    );
+  });
+
+  it('accepts a fully-formed scheduled save', () => {
+    expect(
+      validateBlogData({ ...schedulable, publishedAt: FUTURE }, 'T', 'scheduled', NOW)
+    ).toBeNull();
+  });
+
+  it('published/draft/archived saves do NOT require publishedAt', () => {
+    expect(validateBlogData({ ...schedulable }, 'T', 'published', NOW)).toBeNull();
+    expect(validateBlogData({ slug: 'p' }, 'T', 'draft', NOW)).toBeNull();
+    expect(validateBlogData({ slug: 'p' }, 'T', 'archived', NOW)).toBeNull();
+  });
+
+  it('an archived post round-trips back to draft via the normal save path (R4-F12)', () => {
+    // The same minimal payload is valid as archived AND as draft — archiving is reversible, not a
+    // one-way trip, and neither state imposes the publish requirements.
+    const minimal = { slug: 'p', excerpt: 'x', body: '![](no-alt)', date: '' };
+    expect(validateBlogData({ ...minimal }, 'T', 'archived', NOW)).toBeNull();
+    expect(validateBlogData({ ...minimal }, 'T', 'draft', NOW)).toBeNull();
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -12,6 +12,7 @@ import { db } from '@lib/db';
 import { queryRows } from '@lib/db/client';
 import type { ContentEntry } from '@lib/db/types';
 import { collectHtmlImageAlts, renderBodyHtml } from './blog-html';
+import { isFutureScheduledPublishAt, isScheduledPublishAtFormat } from './blog-publish-schedule';
 
 export type BlogPost = {
   slug: string;
@@ -25,6 +26,8 @@ export type BlogPost = {
   seoTitle?: string;
   seoDescription?: string;
   status: string;
+  /** Precise scheduled-publish instant (ISO-8601 w/ zone) for `status='scheduled'` posts (R4-F1). */
+  publishedAt?: string;
   categories?: string[];
   tags?: string[];
   readingTime?: number;
@@ -71,6 +74,32 @@ const asStringArray = (value: unknown): string[] | undefined => {
 };
 
 /**
+ * Resolve a post's display byline (R4-F9). When a structured author reference is present
+ * (`author_type` + `author_ref`) AND it resolves against the provided `registry` (staff /
+ * virtual authors from `settings.blog_authors`), the registry's display name wins. Otherwise the
+ * byline falls back to the legacy `data.author` string (default `'Spicebush Team'`).
+ *
+ * The 6 live posts carry only `data.author` (no `author_type`/`author_ref`), so they ALWAYS take
+ * the fallback and their bylines are preserved byte-for-byte — locked by the 6-byline regression
+ * test. `registry` is optional; with none provided every post takes the fallback, which is the
+ * PR1 read-path behavior until the author registry is wired in (later Phase-2/3 PR). The fallback
+ * must NEVER short-circuit to the default where a real `data.author` exists, or every legacy
+ * byline would be silently rewritten to 'Spicebush Team'.
+ */
+export function resolveAuthorByline(
+  data: Record<string, unknown>,
+  registry?: ReadonlyMap<string, string>
+): string {
+  const authorType = asTrimmedString(data.author_type);
+  const authorRef = asTrimmedString(data.author_ref);
+  if (authorType && authorRef && registry) {
+    const resolved = registry.get(authorRef);
+    if (resolved && resolved.trim().length > 0) return resolved.trim();
+  }
+  return asTrimmedString(data.author) || DEFAULT_AUTHOR;
+}
+
+/**
  * Shared field mapper — builds a `BlogPost` from a stored `ContentEntry` WITHOUT the
  * date/excerpt completeness gate. Returns `null` only when the row is structurally
  * untrustworthy (slug fails the charset/length shape or title is absent).
@@ -98,7 +127,7 @@ function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
   const date = asTrimmedString(data.date);
   const excerpt = asTrimmedString(data.excerpt);
   const body = typeof entry.body === 'string' ? entry.body : '';
-  const author = asTrimmedString(data.author) || DEFAULT_AUTHOR;
+  const author = resolveAuthorByline(data);
 
   // Null/strip a featured image failing the backslash-aware scheme — treat as absent.
   const rawImage = asTrimmedString(data.image);
@@ -116,6 +145,7 @@ function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
     seoTitle: emptyToUndefined(asTrimmedString(data.seoTitle)),
     seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
     status: 'published',
+    publishedAt: emptyToUndefined(asTrimmedString(data.publishedAt)),
     categories: asStringArray(data.categories),
     tags: asStringArray(data.tags),
     // Prefer the value stored on save; fall back to computing from the body so the 6 legacy posts
@@ -150,6 +180,9 @@ export function blogPostToEditData(post: BlogPost): Record<string, unknown> {
     seoTitle: post.seoTitle,
     seoDescription: post.seoDescription,
     status: post.status,
+    // Carry the scheduled-publish instant through an edit — it has no form input of its own yet,
+    // and the upsert writes `data` wholesale, so omitting it here would wipe it on the next save.
+    publishedAt: post.publishedAt,
     categories: post.categories,
     tags: post.tags
   };
@@ -169,7 +202,11 @@ export function normalizeBlogEntry(entry: ContentEntry): BlogPost | null {
 }
 
 /**
- * The ONLY ordering implementation (R1-F9): date DESC, slug DESC tiebreak, undated-last (R3-F18).
+ * The ONLY ordering implementation (R1-F9): date DESC, then `publishedAt` DESC, slug DESC
+ * tiebreak, undated-last (R3-F18). The `publishedAt` tiebreak (R1-F17) orders two posts sharing a
+ * calendar `date` by their precise scheduled-publish instant before falling back to the slug —
+ * legacy posts carry no `publishedAt` (both `''`), so this step is a no-op for them and the
+ * existing date/slug ordering is unchanged.
  */
 export function compareBlogPosts(a: BlogPost, b: BlogPost): number {
   const aDated = a.date.length > 0;
@@ -177,6 +214,11 @@ export function compareBlogPosts(a: BlogPost, b: BlogPost): number {
   if (aDated !== bDated) return aDated ? -1 : 1; // undated sorts last
 
   if (a.date !== b.date) return a.date < b.date ? 1 : -1; // date DESC
+
+  const aAt = a.publishedAt ?? '';
+  const bAt = b.publishedAt ?? '';
+  if (aAt !== bAt) return aAt < bAt ? 1 : -1; // publishedAt DESC (R1-F17)
+
   if (a.slug !== b.slug) return a.slug < b.slug ? 1 : -1; // slug DESC
   return 0;
 }
@@ -276,7 +318,15 @@ export function normalizeBlogData(data: Record<string, unknown>): Record<string,
   const normalized: Record<string, unknown> = { ...data };
 
   // Trim short string fields.
-  for (const key of ['date', 'author', 'image', 'imageAlt', 'seoTitle', 'seoDescription']) {
+  for (const key of [
+    'date',
+    'author',
+    'image',
+    'imageAlt',
+    'seoTitle',
+    'seoDescription',
+    'publishedAt'
+  ]) {
     if (typeof normalized[key] === 'string') {
       normalized[key] = (normalized[key] as string).trim();
     }
@@ -290,8 +340,9 @@ export function normalizeBlogData(data: Record<string, unknown>): Record<string,
     normalized.excerpt = normalized.excerpt.trim();
   }
 
-  // Delete optional keys whose trimmed value is '' (R2-F20).
-  for (const key of ['image', 'imageAlt', 'seoTitle', 'seoDescription', 'date']) {
+  // Delete optional keys whose trimmed value is '' (R2-F20). `publishedAt` is included so an empty
+  // value never persists — only a real scheduled instant is stored (a draft/published save clears it).
+  for (const key of ['image', 'imageAlt', 'seoTitle', 'seoDescription', 'date', 'publishedAt']) {
     if (normalized[key] === '') {
       delete normalized[key];
     }
@@ -341,14 +392,26 @@ const collectBodyImageAlts = (markdown: string): string[] => {
 export function validateBlogData(
   data: Record<string, unknown>,
   title: string | null,
-  rawStatus: string | undefined
+  rawStatus: string | undefined,
+  now: number = Date.now()
 ): string | null {
-  // 1. Explicit-status check FIRST, against the RAW pre-default value (R2-F2).
+  // 1. Explicit-status check FIRST, against the RAW pre-default value (R2-F2). Four-state
+  // whitelist (R2-F11): draft | published | scheduled | archived. The DB CHECK constraint
+  // (PR4) is defense-in-depth behind this gate.
   const statusValue = typeof rawStatus === 'string' ? rawStatus.trim().toLowerCase() : '';
-  if (statusValue !== 'draft' && statusValue !== 'published') {
-    return 'Status must be Draft or Published';
+  if (
+    statusValue !== 'draft' &&
+    statusValue !== 'published' &&
+    statusValue !== 'scheduled' &&
+    statusValue !== 'archived'
+  ) {
+    return 'Status must be Draft, Published, Scheduled, or Archived';
   }
-  const isPublishing = statusValue === 'published';
+  // A scheduled post passes the FULL publish gate at save time (R1-F1): it goes live unattended,
+  // so it must be publish-ready NOW. `archived` is non-publishing — exempt like a draft (and an
+  // archived post round-trips back to draft via this same path, R4-F12).
+  const isPublishing = statusValue === 'published' || statusValue === 'scheduled';
+  const isScheduled = statusValue === 'scheduled';
 
   // 2. Slug shape + date-prefix rejection (R2-F19).
   const slug = typeof data.slug === 'string' ? data.slug : '';
@@ -407,6 +470,24 @@ export function validateBlogData(
   if (!date || !DATE_FORMAT_REGEX.test(date) || Number.isNaN(Date.parse(date))) {
     return 'A valid publish date (YYYY-MM-DD) is required to publish';
   }
+
+  // Scheduled posts additionally need a precise, future publish timestamp sharing the cron's exact
+  // format contract (R4-F1) — so a save that succeeds is exactly the set the cron will fire, and a
+  // post that saves can never sit un-firing forever. Plain-language guidance nudges the
+  // "Save as Draft instead" fallback (R3-F16) when the post is not yet schedule-ready.
+  if (isScheduled) {
+    const publishedAt = typeof data.publishedAt === 'string' ? data.publishedAt.trim() : '';
+    if (!publishedAt) {
+      return 'A scheduled post needs a publish date and time — pick when it should go live, or save it as a draft instead';
+    }
+    if (!isScheduledPublishAtFormat(publishedAt)) {
+      return 'Scheduled publish time must be a valid date and time with a time zone (for example 2026-06-15T09:00:00Z)';
+    }
+    if (!isFutureScheduledPublishAt(publishedAt, now)) {
+      return 'Scheduled publish time must be in the future — pick a later time, or save it as a draft instead';
+    }
+  }
+
   if (image && !imageAlt) {
     return 'Featured image alt text is required to publish';
   }

--- a/app/src/lib/blog-publish-schedule.test.ts
+++ b/app/src/lib/blog-publish-schedule.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SCHEDULED_PUBLISH_AT_REGEX,
+  isDueScheduledPublishAt,
+  isFutureScheduledPublishAt,
+  isScheduledPublishAtFormat
+} from './blog-publish-schedule';
+
+// The shared scheduled-publish date contract (R4-F1). The same predicates gate the write-time
+// save AND the PR4 cron's fire decision, so these tests lock the ONE contract both depend on.
+const NOW = Date.parse('2024-06-01T00:00:00Z');
+
+describe('isScheduledPublishAtFormat', () => {
+  it('accepts ISO-8601 instants with an explicit zone (Z or numeric offset)', () => {
+    for (const v of [
+      '2024-12-31T09:00Z',
+      '2024-12-31T09:00:00Z',
+      '2024-12-31T09:00:00.500Z',
+      '2024-12-31T09:00:00+00:00',
+      '2024-12-31T09:00:00-05:00'
+    ]) {
+      expect(isScheduledPublishAtFormat(v)).toBe(true);
+      expect(SCHEDULED_PUBLISH_AT_REGEX.test(v)).toBe(true);
+    }
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(isScheduledPublishAtFormat('  2024-12-31T09:00:00Z  ')).toBe(true);
+  });
+
+  it('rejects zone-less, date-only, malformed, impossible, and non-string values', () => {
+    for (const v of [
+      '2024-12-31T09:00:00', // no zone — Postgres would read it in session TimeZone
+      '2024-12-31T09:00', // datetime-local, no zone
+      '2024-12-31', // date only
+      '2024-13-31T09:00:00Z', // impossible month → Date.parse NaN
+      '2024-12-31 09:00:00Z', // space, not 'T'
+      'not-a-date',
+      '',
+      undefined,
+      null,
+      12345
+    ]) {
+      expect(isScheduledPublishAtFormat(v as unknown)).toBe(false);
+    }
+  });
+});
+
+describe('isFutureScheduledPublishAt', () => {
+  it('is true strictly after now, false at/before now or when malformed', () => {
+    expect(isFutureScheduledPublishAt('2024-12-31T09:00:00Z', NOW)).toBe(true);
+    expect(isFutureScheduledPublishAt('2024-01-01T09:00:00Z', NOW)).toBe(false);
+    expect(isFutureScheduledPublishAt('2024-06-01T00:00:00Z', NOW)).toBe(false); // exactly now → not future
+    expect(isFutureScheduledPublishAt('2024-12-31', NOW)).toBe(false); // malformed
+  });
+});
+
+describe('isDueScheduledPublishAt (cron fire predicate)', () => {
+  it('is true at/before now (due), false in the future or when malformed', () => {
+    expect(isDueScheduledPublishAt('2024-01-01T09:00:00Z', NOW)).toBe(true);
+    expect(isDueScheduledPublishAt('2024-06-01T00:00:00Z', NOW)).toBe(true); // exactly now → due
+    expect(isDueScheduledPublishAt('2024-12-31T09:00:00Z', NOW)).toBe(false); // future → not yet
+    // A malformed/garbage row is skipped (false), never fatal — the cron's R3-F2 resilience.
+    expect(isDueScheduledPublishAt('garbage', NOW)).toBe(false);
+    expect(isDueScheduledPublishAt('2024-12-31T09:00', NOW)).toBe(false);
+  });
+
+  it('future and due are mutually exclusive across the same instant', () => {
+    const v = '2024-09-01T12:00:00Z';
+    expect(isFutureScheduledPublishAt(v, NOW)).toBe(true);
+    expect(isDueScheduledPublishAt(v, NOW)).toBe(false);
+  });
+});

--- a/app/src/lib/blog-publish-schedule.test.ts
+++ b/app/src/lib/blog-publish-schedule.test.ts
@@ -33,7 +33,9 @@ describe('isScheduledPublishAtFormat', () => {
       '2024-12-31T09:00:00', // no zone — Postgres would read it in session TimeZone
       '2024-12-31T09:00', // datetime-local, no zone
       '2024-12-31', // date only
-      '2024-13-31T09:00:00Z', // impossible month → Date.parse NaN
+      '2024-13-31T09:00:00Z', // impossible month (>12) → rejected by the explicit day check + NaN
+      '2024-12-32T09:00:00Z', // impossible day (>31)
+      '2024-12-31T25:00:00Z', // impossible hour → Date.parse NaN
       '2024-12-31 09:00:00Z', // space, not 'T'
       'not-a-date',
       '',
@@ -43,6 +45,25 @@ describe('isScheduledPublishAtFormat', () => {
     ]) {
       expect(isScheduledPublishAtFormat(v as unknown)).toBe(false);
     }
+  });
+
+  it('rejects calendar-overflow days that Date.parse would silently roll forward', () => {
+    // V8 normalizes these to the 1st of the next month; the explicit wall-clock day check rejects
+    // them so a nonsensical typed date can never persist + fire a day late.
+    for (const v of [
+      '2025-02-29T09:00:00Z', // non-leap Feb 29
+      '2024-02-30T09:00:00Z', // Feb 30
+      '2024-04-31T09:00:00Z', // Apr 31
+      '2024-06-31T09:00:00Z', // Jun 31
+      '2024-11-31T09:00:00Z', // Nov 31
+      '2024-01-00T09:00:00Z' // day 00
+    ]) {
+      expect(isScheduledPublishAtFormat(v)).toBe(false);
+    }
+  });
+
+  it('accepts a real leap-day instant (Feb 29 in a leap year)', () => {
+    expect(isScheduledPublishAtFormat('2024-02-29T09:00:00Z')).toBe(true);
   });
 });
 

--- a/app/src/lib/blog-publish-schedule.ts
+++ b/app/src/lib/blog-publish-schedule.ts
@@ -22,13 +22,25 @@ export const SCHEDULED_PUBLISH_AT_REGEX =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 /**
- * True when `value` is a string matching the shared format AND a real, parseable instant.
- * Rejects malformed shapes and impossible dates (`Date.parse` → `NaN`).
+ * True when `value` is a string matching the shared format AND a real, valid instant. Rejects
+ * malformed shapes, calendar-overflow days (Feb 30, non-leap Feb 29 — validated explicitly, since
+ * `Date.parse` silently rolls those forward instead of returning `NaN`), and out-of-range time /
+ * offset fields (hour 25, minute 60, `+99:99` — caught by the `Date.parse` → `NaN` check).
  */
 export function isScheduledPublishAtFormat(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   const trimmed = value.trim();
   if (!SCHEDULED_PUBLISH_AT_REGEX.test(trimmed)) return false;
+  // Reject calendar-overflow days (non-leap Feb 29, Feb 30, Apr/Jun/Sep/Nov 31, …). `Date.parse`
+  // does NOT catch these — V8 silently rolls them into the next month — so validate the wall-clock
+  // date directly from the matched Y-M-D (invalid regardless of zone offset). The anchored regex
+  // guarantees the first 10 chars are `YYYY-MM-DD`.
+  const [year, month, day] = trimmed.slice(0, 10).split('-').map(Number);
+  const isLeap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, isLeap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]) return false;
+  // Date.parse still earns its place for the out-of-range time/offset fields the day check above
+  // does not cover (hour 25, minute 60, second 61, +99:99).
   return !Number.isNaN(Date.parse(trimmed));
 }
 

--- a/app/src/lib/blog-publish-schedule.ts
+++ b/app/src/lib/blog-publish-schedule.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared scheduled-publish date contract (R4-F1).
+ *
+ * The write-time validator (`validateBlogData` in `blog-content.ts`) and the scheduled-publish
+ * cron (Phase-2 PR4) BOTH import from here, so a `scheduled` post that saves cleanly is exactly
+ * the set the cron will fire — one regex, one parse rule, no drift. A hand-rolled second regex in
+ * the cron is the failure this module exists to prevent: a post that saves but can never fire.
+ *
+ * Dependency-free on purpose — the cron must not pull in the render stack (`marked` / DOMPurify /
+ * TipTap) just to validate a timestamp.
+ *
+ * Format: ISO-8601 date-time with an EXPLICIT zone — a UTC designator (`Z`) or a numeric offset
+ * (`±HH:MM`). Seconds and milliseconds are optional. A bare `datetime-local` value (no zone) is
+ * REJECTED: Postgres `::timestamptz` would interpret it in the server's session TimeZone, so the
+ * authoring form (PR2) must attach a zone before saving (UTC contract, R1-F27). The cron guards
+ * its `::timestamptz` cast with this SAME contract so one malformed `publishedAt` row is skipped,
+ * not statement-aborting every due post (R3-F2); the most robust way for PR4 to honor that is to
+ * select candidate `scheduled` rows and filter them in JS with {@link isDueScheduledPublishAt}
+ * rather than re-encode this pattern as a (subtly different) POSIX regex in SQL.
+ */
+export const SCHEDULED_PUBLISH_AT_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * True when `value` is a string matching the shared format AND a real, parseable instant.
+ * Rejects malformed shapes and impossible dates (`Date.parse` → `NaN`).
+ */
+export function isScheduledPublishAtFormat(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!SCHEDULED_PUBLISH_AT_REGEX.test(trimmed)) return false;
+  return !Number.isNaN(Date.parse(trimmed));
+}
+
+/**
+ * True when `value` is a well-formed scheduled instant strictly AFTER `now` (ms epoch) — the
+ * save-time gate: a scheduled post must be set to go live later, never in the past.
+ */
+export function isFutureScheduledPublishAt(value: unknown, now: number): boolean {
+  if (!isScheduledPublishAtFormat(value)) return false;
+  return Date.parse(value.trim()) > now;
+}
+
+/**
+ * True when `value` is a well-formed scheduled instant AT or BEFORE `now` (ms epoch) — i.e. DUE
+ * to publish. The scheduled-publish cron (PR4) uses THIS to decide which rows to flip, so the
+ * cron and the save-time gate share one format guard and a malformed `publishedAt` is skipped
+ * (returns `false`), never fatal.
+ */
+export function isDueScheduledPublishAt(value: unknown, now: number): boolean {
+  if (!isScheduledPublishAtFormat(value)) return false;
+  return Date.parse(value.trim()) <= now;
+}

--- a/app/src/pages/api/admin/content.test.ts
+++ b/app/src/pages/api/admin/content.test.ts
@@ -242,7 +242,7 @@ describe('POST /api/admin/content — blog validation (test 13 / acceptance)', (
     const response = await callPost(formRequest(fields));
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe('Status must be Draft or Published');
+    expect(body.error).toBe('Status must be Draft, Published, Scheduled, or Archived');
     expect(queryMock).not.toHaveBeenCalled();
   });
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -329,14 +329,17 @@ carry a header-splitting payload regardless of which response branch sets the
 `Location` header (defense-in-depth). A rejected `redirectTo` falls back to a JSON
 response (no `303` to the unsafe path).
 
-**Blog explicit-status requirement**: blog POSTs must carry a `status` of `draft`
-or `published` **explicitly**. A missing / empty / whitespace-only status is a
-`400` ("Status must be Draft or Published"), checked first against the raw form
-value — never silently defaulted to `published`. The `status || 'published'`
-default still applies to all other collections. The validated status is stored
-**lowercased** (`draft` / `published`) so a mixed-case input (e.g. `Published`)
+**Blog explicit-status requirement**: blog POSTs must carry a `status` of `draft`,
+`published`, `scheduled`, or `archived` **explicitly** (Phase-2 four-state
+lifecycle). A missing / empty / whitespace-only / unknown status is a `400`
+("Status must be Draft, Published, Scheduled, or Archived"), checked first against
+the raw form value — never silently defaulted to `published`. The
+`status || 'published'` default still applies to all other collections. The
+validated status is stored **lowercased** so a mixed-case input (e.g. `Published`)
 cannot pass validation yet stay invisible behind the exact `status = 'published'`
-read filter.
+read filter. A `scheduled` save additionally requires a future, zone-explicit
+`data.publishedAt` (shared format contract in `blog-publish-schedule.ts`); a
+`scheduled` post passes the full publish gate at save time.
 
 ---
 

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -299,10 +299,40 @@ The middleware protects `/admin` and `/api/admin` prefixes:
 
 ### Status requirement
 
-Blog POSTs must carry `status ∈ {draft, published}` **explicitly**. A missing / empty /
-whitespace-only status is rejected with `400` "Status must be Draft or Published" — checked first,
-against the raw form value, before the endpoint's `status || 'published'` default (which never
-applies to blog). The admin form always submits a status, so owners never see this error.
+Blog POSTs must carry `status ∈ {draft, published, scheduled, archived}` **explicitly** (Phase-2
+four-state lifecycle, R2-F11). A missing / empty / whitespace-only / unknown status is rejected with
+`400` "Status must be Draft, Published, Scheduled, or Archived" — checked first, against the raw form
+value, before the endpoint's `status || 'published'` default (which never applies to blog). The admin
+form always submits a status, so owners never see this error. Phase-2 PR4 adds a DB
+`CHECK (status IN ('draft','published','scheduled','archived'))` as defense-in-depth behind this gate
+and behind the exact-match `WHERE status = 'published'` public read filter.
+
+- **`published`** — live on every public surface.
+- **`draft`** — exempt from the publish requirements below; invisible publicly.
+- **`scheduled`** — passes the FULL publish gate at SAVE time (R1-F1): it goes live unattended, so it
+  must be publish-ready now AND carry a future `data.publishedAt`. Invisible publicly until the
+  every-5-min scheduled-publish cron (PR4) flips it to `published`.
+- **`archived`** — non-publishing (exempt like a draft) and **reversible**: round-trips back to
+  `draft`/`published` through the normal save path (R4-F12), so it is never a one-way trip.
+
+#### Scheduled publish timestamp (`data.publishedAt`) — R4-F1
+
+A `scheduled` save additionally requires `data.publishedAt`: an ISO-8601 date-time with an explicit
+zone (`Z` or `±HH:MM`; seconds/millis optional) that is a real instant in the **future**. A bare
+`datetime-local` (no zone) is rejected — the authoring form attaches a zone before saving (UTC
+contract). This format contract lives in `app/src/lib/blog-publish-schedule.ts`
+(`isScheduledPublishAtFormat` / `isFutureScheduledPublishAt` / `isDueScheduledPublishAt`) and is
+imported by BOTH `validateBlogData` (save gate) and the scheduled-publish cron (PR4 fire predicate),
+so a post that saves cleanly is exactly the set the cron will fire — one contract, no drift.
+
+#### Author byline (`resolveAuthorByline`) — R4-F9
+
+The display byline resolves as: `registry.get(author_ref)` when `data.author_type` + `data.author_ref`
+are both present AND resolve against the author registry (`settings.blog_authors`); otherwise the
+legacy `data.author` string (default `'Spicebush Team'`). The 6 live posts carry only `data.author`
+(no `author_type`/`author_ref`), so they always take the fallback and their bylines are preserved
+byte-for-byte (6-byline regression test). Ordering tiebreak: posts sharing a calendar `date` order by
+`data.publishedAt` DESC before the slug tiebreak (R1-F17), a no-op for legacy posts that carry none.
 
 ### Validation rules (`validateBlogData`)
 


### PR DESCRIPTION
## Phase 2 · PR1 — lifecycle schema/validation (lib-only)

First PR of the Blog V2 **Phase 2 (lifecycle + dashboard)** build. Lib-only foundation: **no UI, endpoint, or migration changes.** The dashboard (keep-accordion, owner decision), `action=archive` endpoint, the `status` CHECK constraint, and the scheduled-publish cron land in later Phase-2 PRs and depend on this contract.

### What changed
- **Four-state status whitelist** in `validateBlogData`: `draft | published | scheduled | archived` with four-state error copy (R2-F11). A `scheduled` save passes the **FULL publish gate at save time** (R1-F1) — it goes live unattended, so it must be publish-ready now. `archived` is non-publishing (exempt like draft) and **round-trips back to draft** via the normal save path (R4-F12).
- **`blog-publish-schedule.ts` (new)** — the ONE shared scheduled-publish date contract (R4-F1). `isScheduledPublishAtFormat` / `isFutureScheduledPublishAt` / `isDueScheduledPublishAt`. `validateBlogData` imports it now; **the PR4 cron imports the same predicates**, so a post that saves cleanly is exactly the set the cron fires — no second hand-rolled regex, no drift. Format = ISO-8601 with an explicit zone; a bare `datetime-local` (no zone) is rejected (UTC contract, R1-F27).
- **`resolveAuthorByline` (R4-F9)** — registry-resolved byline when `author_type`+`author_ref` resolve, else the legacy `data.author` fallback (default `Spicebush Team`). Wired into the read path. The **6-byline regression** locks that the 6 live posts (author-only, no type/ref) keep their bylines byte-for-byte — the resolver never flattens a real author to the default.
- **`publishedAt`** surfaced on `BlogPost`, carried through `blogPostToEditData` (an edit cannot wipe it), trimmed/cleared in `normalizeBlogData`; `compareBlogPosts` gains a `publishedAt` DESC tiebreak before the slug (R1-F17) — a **no-op for legacy posts** that carry none.
- **Docs:** `blog.md` status/lifecycle + `publishedAt` contract + byline sections; `api.md` status copy.

### Intended test changes (not regressions)
- The prior `'rejects an invalid status value'` assertion (`archived` → rejected) is **inverted** per R2-F11 — `archived` is now valid; the rejection case uses a genuinely unknown status. The R2-F2 error-copy assertions move to the four-state string. Planned, per the Phase-2 plan §11.

### Gates
lint `--max-warnings=0` clean · typecheck 0 errors · format clean · **381 tests pass** (incl. 2 new focused suites: `blog-publish-schedule.test.ts`, expanded `blog-content.test.ts`) · build OK.

### Sequencing note
Under merge-on-CI-green, this lib-only PR exposes nothing to users (no form wires `scheduled` yet). The plan prefers landing the cron (PR4) before PR2's scheduling UI so a post scheduled in the gap fires on the cron's first run rather than waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)