### PR TITLE
feat(blog): Phase-2 PR2 — scheduled-publish backend (cron + status CHECK)

### DIFF
--- a/app/db/migrations/016_blog_status_check.sql
+++ b/app/db/migrations/016_blog_status_check.sql
@@ -1,0 +1,26 @@
+-- Phase-2 lifecycle (R4-F2): enforce the blog four-state status set at the storage layer as
+-- defense-in-depth behind validateBlogData's whitelist AND behind the exact-match
+-- `WHERE status = 'published'` public read filter. This documents the canonical blog state set
+-- authoritatively and stops both the widened validateBlogData path and the separate
+-- `action=archive` path from ever persisting an unexpected blog status string.
+--
+-- TYPE-SCOPED, not table-wide: `content.status` is SHARED across all content types
+-- (blog/faq/hours/media-slots/photos/school-info/staff/testimonials/tuition), every one of which
+-- uses only 'published' today. A table-wide `status IN (4 blog states)` CHECK would couple every
+-- content type to the BLOG lifecycle and would break a future non-blog status. The
+-- `type <> 'blog' OR ...` form constrains ONLY blog rows and leaves every other type unconstrained.
+-- All existing blog rows are 'published' (a member of the set), so the constraint validates
+-- immediately without rewriting any data.
+--
+-- Idempotent: guarded on pg_constraint so a re-run (or out-of-band manual apply) is a no-op. The
+-- migration runner also tracks applied versions in schema_migrations, so this normally runs once.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'content_blog_status_check'
+  ) THEN
+    ALTER TABLE content
+      ADD CONSTRAINT content_blog_status_check
+      CHECK (type <> 'blog' OR status IN ('draft', 'published', 'scheduled', 'archived'));
+  END IF;
+END $$;

--- a/app/netlify/functions/publish-scheduled-blog-posts.ts
+++ b/app/netlify/functions/publish-scheduled-blog-posts.ts
@@ -1,0 +1,34 @@
+import type { Handler } from '@netlify/functions';
+import { publishDueScheduledPosts } from '../../src/lib/blog-scheduled-publish';
+
+// Every 5 minutes (R3-F12): by-design visibility lag (the 5-min collection TTL) never produces a
+// visibly-overdue post. In-file `export const config` schedule, mirroring the existing
+// process-announcement-email-jobs cron — not netlify.toml (R1-F14).
+export const config = {
+  schedule: '*/5 * * * *'
+};
+
+export const handler: Handler = async () => {
+  try {
+    const summary = await publishDueScheduledPosts();
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        success: true,
+        summary,
+        timestamp: new Date().toISOString()
+      })
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to publish scheduled blog posts',
+        timestamp: new Date().toISOString()
+      })
+    };
+  }
+};

--- a/app/src/lib/blog-scheduled-publish.test.ts
+++ b/app/src/lib/blog-scheduled-publish.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryRowsMock, queryMock } = vi.hoisted(() => ({
+  queryRowsMock: vi.fn(),
+  queryMock: vi.fn()
+}));
+
+vi.mock('@lib/db/client', () => ({
+  queryRows: queryRowsMock,
+  query: queryMock
+}));
+
+import { publishDueScheduledPosts } from './blog-scheduled-publish';
+
+const NOW = Date.parse('2024-06-01T12:00:00Z');
+const DUE = '2024-06-01T09:00:00Z'; // before NOW
+const FUTURE = '2024-12-31T09:00:00Z'; // after NOW
+
+beforeEach(() => {
+  queryRowsMock.mockReset();
+  queryMock.mockReset();
+  queryMock.mockResolvedValue({ rowCount: 1 });
+});
+
+describe('publishDueScheduledPosts', () => {
+  it('flips only DUE rows and reports a per-bucket summary', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      { slug: 'due-one', published_at: DUE },
+      { slug: 'future-one', published_at: FUTURE },
+      { slug: 'due-two', published_at: '2024-06-01T11:59:59Z' }
+    ]);
+
+    const summary = await publishDueScheduledPosts({ now: NOW });
+
+    expect(summary.scannedScheduled).toBe(3);
+    expect(summary.published.sort()).toEqual(['due-one', 'due-two']);
+    expect(summary.notYetDue).toBe(1);
+    expect(summary.skippedMalformed).toBe(0);
+
+    // Only the two due rows are UPDATEd; the future row is never touched.
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    const updatedSlugs = queryMock.mock.calls.map(call => call[1][0]).sort();
+    expect(updatedSlugs).toEqual(['due-one', 'due-two']);
+    // The UPDATE re-asserts status='scheduled' so a concurrent edit is not double-flipped.
+    expect(queryMock.mock.calls[0][0]).toMatch(/status = 'scheduled'/);
+    expect(queryMock.mock.calls[0][0]).toMatch(/SET status = 'published'/);
+  });
+
+  it('skips a missing/malformed publishedAt WITHOUT throwing and WITHOUT publishing (R3-F2)', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      { slug: 'garbage', published_at: 'not-a-date' },
+      { slug: 'zoneless', published_at: '2024-06-01T09:00' }, // no zone → rejected by the shared contract
+      { slug: 'missing', published_at: null },
+      { slug: 'good', published_at: DUE }
+    ]);
+
+    const summary = await publishDueScheduledPosts({ now: NOW });
+
+    expect(summary.skippedMalformed).toBe(3);
+    expect(summary.published).toEqual(['good']);
+    // Exactly one UPDATE — the bad rows neither fire nor abort the batch.
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][1][0]).toBe('good');
+  });
+
+  it('is a clean no-op when there are no scheduled rows', async () => {
+    queryRowsMock.mockResolvedValueOnce([]);
+    const summary = await publishDueScheduledPosts({ now: NOW });
+    expect(summary).toEqual({
+      scannedScheduled: 0,
+      published: [],
+      notYetDue: 0,
+      skippedMalformed: 0
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('treats an exactly-now publishedAt as due (boundary)', async () => {
+    queryRowsMock.mockResolvedValueOnce([{ slug: 'edge', published_at: '2024-06-01T12:00:00Z' }]);
+    const summary = await publishDueScheduledPosts({ now: NOW });
+    expect(summary.published).toEqual(['edge']);
+  });
+
+  it('queries only scheduled blog rows', async () => {
+    queryRowsMock.mockResolvedValueOnce([]);
+    await publishDueScheduledPosts({ now: NOW });
+    const sql = queryRowsMock.mock.calls[0][0] as string;
+    expect(sql).toMatch(/type = 'blog'/);
+    expect(sql).toMatch(/status = 'scheduled'/);
+    expect(sql).toMatch(/publishedAt/);
+  });
+});

--- a/app/src/lib/blog-scheduled-publish.ts
+++ b/app/src/lib/blog-scheduled-publish.ts
@@ -53,8 +53,6 @@ export async function publishDueScheduledPosts(
     skippedMalformed: 0
   };
 
-  const publishedAtIso = new Date(now).toISOString();
-
   for (const row of rows) {
     const at = row.published_at;
     if (!isScheduledPublishAtFormat(at)) {
@@ -66,10 +64,12 @@ export async function publishDueScheduledPosts(
       continue;
     }
     // Flip status ONLY. The WHERE re-asserts status='scheduled' so a concurrent owner edit that
-    // already moved the row (published/archived/back-to-draft) is not double-flipped.
+    // already moved the row (published/archived/back-to-draft) is not double-flipped. `updated_at`
+    // is left to the `trigger_content_set_updated_at` BEFORE-UPDATE trigger (001_core_schema.sql),
+    // which sets it to NOW() — passing it here would only be overwritten.
     await query(
-      "UPDATE content SET status = 'published', updated_at = $2 WHERE type = 'blog' AND slug = $1 AND status = 'scheduled'",
-      [row.slug, publishedAtIso]
+      "UPDATE content SET status = 'published' WHERE type = 'blog' AND slug = $1 AND status = 'scheduled'",
+      [row.slug]
     );
     summary.published.push(row.slug);
   }

--- a/app/src/lib/blog-scheduled-publish.ts
+++ b/app/src/lib/blog-scheduled-publish.ts
@@ -1,0 +1,78 @@
+/**
+ * Scheduled-publish worker (Phase-2 lifecycle). Flips every DUE `scheduled` blog post to
+ * `published`. Invoked by the every-5-min Netlify scheduled function
+ * (`netlify/functions/publish-scheduled-blog-posts.ts`); kept here in `src/lib/**` so the logic is
+ * unit-testable with a mocked DB client and auto-coverage-measured.
+ *
+ * Contract sharing (R4-F1): "due" is decided by `isDueScheduledPublishAt` — the SAME predicate the
+ * save-time gate uses for the future check — so a post that saved cleanly is exactly what fires
+ * here. There is no second, drifting date parser.
+ *
+ * Resilience (R3-F2): a row whose `data.publishedAt` is missing or malformed is SKIPPED (counted),
+ * never fatal — one bad row must not block the others. Because the decision runs in JS over the
+ * fetched candidate set, a garbage value simply fails the format guard; there is no statement-level
+ * `::timestamptz` cast that could abort the whole batch.
+ *
+ * Cache (R1-F16): the worker flips `status` only and does NOT invalidate the SSR collection cache —
+ * that cache lives in OTHER function instances, so a cross-process invalidate is impossible from
+ * here; visibility lag is the 5-min collection TTL by design (and the cadence is every 5 min so a
+ * post never appears visibly overdue, R3-F12).
+ */
+import { query, queryRows } from '@lib/db/client';
+import { isDueScheduledPublishAt, isScheduledPublishAtFormat } from './blog-publish-schedule';
+
+export type ScheduledPublishSummary = {
+  /** Count of `status='scheduled'` blog rows examined this run. */
+  scannedScheduled: number;
+  /** Slugs flipped to `published` this run. */
+  published: string[];
+  /** Rows whose `publishedAt` is valid but still in the future. */
+  notYetDue: number;
+  /** Rows whose `publishedAt` is missing/malformed — skipped, not fatal (R3-F2). */
+  skippedMalformed: number;
+};
+
+/**
+ * Publish every due scheduled blog post. `options.now` (ms epoch) is injectable for tests; defaults
+ * to the wall clock. Returns a summary for the function's JSON response / logs.
+ */
+export async function publishDueScheduledPosts(
+  options: { now?: number } = {}
+): Promise<ScheduledPublishSummary> {
+  const now = options.now ?? Date.now();
+
+  const rows = await queryRows<{ slug: string; published_at: string | null }>(
+    "SELECT slug, data->>'publishedAt' AS published_at FROM content WHERE type = 'blog' AND status = 'scheduled'",
+    []
+  );
+
+  const summary: ScheduledPublishSummary = {
+    scannedScheduled: rows.length,
+    published: [],
+    notYetDue: 0,
+    skippedMalformed: 0
+  };
+
+  const publishedAtIso = new Date(now).toISOString();
+
+  for (const row of rows) {
+    const at = row.published_at;
+    if (!isScheduledPublishAtFormat(at)) {
+      summary.skippedMalformed += 1; // missing/garbage publishedAt — skip, never fatal (R3-F2)
+      continue;
+    }
+    if (!isDueScheduledPublishAt(at, now)) {
+      summary.notYetDue += 1;
+      continue;
+    }
+    // Flip status ONLY. The WHERE re-asserts status='scheduled' so a concurrent owner edit that
+    // already moved the row (published/archived/back-to-draft) is not double-flipped.
+    await query(
+      "UPDATE content SET status = 'published', updated_at = $2 WHERE type = 'blog' AND slug = $1 AND status = 'scheduled'",
+      [row.slug, publishedAtIso]
+    );
+    summary.published.push(row.slug);
+  }
+
+  return summary;
+}

--- a/docs/runbooks/scheduled-publish.md
+++ b/docs/runbooks/scheduled-publish.md
@@ -1,0 +1,76 @@
+# Runbook: Scheduled blog publishing
+
+A blog post saved with **status = `scheduled`** and a future `data.publishedAt` goes live
+automatically when its time arrives. A Netlify **scheduled function** flips due posts to
+`published`; the public site shows them within the normal cache window.
+
+## How it works
+
+- **Function:** `app/netlify/functions/publish-scheduled-blog-posts.ts` — in-file
+  `export const config = { schedule: '*/5 * * * *' }` (every 5 minutes, R3-F12), mirroring the
+  existing `process-announcement-email-jobs` cron. Not `netlify.toml` (R1-F14).
+- **Worker:** `app/src/lib/blog-scheduled-publish.ts` → `publishDueScheduledPosts()`. It selects
+  `type='blog' AND status='scheduled'` rows and, for each, flips `status` to `published` **iff**
+  `data.publishedAt` is at or before now per `isDueScheduledPublishAt` — the SAME contract the
+  save-time gate validated against (`app/src/lib/blog-publish-schedule.ts`, R4-F1). So a post that
+  saved cleanly is exactly what fires; there is no second date parser to drift.
+- **UTC contract (R1-F27):** `publishedAt` is stored zone-explicit (ISO-8601 with `Z` or `±HH:MM`).
+  A bare `datetime-local` (no zone) is rejected at save time, so the cron never guesses a zone.
+- **Cadence rationale:** every 5 minutes means the by-design visibility lag never produces a
+  *visibly* overdue post (R3-F12). The 30s function cap is ample — the worker touches only the
+  handful of scheduled rows.
+
+### Resilience — a bad row never blocks the batch (R3-F2)
+
+The due/not-due decision runs in JS over the fetched candidate set, not as a SQL `::timestamptz`
+cast. A row whose `publishedAt` is missing or malformed simply **fails the format guard and is
+skipped** (counted in `skippedMalformed`); it cannot statement-abort the run, so every other due
+post still publishes. The flip's `WHERE` re-asserts `status='scheduled'`, so a row an owner edited
+out of `scheduled` in the same window is never double-flipped.
+
+### Cache (R1-F16)
+
+The cron flips `status` only and does **not** invalidate the SSR collection cache — that cache lives
+in other function instances, so a cross-process invalidate is impossible from the cron. Visibility
+lag is the 5-minute collection TTL (`DEFAULT_COLLECTION_TTL`) by design.
+
+## Verify after deploy (one-line firing check — R2-F30 / R3-F12)
+
+The function runs unauthenticated on Netlify's scheduler; confirm it is registered and firing:
+
+```bash
+# It appears in the deployed function list and the Netlify scheduled-functions logs show a
+# ~5-min cadence with a 200 + JSON summary { scannedScheduled, published, notYetDue, skippedMalformed }.
+npx netlify functions:list | grep publish-scheduled-blog-posts
+```
+
+End-to-end smoke: save a draft as `scheduled` with `publishedAt` ~6 minutes out, wait two cron
+ticks, confirm it became `published` and appears at `/blog/<slug>` (allow the 5-min cache TTL).
+
+## Apply the migration
+
+`016_blog_status_check.sql` adds a **type-scoped** CHECK
+(`type <> 'blog' OR status IN ('draft','published','scheduled','archived')`) — defense-in-depth so
+no path persists an unexpected blog status. It constrains only blog rows; other content types are
+untouched. All blog rows are already `published`, so it validates without rewriting data.
+
+```bash
+# From app/, against the Neon production pooler (apply-migrations.sh echoes the host — confirm it):
+NETLIFY_DATABASE_URL="<neon pooler url>" npm run db:migrate
+```
+
+## Recovery & rollback
+
+- **A stuck/overdue scheduled post** — the owner self-service path is the **editor**: open the post,
+  set status to `Published` (publish now) or `Draft`, and save. The normal save path is the lever;
+  no bespoke recovery UI exists (R3-F12).
+- **`archived` recovery (R4-F12)** — `archived` is reversible: the editor status dropdown offers it
+  and the dashboard has a per-row Restore / Move-to-Draft action. The operator DB-revert below is a
+  **last resort**, not the primary path.
+- **Disable the cron** — remove (or rename) the function file and redeploy; deploy-disable is the
+  rollback. Scheduled rows simply stay `scheduled` (invisible) until the cron returns or an owner
+  publishes them by hand.
+- **DB-revert a scheduled row (last resort):**
+  ```sql
+  UPDATE content SET status = 'draft' WHERE type = 'blog' AND slug = '<slug>' AND status = 'scheduled';
+  ```

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -303,15 +303,20 @@ Blog POSTs must carry `status ∈ {draft, published, scheduled, archived}` **exp
 four-state lifecycle, R2-F11). A missing / empty / whitespace-only / unknown status is rejected with
 `400` "Status must be Draft, Published, Scheduled, or Archived" — checked first, against the raw form
 value, before the endpoint's `status || 'published'` default (which never applies to blog). The admin
-form always submits a status, so owners never see this error. Phase-2 PR4 adds a DB
-`CHECK (status IN ('draft','published','scheduled','archived'))` as defense-in-depth behind this gate
-and behind the exact-match `WHERE status = 'published'` public read filter.
+form always submits a status, so owners never see this error. Migration `016_blog_status_check.sql`
+adds a **type-scoped** DB CHECK
+(`type <> 'blog' OR status IN ('draft','published','scheduled','archived')`) as defense-in-depth
+behind this gate and behind the exact-match `WHERE status = 'published'` public read filter — scoped
+to blog rows so the shared `content.status` column does not couple other content types to the blog
+lifecycle.
 
 - **`published`** — live on every public surface.
 - **`draft`** — exempt from the publish requirements below; invisible publicly.
 - **`scheduled`** — passes the FULL publish gate at SAVE time (R1-F1): it goes live unattended, so it
   must be publish-ready now AND carry a future `data.publishedAt`. Invisible publicly until the
-  every-5-min scheduled-publish cron (PR4) flips it to `published`.
+  every-5-min scheduled-publish cron flips it to `published`
+  (`netlify/functions/publish-scheduled-blog-posts.ts` → `blog-scheduled-publish.ts`; see
+  `docs/runbooks/scheduled-publish.md`).
 - **`archived`** — non-publishing (exempt like a draft) and **reversible**: round-trips back to
   `draft`/`published` through the normal save path (R4-F12), so it is never a one-way trip.
 


### PR DESCRIPTION
## Phase 2 · PR2 — scheduled-publish backend (cron + migration)

Backend for the four-state lifecycle. **Surface-inert** — no UI changes. Builds on PR1 (#92, the lib validation that now accepts `scheduled`/`archived`). Lands the cron **before** any scheduling UI so a post scheduled in a later PR's UI fires on the cron's first run rather than waiting (advisor sequencing).

### What changed
- **`blog-scheduled-publish.ts` (new)** — `publishDueScheduledPosts({ now? })`. Selects `type='blog' AND status='scheduled'`, flips each **due** row to `published` using the SHARED `isDueScheduledPublishAt` predicate — the same contract the save gate validated against (R4-F1, no drift). A missing/malformed `publishedAt` is **skipped, never fatal** (R3-F2): the decision runs in JS over the candidate set, so there's no batch-aborting `::timestamptz` cast. The `UPDATE` re-asserts `status='scheduled'` so a concurrent owner edit isn't double-flipped. Flips status only — **no cross-process cache invalidation** (visibility lag is the 5-min collection TTL, R1-F16).
- **`netlify/functions/publish-scheduled-blog-posts.ts` (new)** — every-5-min scheduled function (R3-F12), in-file `export const config` schedule, mirroring `process-announcement-email-jobs` (R1-F14).
- **`016_blog_status_check.sql` (new)** — **type-scoped** CHECK `type <> 'blog' OR status IN ('draft','published','scheduled','archived')` (R4-F2). `content.status` is shared across all 9 content types (all `published` today, verified vs prod); scoping to blog rows keeps the blog lifecycle from coupling staff/photos/etc. Idempotent (`pg_constraint` guard); validates without rewriting data. **Applied manually** via `npm run db:migrate` after merge+deploy.
- **`docs/runbooks/scheduled-publish.md` (new)** + blog.md references.

### Rollout (post-merge)
1. Merge → deploy (cron registers; scans 0 scheduled rows harmlessly until UI exists).
2. `NETLIFY_DATABASE_URL=<neon pooler> npm run db:migrate` to add the CHECK.
3. One-line firing check per the runbook.

The cron and the constraint are independent — neither breaks without the other, and nothing in the deployed code *requires* the constraint (PR1's validator already only emits the 4 valid statuses; the CHECK is defense-in-depth).

### Gates
lint `--max-warnings=0` clean · typecheck 0 errors · format clean · **388 tests pass** (5 new in `blog-scheduled-publish.test.ts`) · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)