### PR TITLE
feat(blog): Phase-2 PR3 — endpoint lifecycle actions (archive/restore + bulk)

### DIFF
--- a/app/src/pages/api/admin/content.test.ts
+++ b/app/src/pages/api/admin/content.test.ts
@@ -161,6 +161,87 @@ describe('POST /api/admin/content — allowlist + delete + origin + redirect (te
     expect(invalidateMock).toHaveBeenCalledWith('blog');
   });
 
+  it('handles action=archive for blog (status=archived + invalidate)', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'blog', slug: 'old-post', action: 'archive' })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('SET status = $2');
+    expect(queryMock.mock.calls[0][1]).toEqual(['old-post', 'archived']);
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+
+  it('handles action=restore for blog (status=draft — archived is reversible, R4-F12)', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'blog', slug: 'old-post', action: 'restore' })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][1]).toEqual(['old-post', 'draft']);
+  });
+
+  it('rejects archive/restore for a non-blog collection with 400', async () => {
+    const response = await callPost(
+      formRequest({ collection: 'faq', slug: 'q1', action: 'archive' })
+    );
+    expect(response.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('handles action=bulk-archive (UPDATE … slug = ANY, deduped + lowercased)', async () => {
+    const body = new URLSearchParams();
+    body.append('collection', 'blog');
+    body.append('action', 'bulk-archive');
+    body.append('slugs', 'Post-A');
+    body.append('slugs', 'post-b');
+    body.append('slugs', 'post-a'); // dup of the lowercased Post-A
+    const response = await callPost(
+      new Request(ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('UPDATE content');
+    expect(queryMock.mock.calls[0][0]).toContain('slug = ANY($1)');
+    expect(queryMock.mock.calls[0][1]).toEqual([['post-a', 'post-b']]); // deduped + lowercased
+    expect(invalidateMock).toHaveBeenCalledWith('blog');
+  });
+
+  it('handles action=bulk-delete (DELETE … slug = ANY)', async () => {
+    const body = new URLSearchParams();
+    body.append('collection', 'blog');
+    body.append('action', 'bulk-delete');
+    body.append('slugs', 'a');
+    body.append('slugs', 'b');
+    const response = await callPost(
+      new Request(ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(queryMock.mock.calls[0][0]).toContain('DELETE FROM content');
+    expect(queryMock.mock.calls[0][1]).toEqual([['a', 'b']]);
+  });
+
+  it('rejects a bulk action with no valid slugs (400, no query)', async () => {
+    const body = new URLSearchParams();
+    body.append('collection', 'blog');
+    body.append('action', 'bulk-archive');
+    body.append('slugs', 'Bad Slug!'); // fails the charset filter → dropped → empty set
+    const response = await callPost(
+      new Request(ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-allowlisted collection with 400', async () => {
     const response = await callPost(
       formRequest({ collection: 'users', slug: 'x', title: 'x', status: 'draft' })

--- a/app/src/pages/api/admin/content.ts
+++ b/app/src/pages/api/admin/content.ts
@@ -28,6 +28,9 @@ type ContentPayload = {
   redirectTo?: string;
   createOnly?: boolean;
   action?: string;
+  // Selected slugs for a bulk lifecycle action (dashboard checkboxes named `slugs`). Distinct from
+  // the single `slug`; only read by the bulk-archive / bulk-delete branches.
+  slugs?: string[];
 };
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -125,7 +128,9 @@ const parseFormDataPayload = (formData: FormData): ContentPayload => {
     baseDataJson: String(formData.get('baseDataJson') ?? ''),
     redirectTo: String(formData.get('redirectTo') ?? ''),
     createOnly: parseBooleanValue(formData.get('createOnly'), false),
-    action: String(formData.get('action') ?? '')
+    action: String(formData.get('action') ?? ''),
+    // Repeated `slugs` checkbox values for a bulk action.
+    slugs: formData.getAll('slugs').map(value => String(value))
   };
 };
 
@@ -459,6 +464,49 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return responseByFormat(redirectTo, { error: 'Collection is not allowed' }, 400);
   }
 
+  // Bulk lifecycle actions (blog only): archive or delete a SET of posts selected in the dashboard.
+  // Uses the repeated `slugs` field (NOT the single `slug`), so it runs BEFORE the single-slug
+  // validation below. The count-aware irreversibility confirmation (R4-F14) is enforced in the
+  // dashboard UI (data-confirm); the endpoint is the auth + persistence boundary. Origin/CSRF is
+  // already checked above for every POST.
+  if (payload.action === 'bulk-archive' || payload.action === 'bulk-delete') {
+    if (collection !== 'blog') {
+      return responseByFormat(
+        redirectTo,
+        { error: 'Bulk actions are only available for blog posts' },
+        400
+      );
+    }
+    const slugs = [
+      ...new Set(
+        (Array.isArray(payload.slugs) ? payload.slugs : [])
+          .map(value => String(value).trim().toLowerCase())
+          .filter(value => /^[a-z0-9-_]+$/.test(value))
+      )
+    ];
+    if (slugs.length === 0) {
+      return responseByFormat(redirectTo, { error: 'Select at least one post' }, 400);
+    }
+    try {
+      if (payload.action === 'bulk-delete') {
+        await query("DELETE FROM content WHERE type = 'blog' AND slug = ANY($1)", [slugs]);
+      } else {
+        await query(
+          "UPDATE content SET status = 'archived' WHERE type = 'blog' AND slug = ANY($1)",
+          [slugs]
+        );
+      }
+      db.cache.invalidateCollection('blog');
+      return responseByFormat(redirectTo, {
+        success: true,
+        collection: 'blog',
+        count: slugs.length
+      });
+    } catch {
+      return responseByFormat(redirectTo, { error: 'Failed to update posts' }, 500);
+    }
+  }
+
   if (!slug || !/^[a-z0-9-_]+$/.test(slug)) {
     return responseByFormat(
       redirectTo,
@@ -484,6 +532,35 @@ export const POST: APIRoute = async ({ request, locals }) => {
       return responseByFormat(redirectTo, { success: true, collection, slug });
     } catch {
       return responseByFormat(redirectTo, { error: 'Failed to delete content' }, 500);
+    }
+  }
+
+  // Single-post lifecycle quick actions (blog only): `archive` (status='archived') or `restore`
+  // (status='draft' — archived is reversible, R4-F12). The full editor save path also performs
+  // these; these are the dashboard per-row quick actions. `slug` is already shape-validated above.
+  if (payload.action === 'archive' || payload.action === 'restore') {
+    if (collection !== 'blog') {
+      return responseByFormat(
+        redirectTo,
+        { error: 'This action is only available for blog posts' },
+        400
+      );
+    }
+    const nextStatus = payload.action === 'archive' ? 'archived' : 'draft';
+    try {
+      await query("UPDATE content SET status = $2 WHERE type = 'blog' AND slug = $1", [
+        slug,
+        nextStatus
+      ]);
+      db.cache.invalidateCollection('blog');
+      return responseByFormat(redirectTo, {
+        success: true,
+        collection: 'blog',
+        slug,
+        status: nextStatus
+      });
+    } catch {
+      return responseByFormat(redirectTo, { error: 'Failed to update post' }, 500);
     }
   }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -321,6 +321,18 @@ same DELETE as the standalone `DELETE` export (allowlist + slug check + cache
 invalidation) and responds via the shared response helper, so HTML form posts
 receive a `303` redirect (with `redirectTo`) rather than a JSON body.
 
+**Blog lifecycle actions (Phase 2)** — all blog-only, origin/CSRF-checked like every POST,
+cache-invalidated, and `303`/JSON via the shared helper:
+
+- `action=archive` — `UPDATE status='archived'` for the single validated `slug`.
+- `action=restore` — `UPDATE status='draft'` (archived is reversible, R4-F12).
+- `action=bulk-archive` / `action=bulk-delete` — operate on the repeated `slugs` field (dashboard
+  checkboxes), NOT the single `slug`, so they run before the single-slug validation. Slugs are
+  lowercased, charset-filtered (`^[a-z0-9-_]+$`), and deduped; an empty resulting set is a `400`.
+  Archive does `UPDATE status='archived' … WHERE slug = ANY($1)`; delete does
+  `DELETE … WHERE slug = ANY($1)`. The count-aware irreversibility confirmation for bulk-delete
+  (R4-F14) is enforced in the dashboard UI; the endpoint is the authorization + persistence boundary.
+
 **`parseRedirectPath` hardening**: the `redirectTo` validator rejects
 backslash-leading paths (`/\evil.com`) that browsers resolve off-site as
 `//evil.com` — regex `^\/(?![/\\])`. It also rejects any value containing a


### PR DESCRIPTION
## Phase 2 · PR3 — endpoint lifecycle actions

Backend for the dashboard's per-row and bulk lifecycle controls (PR5 wires the UI). Builds on PR1 (#92) + PR2 (#93). `content.ts` POST gains four **blog-only**, origin/CSRF-checked, cache-invalidating actions:

| action | effect |
|---|---|
| `archive` | `UPDATE status='archived'` for the single validated `slug` |
| `restore` | `UPDATE status='draft'` — archived is reversible (R4-F12) |
| `bulk-archive` | `UPDATE status='archived' … WHERE slug = ANY($1)` over selected `slugs` |
| `bulk-delete` | `DELETE … WHERE slug = ANY($1)` over selected `slugs` |

- **Bulk** reads the repeated `slugs` checkbox field (not the single `slug`), so it runs **before** the single-slug validation. Slugs are lowercased, charset-filtered (`^[a-z0-9-_]+$`), and **deduped**; an empty resulting set → `400` (no query).
- All SQL parameterized. Origin/CSRF check (already on every POST) covers these. The count-aware irreversibility confirmation for bulk-delete (R4-F14) is a **UI** concern landing in PR5 — this endpoint is the authorization + persistence boundary.
- Non-blog collections are rejected for these actions (`400`).

### Gates
lint `--max-warnings=0` clean · typecheck 0 errors · format clean · **394 tests pass** (6 new endpoint tests) · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)