### PR TITLE
feat(blog): Phase-2 PR4 — authoring form scheduling UI (scheduled + archived)

### DIFF
--- a/app/src/lib/blog-admin-client.test.ts
+++ b/app/src/lib/blog-admin-client.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { initBlogAdmin } from '@lib/blog-admin-client';
 import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+import {
+  SCHEDULED_PUBLISH_AT_REGEX,
+  localInputToUtcIso,
+  utcIsoToLocalInput
+} from '@lib/blog-publish-schedule';
 
 // vitest's `environment: 'jsdom'` is global (vitest.config.ts:22) — no per-file docblock needed.
 
@@ -10,6 +15,7 @@ interface BuildOptions {
   kind: FormKind;
   status?: string; // initial status select value
   imageValue?: string; // initial image URL value
+  publishedAt?: string; // initial stored UTC publishedAt (edit form)
 }
 
 /**
@@ -39,15 +45,29 @@ function buildDoc(options: BuildOptions, existingSlugs: string[] = []): { doc: D
 
   const status = doc.createElement('select');
   status.setAttribute('name', BLOG_FORM_FIELDS.status);
-  const draftOpt = doc.createElement('option');
-  draftOpt.value = 'draft';
-  draftOpt.textContent = 'Draft';
-  const publishedOpt = doc.createElement('option');
-  publishedOpt.value = 'published';
-  publishedOpt.textContent = 'Published';
-  status.append(draftOpt, publishedOpt);
+  for (const value of ['draft', 'published', 'scheduled', 'archived']) {
+    const opt = doc.createElement('option');
+    opt.value = value;
+    opt.textContent = value;
+    status.appendChild(opt);
+  }
   status.value = options.status ?? 'draft';
   form.appendChild(status);
+
+  // Schedule group — mirrors blog.astro: a visibility wrapper, the visible datetime-local control,
+  // and the hidden persisted UTC field. Initially hidden unless the post is already scheduled.
+  const scheduleGroup = doc.createElement('div');
+  scheduleGroup.setAttribute('data-schedule-group', '');
+  scheduleGroup.hidden = (options.status ?? 'draft') !== 'scheduled';
+  const publishedAtLocal = doc.createElement('input');
+  publishedAtLocal.type = 'datetime-local';
+  publishedAtLocal.setAttribute('name', BLOG_FORM_FIELDS.publishedAtLocal);
+  const publishedAtHidden = doc.createElement('input');
+  publishedAtHidden.type = 'hidden';
+  publishedAtHidden.setAttribute('name', BLOG_FORM_FIELDS.publishedAt);
+  publishedAtHidden.value = options.publishedAt ?? '';
+  scheduleGroup.append(publishedAtLocal, publishedAtHidden);
+  form.appendChild(scheduleGroup);
 
   const date = doc.createElement('input');
   date.type = 'date';
@@ -156,6 +176,107 @@ describe('initBlogAdmin — conditional required', () => {
     const { doc } = buildDoc({ kind: 'edit', status: 'draft', imageValue: '/images/seed.jpg' });
     initBlogAdmin(doc);
     expect(field(doc, BLOG_FORM_FIELDS.imageAlt).required).toBe(true);
+  });
+});
+
+describe('initBlogAdmin — scheduling (R1-F1 / R4-F1 / R2-F19)', () => {
+  const statusSelect = (doc: Document): HTMLSelectElement =>
+    doc.querySelector(`[name="${BLOG_FORM_FIELDS.status}"]`) as HTMLSelectElement;
+  const group = (doc: Document): HTMLElement =>
+    doc.querySelector('[data-schedule-group]') as HTMLElement;
+
+  it('scheduled treats excerpt+date as publish fields AND shows+requires the datetime (lockstep)', () => {
+    const { doc } = buildDoc({ kind: 'edit', status: 'scheduled' });
+    initBlogAdmin(doc);
+    expect(field(doc, BLOG_FORM_FIELDS.excerptRaw).required).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.date).required).toBe(true);
+    // The schedule control is visible AND required together — never hidden-but-required.
+    expect(group(doc).hidden).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.publishedAtLocal).required).toBe(true);
+  });
+
+  it('published/draft/archived hide the datetime AND leave it NOT required (no unsubmittable trap)', () => {
+    for (const status of ['published', 'draft', 'archived']) {
+      const { doc } = buildDoc({ kind: 'edit', status });
+      initBlogAdmin(doc);
+      expect(group(doc).hidden).toBe(true);
+      expect(field(doc, BLOG_FORM_FIELDS.publishedAtLocal).required).toBe(false);
+    }
+  });
+
+  it('toggles the datetime group + required in lockstep when status changes', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'draft' });
+    initBlogAdmin(doc);
+    const status = statusSelect(doc);
+
+    status.value = 'scheduled';
+    status.dispatchEvent(new Event('change'));
+    expect(group(doc).hidden).toBe(false);
+    expect(field(doc, BLOG_FORM_FIELDS.publishedAtLocal).required).toBe(true);
+
+    status.value = 'published';
+    status.dispatchEvent(new Event('change'));
+    expect(group(doc).hidden).toBe(true);
+    expect(field(doc, BLOG_FORM_FIELDS.publishedAtLocal).required).toBe(false);
+  });
+
+  it('on submit, writes the zone-attached UTC-Z instant into the hidden publishedAt (scheduled)', () => {
+    const { doc } = buildDoc({ kind: 'add', status: 'scheduled' });
+    initBlogAdmin(doc);
+    const form = doc.querySelector('form[data-blog-form]') as HTMLFormElement;
+    field(doc, BLOG_FORM_FIELDS.bodyRaw).value = '<p>Body.</p>';
+    const local = '2026-09-15T09:00';
+    field(doc, BLOG_FORM_FIELDS.publishedAtLocal).value = local;
+
+    form.dispatchEvent(new Event('submit', { cancelable: true }));
+
+    const hidden = field(doc, BLOG_FORM_FIELDS.publishedAt).value;
+    expect(hidden).toMatch(SCHEDULED_PUBLISH_AT_REGEX);
+    // Deterministic regardless of the test env's zone: the expected value is computed with the same
+    // offset the client reads from the same local string.
+    expect(hidden).toBe(localInputToUtcIso(local, new Date(local).getTimezoneOffset()));
+  });
+
+  it('pre-fills the visible datetime from the stored UTC publishedAt (edit, scheduled)', () => {
+    const stored = '2026-09-15T13:00:00.000Z';
+    const { doc } = buildDoc({ kind: 'edit', status: 'scheduled', publishedAt: stored });
+    initBlogAdmin(doc);
+    expect(field(doc, BLOG_FORM_FIELDS.publishedAtLocal).value).toBe(
+      utcIsoToLocalInput(stored, new Date(stored).getTimezoneOffset())
+    );
+  });
+
+  it('two-gesture (R2-F19): Published + a FUTURE time prompts confirm; cancel blocks the submit', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { doc } = buildDoc({ kind: 'add', status: 'published' });
+    initBlogAdmin(doc);
+    const form = doc.querySelector('form[data-blog-form]') as HTMLFormElement;
+    field(doc, BLOG_FORM_FIELDS.bodyRaw).value = '<p>Body.</p>';
+    // A future local time sitting in the (hidden) datetime control while status is Published.
+    field(doc, BLOG_FORM_FIELDS.publishedAtLocal).value = '2099-01-01T09:00';
+
+    const ev = new Event('submit', { cancelable: true });
+    form.dispatchEvent(ev);
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(ev.defaultPrevented).toBe(true); // cancelled → submit blocked
+    confirmSpy.mockRestore();
+  });
+
+  it('two-gesture: confirming the dialog lets the Published submit through', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const { doc } = buildDoc({ kind: 'add', status: 'published' });
+    initBlogAdmin(doc);
+    const form = doc.querySelector('form[data-blog-form]') as HTMLFormElement;
+    field(doc, BLOG_FORM_FIELDS.bodyRaw).value = '<p>Body.</p>';
+    field(doc, BLOG_FORM_FIELDS.publishedAtLocal).value = '2099-01-01T09:00';
+
+    const ev = new Event('submit', { cancelable: true });
+    form.dispatchEvent(ev);
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(ev.defaultPrevented).toBe(false);
+    confirmSpy.mockRestore();
   });
 });
 

--- a/app/src/lib/blog-admin-client.ts
+++ b/app/src/lib/blog-admin-client.ts
@@ -9,9 +9,14 @@
  * `initBlogAdmin(doc)` takes an optional Document so jsdom unit tests can pass a constructed one.
  */
 import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+import { localInputToUtcIso, utcIsoToLocalInput } from './blog-publish-schedule';
 
 const COLLISION_MESSAGE =
   'A post with this address already exists — choose a different address or edit the existing post.';
+
+// Statuses that must satisfy the full publish gate at save time (R1-F1): published goes live now,
+// scheduled goes live unattended — both need excerpt + date + body.
+const PUBLISHING_STATUSES = new Set(['published', 'scheduled']);
 
 const slugify = (value: string): string =>
   String(value || '')
@@ -30,6 +35,9 @@ function initConditionalRequired(form: HTMLFormElement): void {
   const date = form.querySelector(`[name="${BLOG_FORM_FIELDS.date}"]`);
   const image = form.querySelector(`[name="${BLOG_FORM_FIELDS.image}"]`);
   const imageAlt = form.querySelector(`[name="${BLOG_FORM_FIELDS.imageAlt}"]`);
+  const publishedAtLocal = form.querySelector(`[name="${BLOG_FORM_FIELDS.publishedAtLocal}"]`);
+  const publishedAtHidden = form.querySelector(`[name="${BLOG_FORM_FIELDS.publishedAt}"]`);
+  const scheduleGroup = form.querySelector('[data-schedule-group]');
 
   const setRequired = (el: Element | null, required: boolean): void => {
     if (
@@ -41,17 +49,41 @@ function initConditionalRequired(form: HTMLFormElement): void {
     }
   };
 
+  const currentStatus = (): string =>
+    statusSelect instanceof HTMLSelectElement ? statusSelect.value : '';
+
   const syncPublishRequired = (): void => {
-    const publishing =
-      statusSelect instanceof HTMLSelectElement && statusSelect.value === 'published';
+    const status = currentStatus();
+    const publishing = PUBLISHING_STATUSES.has(status);
+    const scheduled = status === 'scheduled';
     setRequired(excerpt, publishing);
     setRequired(date, publishing);
+    // Lockstep visibility + `required` for the schedule control: a hidden-but-`required` field makes
+    // the form silently unsubmittable ("an invalid form control is not focusable"). So the datetime
+    // is required ONLY while its group is shown (scheduled). The markup carries no static `required`.
+    setRequired(publishedAtLocal, scheduled);
+    if (scheduleGroup instanceof HTMLElement) {
+      scheduleGroup.hidden = !scheduled;
+    }
   };
 
   const syncImageAltRequired = (): void => {
     const hasImage = image instanceof HTMLInputElement && image.value.trim().length > 0;
     setRequired(imageAlt, hasImage);
   };
+
+  // Pre-fill the visible datetime-local from the stored UTC `publishedAt` (edit form) so the owner
+  // sees the LOCAL time they picked, not raw UTC. Offset is read from the stored instant (DST-aware).
+  if (
+    publishedAtLocal instanceof HTMLInputElement &&
+    publishedAtHidden instanceof HTMLInputElement &&
+    publishedAtLocal.value.trim().length === 0 &&
+    publishedAtHidden.value.trim().length > 0
+  ) {
+    const iso = publishedAtHidden.value.trim();
+    const localValue = utcIsoToLocalInput(iso, new Date(iso).getTimezoneOffset());
+    if (localValue) publishedAtLocal.value = localValue;
+  }
 
   // Body moved from a <textarea> to the TipTap island's hidden field, and `required` does NOT apply
   // to a hidden input — so the publish-time "body required" guard moves to a SUBMIT-TIME check
@@ -64,8 +96,43 @@ function initConditionalRequired(form: HTMLFormElement): void {
       .trim().length === 0;
 
   form.addEventListener('submit', event => {
-    const publishing =
-      statusSelect instanceof HTMLSelectElement && statusSelect.value === 'published';
+    const status = currentStatus();
+    const publishing = PUBLISHING_STATUSES.has(status);
+
+    // Scheduled: write the zone-attached UTC-Z instant into the hidden persisted field from the
+    // owner's local pick. An empty pick stays empty so the server rejects it with the readiness
+    // message rather than this client silently inventing a time.
+    if (
+      status === 'scheduled' &&
+      publishedAtLocal instanceof HTMLInputElement &&
+      publishedAtHidden instanceof HTMLInputElement
+    ) {
+      const local = publishedAtLocal.value.trim();
+      publishedAtHidden.value = local
+        ? localInputToUtcIso(local, new Date(local).getTimezoneOffset())
+        : '';
+    }
+
+    // Two-gesture reconciliation (R2-F19): Published + a FUTURE picked time would silently
+    // publish-now. Make it an explicit, OVERRIDABLE choice (confirm), never a silent surprise.
+    if (
+      status === 'published' &&
+      publishedAtLocal instanceof HTMLInputElement &&
+      publishedAtLocal.value.trim().length > 0
+    ) {
+      const when = new Date(publishedAtLocal.value.trim()).getTime();
+      if (!Number.isNaN(when) && when > Date.now()) {
+        const proceed = window.confirm(
+          'You picked a future date and time, but the status is Published — this publishes the post NOW, not at that time. Choose Scheduled if you want it to go live later. Publish now anyway?'
+        );
+        if (!proceed) {
+          event.preventDefault();
+          return;
+        }
+      }
+    }
+
+    // Body-required guard, now covering scheduled as well as published.
     if (!publishing) return;
     const bodyField = form.querySelector(`[name="${BLOG_FORM_FIELDS.bodyRaw}"]`);
     const value =

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -379,11 +379,23 @@ describe('publishedAt surfacing + round-trip (R1-F17 / R4-F1)', () => {
     expect('publishedAt' in bare).toBe(false);
   });
 
-  it('normalizeBlogData trims publishedAt and drops an empty value', () => {
-    expect(normalizeBlogData({ publishedAt: '  2024-06-15T09:00:00Z  ' }).publishedAt).toBe(
-      '2024-06-15T09:00:00Z'
-    );
-    expect('publishedAt' in normalizeBlogData({ publishedAt: '   ' })).toBe(false);
+  it('normalizeBlogData trims publishedAt and drops an empty value (scheduled save)', () => {
+    expect(
+      normalizeBlogData({ publishedAt: '  2024-06-15T09:00:00Z  ' }, 'scheduled').publishedAt
+    ).toBe('2024-06-15T09:00:00Z');
+    expect('publishedAt' in normalizeBlogData({ publishedAt: '   ' }, 'scheduled')).toBe(false);
+  });
+
+  it('normalizeBlogData drops publishedAt on any non-scheduled save (no stale future instant)', () => {
+    const withAt = { publishedAt: '2024-06-15T09:00:00Z' };
+    // A scheduled→published/draft/archived edit (or a status-less call) must not retain publishedAt:
+    // compareBlogPosts uses it as a same-date tiebreak, so a stale future value mis-orders the index.
+    expect('publishedAt' in normalizeBlogData({ ...withAt }, 'published')).toBe(false);
+    expect('publishedAt' in normalizeBlogData({ ...withAt }, 'draft')).toBe(false);
+    expect('publishedAt' in normalizeBlogData({ ...withAt }, 'archived')).toBe(false);
+    expect('publishedAt' in normalizeBlogData({ ...withAt })).toBe(false);
+    // ...but a scheduled save keeps it.
+    expect(normalizeBlogData({ ...withAt }, 'scheduled').publishedAt).toBe('2024-06-15T09:00:00Z');
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -314,7 +314,10 @@ export function computeReadingTime(body: unknown): number {
 /**
  * Write-path normalizer (called by the endpoint BEFORE validation). Returns a new object.
  */
-export function normalizeBlogData(data: Record<string, unknown>): Record<string, unknown> {
+export function normalizeBlogData(
+  data: Record<string, unknown>,
+  rawStatus?: string
+): Record<string, unknown> {
   const normalized: Record<string, unknown> = { ...data };
 
   // Trim short string fields.
@@ -340,12 +343,19 @@ export function normalizeBlogData(data: Record<string, unknown>): Record<string,
     normalized.excerpt = normalized.excerpt.trim();
   }
 
-  // Delete optional keys whose trimmed value is '' (R2-F20). `publishedAt` is included so an empty
-  // value never persists — only a real scheduled instant is stored (a draft/published save clears it).
+  // Delete optional keys whose trimmed value is '' (R2-F20).
   for (const key of ['image', 'imageAlt', 'seoTitle', 'seoDescription', 'date', 'publishedAt']) {
     if (normalized[key] === '') {
       delete normalized[key];
     }
+  }
+
+  // `publishedAt` is meaningful ONLY for a scheduled save. Drop it for any other status so a
+  // scheduled→published/draft/archived edit cannot leave a stale future instant behind — that
+  // would mis-order the post on the public index, where `compareBlogPosts` uses `publishedAt` DESC
+  // as the same-`date` tiebreak (server-authoritative, independent of the client clearing it).
+  if (typeof rawStatus !== 'string' || rawStatus.trim().toLowerCase() !== 'scheduled') {
+    delete normalized.publishedAt;
   }
 
   // Default author when missing/empty.

--- a/app/src/lib/blog-form-fields.ts
+++ b/app/src/lib/blog-form-fields.ts
@@ -20,6 +20,11 @@ export const BLOG_FORM_FIELDS = {
   action: 'action',
   date: 'data.date',
   author: 'data.author',
+  // Persisted UTC-Z scheduled instant (hidden input, filled by the client on submit from the
+  // zone-less datetime-local pick below). `publishedAtLocal` is the visible wall-clock control and
+  // is NOT a `data.` field, so it is never persisted directly.
+  publishedAt: 'data.publishedAt',
+  publishedAtLocal: 'publishedAtLocal',
   excerptRaw: 'data.excerpt_raw',
   bodyRaw: 'data.body_raw',
   image: 'data.image',

--- a/app/src/lib/blog-publish-schedule.test.ts
+++ b/app/src/lib/blog-publish-schedule.test.ts
@@ -3,7 +3,9 @@ import {
   SCHEDULED_PUBLISH_AT_REGEX,
   isDueScheduledPublishAt,
   isFutureScheduledPublishAt,
-  isScheduledPublishAtFormat
+  isScheduledPublishAtFormat,
+  localInputToUtcIso,
+  utcIsoToLocalInput
 } from './blog-publish-schedule';
 
 // The shared scheduled-publish date contract (R4-F1). The same predicates gate the write-time
@@ -90,5 +92,40 @@ describe('isDueScheduledPublishAt (cron fire predicate)', () => {
     const v = '2024-09-01T12:00:00Z';
     expect(isFutureScheduledPublishAt(v, NOW)).toBe(true);
     expect(isDueScheduledPublishAt(v, NOW)).toBe(false);
+  });
+});
+
+describe('localInputToUtcIso / utcIsoToLocalInput (offset injected — deterministic in CI)', () => {
+  it('converts a wall-clock local pick to UTC-Z for fixed offsets', () => {
+    // offset is the getTimezoneOffset() convention: minutes UTC is AHEAD of local.
+    expect(localInputToUtcIso('2026-06-15T09:00', 240)).toBe('2026-06-15T13:00:00.000Z'); // EDT (UTC-4)
+    expect(localInputToUtcIso('2026-06-15T09:00', 0)).toBe('2026-06-15T09:00:00.000Z'); // UTC
+    expect(localInputToUtcIso('2026-06-15T09:00', -60)).toBe('2026-06-15T08:00:00.000Z'); // CET (UTC+1)
+    expect(localInputToUtcIso('2026-06-15T09:00:30', 240)).toBe('2026-06-15T13:00:30.000Z'); // seconds kept
+  });
+
+  it('always emits UTC-Z (never offset-form) so compareBlogPosts sorts it chronologically', () => {
+    expect(localInputToUtcIso('2026-01-01T00:00', 240)).toMatch(/Z$/);
+  });
+
+  it('renders a stored UTC ISO back to the local wall-clock value', () => {
+    expect(utcIsoToLocalInput('2026-06-15T13:00:00.000Z', 240)).toBe('2026-06-15T09:00'); // EDT
+    expect(utcIsoToLocalInput('2026-06-15T09:00:00.000Z', 0)).toBe('2026-06-15T09:00'); // UTC
+    // Crosses a date boundary going west: 01:00Z at UTC-4 is the previous evening.
+    expect(utcIsoToLocalInput('2026-06-15T01:00:00.000Z', 240)).toBe('2026-06-14T21:00');
+  });
+
+  it('round-trips local → UTC → local for assorted offsets (property)', () => {
+    for (const offset of [-330, -60, 0, 240, 300, 480]) {
+      for (const local of ['2026-06-15T09:00', '2026-12-31T23:30', '2026-01-01T00:00']) {
+        expect(utcIsoToLocalInput(localInputToUtcIso(local, offset), offset)).toBe(local);
+      }
+    }
+  });
+
+  it('returns empty string for malformed input', () => {
+    expect(localInputToUtcIso('not-a-date', 0)).toBe('');
+    expect(localInputToUtcIso('2026-06-15', 0)).toBe(''); // date only, no time
+    expect(utcIsoToLocalInput('garbage', 0)).toBe('');
   });
 });

--- a/app/src/lib/blog-publish-schedule.ts
+++ b/app/src/lib/blog-publish-schedule.ts
@@ -63,3 +63,44 @@ export function isDueScheduledPublishAt(value: unknown, now: number): boolean {
   if (!isScheduledPublishAtFormat(value)) return false;
   return Date.parse(value.trim()) <= now;
 }
+
+const LOCAL_INPUT_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/;
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+/**
+ * Convert a zone-LESS `datetime-local` input value (`YYYY-MM-DDTHH:mm`, the owner's wall-clock
+ * pick) to the stored UTC-`Z` ISO contract. `offsetMinutes` is the target zone's offset in the
+ * `Date.prototype.getTimezoneOffset()` convention (minutes that UTC is AHEAD of local — e.g. EDT
+ * = `240`), passed in so this stays a PURE function the tests can pin deterministically regardless
+ * of the machine's zone (CI runs UTC). Returns `''` for a malformed input.
+ *
+ * Output is uniformly `...Z` (never offset-explicit) because PR1's `compareBlogPosts` orders
+ * `publishedAt` LEXICALLY — `Z`-form strings sort chronologically, offset-form strings do not.
+ */
+export function localInputToUtcIso(local: string, offsetMinutes: number): string {
+  const match = LOCAL_INPUT_REGEX.exec(typeof local === 'string' ? local.trim() : '');
+  if (!match) return '';
+  const [, y, mo, d, h, min, s] = match;
+  const utcMs =
+    Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(min), s ? Number(s) : 0) +
+    offsetMinutes * 60000;
+  return new Date(utcMs).toISOString();
+}
+
+/**
+ * Inverse of {@link localInputToUtcIso}: render a stored UTC ISO instant back to the
+ * `datetime-local` wall-clock value the owner would see in their zone, so the edit form pre-fills
+ * the time they actually picked (NOT raw UTC — `iso.slice(0,16)` would show UTC and is the footgun
+ * this avoids). `offsetMinutes` follows the same `getTimezoneOffset()` convention. Returns `''` for
+ * an unparseable input.
+ */
+export function utcIsoToLocalInput(iso: string, offsetMinutes: number): string {
+  const ms = Date.parse(typeof iso === 'string' ? iso.trim() : '');
+  if (Number.isNaN(ms)) return '';
+  const local = new Date(ms - offsetMinutes * 60000);
+  return (
+    `${local.getUTCFullYear()}-${pad2(local.getUTCMonth() + 1)}-${pad2(local.getUTCDate())}` +
+    `T${pad2(local.getUTCHours())}:${pad2(local.getUTCMinutes())}`
+  );
+}

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -39,18 +39,51 @@ if (savedSlug === 'deleted') {
   savedMessage =
     'Saved. If you set status to Published it is now live at its link. If you saved it as a draft it is NOT yet visible to the public — set status to Published when ready.';
 } else if (savedPost) {
-  savedMessage =
-    savedPost.status === 'published'
-      ? 'Published — now live at its link.'
-      : 'Saved as a draft — NOT yet visible to the public. Set status to Published when ready.';
+  // State-specific saved copy across the four lifecycle states (R1-F26/R4-F12).
+  switch (savedPost.status) {
+    case 'published':
+      savedMessage = 'Published — now live at its link.';
+      break;
+    case 'scheduled':
+      savedMessage =
+        'Scheduled — NOT yet visible. It will publish automatically at the time you set (checked every 5 minutes).';
+      break;
+    case 'archived':
+      savedMessage =
+        'Archived — hidden from the public but kept. Set status to Draft or Published to bring it back.';
+      break;
+    default:
+      savedMessage =
+        'Saved as a draft — NOT yet visible to the public. Set status to Published when ready.';
+  }
 }
 
-const statusBadgeClass = (post: BlogPost): string =>
-  post.status === 'published'
-    ? 'bg-green-50 text-green-800 border border-green-200'
-    : 'bg-amber-50 text-amber-800 border border-amber-200';
-const statusBadgeLabel = (post: BlogPost): string =>
-  post.status === 'published' ? 'Published' : 'Draft';
+// Four-state badge (R1-F26): each lifecycle status reads distinctly so a scheduled/archived post
+// is never mislabelled as a generic "Draft".
+const statusBadgeClass = (post: BlogPost): string => {
+  switch (post.status) {
+    case 'published':
+      return 'bg-green-50 text-green-800 border border-green-200';
+    case 'scheduled':
+      return 'bg-blue-50 text-blue-800 border border-blue-200';
+    case 'archived':
+      return 'bg-stone-100 text-earth-brown border border-stone-300';
+    default:
+      return 'bg-amber-50 text-amber-800 border border-amber-200';
+  }
+};
+const statusBadgeLabel = (post: BlogPost): string => {
+  switch (post.status) {
+    case 'published':
+      return 'Published';
+    case 'scheduled':
+      return 'Scheduled';
+    case 'archived':
+      return 'Archived';
+    default:
+      return 'Draft';
+  }
+};
 
 // `baseDataJson` for an edit form: carry the blog data.* fields reconstructable from `post`,
 // including categories/tags (which have no form input) so the wholesale-replace upsert does not
@@ -170,14 +203,41 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                 >
                   <option value="draft" selected>Draft</option>
                   <option value="published">Published</option>
+                  <option value="scheduled">Scheduled</option>
+                  <option value="archived">Archived</option>
                 </select>
                 <span id="add-status-help" class="mt-1 block text-xs text-earth-brown/70">
-                  Title is always required. To publish you also need an excerpt, a body, and a date;
-                  if you set a featured image you also need an image description. New posts appear
-                  at their link immediately after publishing. The blog index, and edits to
+                  Title is always required. To publish (now or scheduled) you also need an excerpt,
+                  a body, and a date; if you set a featured image you also need an image
+                  description. Scheduled posts go live automatically at the time you pick. New posts
+                  appear at their link immediately after publishing. The blog index, and edits to
                   already-published posts, can take up to 5 minutes to update.
                 </span>
               </label>
+
+              {
+                /* Schedule control — shown only when Status = Scheduled (toggled by the client).
+                  No static `required` (a hidden required field is unsubmittable); the client adds
+                  `required` in lockstep with visibility. The visible value is local wall-clock; the
+                  client writes the UTC-Z instant into the hidden `data.publishedAt` on submit. */
+              }
+              <div class="block text-sm font-medium" data-schedule-group hidden>
+                <label class="block">
+                  Go live on (your local time)
+                  <input
+                    type="datetime-local"
+                    name={BLOG_FORM_FIELDS.publishedAtLocal}
+                    aria-describedby="add-schedule-help"
+                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                  />
+                </label>
+                <input type="hidden" name={BLOG_FORM_FIELDS.publishedAt} value="" />
+                <span id="add-schedule-help" class="mt-1 block text-xs text-earth-brown/70">
+                  Pick a future date and time — the post stays hidden until then, when it publishes
+                  automatically (checked every 5 minutes). Not ready to commit to a time? Set Status
+                  back to Draft instead.
+                </span>
+              </div>
 
               <label class="block text-sm font-medium">
                 Date (required to publish)
@@ -450,7 +510,10 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                         </label>
 
                         {/* PR-2 deviation 1 (R2-F14): status select top-level. */}
-                        {/* PR-2 deviation 6 (R4-F11): selected={post.status} so an untouched edit re-submits the current status (no silent unpublish). */}
+                        {/* R3-F10/R4-F12: each option's `selected` matches the post's EXACT status,
+                            so an untouched edit re-submits the current status. The prior
+                            `selected={post.status !== 'draft'}` collapsed scheduled/archived into
+                            "Published" and would silently publish them on save — fixed here. */}
                         <label class="block text-sm font-medium">
                           Status
                           <select
@@ -458,11 +521,17 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                             aria-describedby={`edit-status-help-${post.slug}`}
                             class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
                           >
-                            <option value="published" selected={post.status !== 'draft'}>
-                              Published
-                            </option>
                             <option value="draft" selected={post.status === 'draft'}>
                               Draft
+                            </option>
+                            <option value="published" selected={post.status === 'published'}>
+                              Published
+                            </option>
+                            <option value="scheduled" selected={post.status === 'scheduled'}>
+                              Scheduled
+                            </option>
+                            <option value="archived" selected={post.status === 'archived'}>
+                              Archived
                             </option>
                           </select>
                           {/* PR-2 R1-F38: staleness helper text linked to the edit-form status control. */}
@@ -470,11 +539,44 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                             id={`edit-status-help-${post.slug}`}
                             class="mt-1 block text-xs text-earth-brown/70"
                           >
-                            New posts appear at their link immediately after publishing. The blog
-                            index, and edits to already-published posts, can take up to 5 minutes to
-                            update.
+                            Set <strong>Archived</strong> to hide a post without deleting it (you
+                            can restore it any time). New posts appear at their link immediately
+                            after publishing. The blog index, and edits to already-published posts,
+                            can take up to 5 minutes to update.
                           </span>
                         </label>
+
+                        {/* Schedule control — shown when this post is (or is being set) Scheduled.
+                            No static `required`; the client toggles visibility + `required` in
+                            lockstep and round-trips the time through the hidden UTC field. */}
+                        <div
+                          class="block text-sm font-medium"
+                          data-schedule-group
+                          hidden={post.status !== 'scheduled'}
+                        >
+                          <label class="block">
+                            Go live on (your local time)
+                            <input
+                              type="datetime-local"
+                              name={BLOG_FORM_FIELDS.publishedAtLocal}
+                              aria-describedby={`edit-schedule-help-${post.slug}`}
+                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                            />
+                          </label>
+                          <input
+                            type="hidden"
+                            name={BLOG_FORM_FIELDS.publishedAt}
+                            value={post.publishedAt ?? ''}
+                          />
+                          <span
+                            id={`edit-schedule-help-${post.slug}`}
+                            class="mt-1 block text-xs text-earth-brown/70"
+                          >
+                            Pick a future date and time — the post stays hidden until then, when it
+                            publishes automatically (checked every 5 minutes). Not ready? Set Status
+                            back to Draft instead.
+                          </span>
+                        </div>
 
                         <label class="block text-sm font-medium">
                           Date (required to publish)

--- a/app/src/pages/api/admin/content.ts
+++ b/app/src/pages/api/admin/content.ts
@@ -575,7 +575,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
   } else if (collection === 'testimonials') {
     data = normalizeTestimonialsData(rawData);
   } else if (collection === 'blog') {
-    data = normalizeBlogData(rawData);
+    // Pass the RAW status so the normalizer can drop a stale `publishedAt` on any non-scheduled
+    // save (it is only meaningful while scheduled).
+    data = normalizeBlogData(rawData, payload.status);
   }
 
   if (collection === 'blog') {

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -327,8 +327,25 @@ zone (`Z` or `±HH:MM`; seconds/millis optional) that is a real instant in the *
 `datetime-local` (no zone) is rejected — the authoring form attaches a zone before saving (UTC
 contract). This format contract lives in `app/src/lib/blog-publish-schedule.ts`
 (`isScheduledPublishAtFormat` / `isFutureScheduledPublishAt` / `isDueScheduledPublishAt`) and is
-imported by BOTH `validateBlogData` (save gate) and the scheduled-publish cron (PR4 fire predicate),
+imported by BOTH `validateBlogData` (save gate) and the scheduled-publish cron (fire predicate),
 so a post that saves cleanly is exactly the set the cron will fire — one contract, no drift.
+
+#### Authoring the lifecycle (`/admin/blog` form + `blog-admin-client.ts`)
+
+The add/edit forms expose all four statuses in the status dropdown. Each edit-form option's
+`selected` matches the post's EXACT status (R3-F10) — the prior `selected={post.status !== 'draft'}`
+would have silently published a scheduled/archived post on an untouched save. Scheduling specifics:
+
+- A **datetime-local** "Go live on (your local time)" control appears only while status = Scheduled;
+  the client toggles its visibility AND its `required` in **lockstep** (a hidden-but-`required`
+  control is silently unsubmittable, so the markup carries no static `required`).
+- On submit the client converts the local pick to UTC-`Z` (`localInputToUtcIso`, offset read from
+  the target date for DST correctness) into a hidden `data.publishedAt`; the edit form pre-fills the
+  visible control back from the stored UTC (`utcIsoToLocalInput`) so the owner sees the local time
+  they picked, not raw UTC. Both helpers are pure (offset injected) and unit-tested.
+- **Two-gesture reconciliation (R2-F19):** choosing Published while a future time is set prompts an
+  overridable `confirm()` ("this publishes now, not at that time") so a future date never silently
+  publishes-now. `archived` is selectable here and round-trips to Draft/Published via a normal save.
 
 #### Author byline (`resolveAuthorByline`) — R4-F9
 


### PR DESCRIPTION
## Phase 2 · PR4 — authoring form scheduling UI

The `/admin/blog` add/edit forms now drive the full four-state lifecycle. Builds on PR1–PR3. This is the owner-facing authoring half; PR5 adds the dashboard list (filters/bulk).

### What changed
- **Status dropdown** gains **Scheduled** + **Archived** on both forms. **FIX R3-F10/R4-F12:** the edit-form options now use `selected={post.status === '<exact>'}`. The prior `selected={post.status !== 'draft'}` collapsed scheduled/archived into "Published" — opening such a post and saving without touching status would **silently publish it**. Now each option matches the exact stored status.
- **Schedule control** — a `datetime-local` "Go live on (your local time)" shown ONLY when status = Scheduled. Visibility and `required` toggle in **lockstep** (no static `required`: a hidden-but-required control is silently unsubmittable — "invalid form control is not focusable").
- **Timezone handling** — on submit the client converts the local pick → UTC-`Z` into a hidden `data.publishedAt`; the edit form pre-fills the visible control back from stored UTC so the owner sees the time they picked, not raw UTC. New **pure, offset-injected** helpers `localInputToUtcIso` / `utcIsoToLocalInput` (deterministic in CI's UTC). UTC-`Z` output is required because PR1's `compareBlogPosts` sorts `publishedAt` **lexically**.
- **Two-gesture reconciliation (R2-F19)** — choosing Published while a future time is set prompts an **overridable** `confirm()` so a future date never silently publishes-now.
- `blog-admin-client.ts`: `PUBLISHING_STATUSES` widens the publish gate (excerpt/date/body) to scheduled. Four-state **badges** + state-specific saved-confirmation copy (R1-F26). Docs: blog.md authoring section.

### Verification note
Per the owner's "merge on CI + code review, skip the live check" decision, this UI is validated by CI + code review, not a live editor check. The timezone conversion and the lockstep `required`/visibility (the two silent-failure footguns flagged in review) are covered by deterministic jsdom + pure-function unit tests.

### Gates
lint `--max-warnings=0` clean · typecheck 0 errors · format clean · **406 tests pass** (12 new) · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scheduled status for blog posts with a "Go live on" date and time picker
  * Added Archived status for comprehensive post lifecycle management
  * Added confirmation prompt when publishing posts with future dates to prevent accidental scheduling
  * Automatic timezone handling for scheduled posts

* **Documentation**
  * Updated admin guide with new scheduling workflow and post lifecycle documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->