### PR TITLE
feat(blog): Phase-3 PR1 — public-discovery lib helpers

### DIFF
--- a/app/src/lib/blog-discovery.test.ts
+++ b/app/src/lib/blog-discovery.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import type { BlogPost } from './blog-content';
+import {
+  BLOG_PAGE_SIZE,
+  CATEGORY_INDEX_THRESHOLD,
+  buildTaxonomy,
+  findTaxonomy,
+  getRelatedPosts,
+  indexableCategories,
+  paginate,
+  taxonomySlug
+} from './blog-discovery';
+
+const makePost = (overrides: Partial<BlogPost> = {}): BlogPost => ({
+  slug: 'a-post',
+  title: 'A Post',
+  date: '2024-01-01',
+  author: 'Spicebush Team',
+  excerpt: 'An excerpt',
+  body: 'Body',
+  status: 'published',
+  ...overrides
+});
+
+describe('taxonomySlug', () => {
+  it('lowercases, hyphenates spaces, strips to [a-z0-9-], collapses + trims hyphens', () => {
+    expect(taxonomySlug('Montessori Method')).toBe('montessori-method');
+    expect(taxonomySlug('  Cosmic   Curriculum!! ')).toBe('cosmic-curriculum');
+    expect(taxonomySlug('ADHD & Neurodiversity')).toBe('adhd-neurodiversity');
+    expect(taxonomySlug('--Edge--')).toBe('edge');
+  });
+
+  it('returns empty for unusable / non-string input', () => {
+    expect(taxonomySlug('')).toBe('');
+    expect(taxonomySlug('!!!')).toBe('');
+    expect(taxonomySlug(undefined)).toBe('');
+    expect(taxonomySlug(123 as unknown)).toBe('');
+  });
+});
+
+describe('buildTaxonomy', () => {
+  it('groups variant spellings under one slug, counts members, sorts by count then slug', () => {
+    const posts = [
+      makePost({ slug: 'a', categories: ['Montessori', 'Gardening'] }),
+      makePost({ slug: 'b', categories: ['montessori'] }), // variant → same slug
+      makePost({ slug: 'c', categories: ['Gardening'] })
+    ];
+    const groups = buildTaxonomy(posts, 'categories');
+    expect(groups.map(g => g.slug)).toEqual(['gardening', 'montessori']); // both count 2 → slug ASC
+    const montessori = groups.find(g => g.slug === 'montessori')!;
+    expect(montessori.count).toBe(2);
+    expect(montessori.posts.map(p => p.slug)).toEqual(['a', 'b']); // input order preserved
+  });
+
+  it('collision rule: display = most frequent raw label, ties alphabetical', () => {
+    const posts = [
+      makePost({ slug: 'a', categories: ['Montessori'] }),
+      makePost({ slug: 'b', categories: ['montessori'] }),
+      makePost({ slug: 'c', categories: ['Montessori'] }) // "Montessori" x2 > "montessori" x1
+    ];
+    expect(buildTaxonomy(posts, 'categories')[0].display).toBe('Montessori');
+  });
+
+  it('counts a post once per slug even if it lists two variants of the same slug', () => {
+    const posts = [makePost({ slug: 'a', tags: ['Play', 'play', 'PLAY'] })];
+    const groups = buildTaxonomy(posts, 'tags');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(1);
+  });
+
+  it('ignores non-array / empty / unusable taxonomy values', () => {
+    const posts = [
+      makePost({ slug: 'a' }),
+      makePost({ slug: 'b', categories: [] }),
+      makePost({ slug: 'c', categories: ['!!!', ''] })
+    ];
+    expect(buildTaxonomy(posts, 'categories')).toEqual([]);
+  });
+});
+
+describe('indexableCategories (R1-F31 ≥2 threshold)', () => {
+  it('keeps only categories with at least the threshold members', () => {
+    expect(CATEGORY_INDEX_THRESHOLD).toBe(2);
+    const posts = [
+      makePost({ slug: 'a', categories: ['Shared', 'Lonely'] }),
+      makePost({ slug: 'b', categories: ['Shared'] })
+    ];
+    const indexable = indexableCategories(posts);
+    expect(indexable.map(c => c.slug)).toEqual(['shared']); // "lonely" has 1 member → excluded
+  });
+});
+
+describe('findTaxonomy', () => {
+  const posts = [
+    makePost({ slug: 'a', categories: ['Cosmic Curriculum'] }),
+    makePost({ slug: 'b', categories: ['Cosmic Curriculum'] })
+  ];
+  it('resolves a group by (canonicalized) slug', () => {
+    const found = findTaxonomy(posts, 'categories', 'Cosmic Curriculum'); // raw label canonicalizes
+    expect(found?.slug).toBe('cosmic-curriculum');
+    expect(found?.count).toBe(2);
+  });
+  it('returns null on a miss or unusable slug', () => {
+    expect(findTaxonomy(posts, 'categories', 'nope')).toBeNull();
+    expect(findTaxonomy(posts, 'categories', '!!!')).toBeNull();
+  });
+});
+
+describe('paginate (R3-F19 / R4-F10)', () => {
+  const make = (n: number): number[] => Array.from({ length: n }, (_, i) => i + 1);
+
+  it('the 6-post corpus is a single page with the default size ≥10 — no prev/next', () => {
+    expect(BLOG_PAGE_SIZE).toBeGreaterThanOrEqual(10);
+    const p = paginate(make(6), 1);
+    expect(p.items).toHaveLength(6);
+    expect(p.totalPages).toBe(1);
+    expect(p.hasPrev).toBe(false);
+    expect(p.hasNext).toBe(false);
+    expect(p.isValidPage).toBe(true);
+  });
+
+  it('splits into pages and reports prev/next at the boundaries', () => {
+    const p1 = paginate(make(25), 1, 10);
+    expect(p1.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(p1.totalPages).toBe(3);
+    expect(p1.hasPrev).toBe(false);
+    expect(p1.hasNext).toBe(true);
+
+    const p3 = paginate(make(25), 3, 10);
+    expect(p3.items).toEqual([21, 22, 23, 24, 25]);
+    expect(p3.hasPrev).toBe(true);
+    expect(p3.hasNext).toBe(false);
+  });
+
+  it('flags an out-of-range or malformed page as invalid (route → 404) but still renders a clamped page', () => {
+    expect(paginate(make(25), 4, 10).isValidPage).toBe(false); // > totalPages
+    expect(paginate(make(25), 0, 10).isValidPage).toBe(false); // < 1
+    expect(paginate(make(25), 1.5, 10).isValidPage).toBe(false); // non-integer
+    expect(paginate(make(25), 4, 10).page).toBe(3); // clamped into range for rendering
+  });
+
+  it('treats an empty list as one empty page', () => {
+    const p = paginate<number>([], 1);
+    expect(p.items).toEqual([]);
+    expect(p.totalPages).toBe(1);
+    expect(p.isValidPage).toBe(true);
+  });
+});
+
+describe('getRelatedPosts', () => {
+  const target = makePost({ slug: 'target', categories: ['Montessori'], tags: ['play'] });
+  const all = [
+    target,
+    makePost({ slug: 'two-overlap', categories: ['Montessori'], tags: ['play'] }), // shared 2
+    makePost({ slug: 'one-overlap', categories: ['Montessori'] }), // shared 1
+    makePost({ slug: 'no-overlap', categories: ['Gardening'] }) // shared 0 → excluded
+  ];
+
+  it('ranks by shared taxonomy count, excludes self and zero-overlap, honors limit', () => {
+    const related = getRelatedPosts(target, all, 3).map(p => p.slug);
+    expect(related).toEqual(['two-overlap', 'one-overlap']); // no-overlap dropped, self excluded
+  });
+
+  it('breaks ties by input (recency) order', () => {
+    const tgt = makePost({ slug: 'target', categories: ['X'] });
+    const newer = makePost({ slug: 'newer', categories: ['X'] });
+    const older = makePost({ slug: 'older', categories: ['X'] });
+    // `all` is recency-sorted (newer before older); both share 1 → tie broken by input order.
+    const related = getRelatedPosts(tgt, [tgt, newer, older]);
+    expect(related.map(p => p.slug)).toEqual(['newer', 'older']);
+  });
+
+  it('a post with no taxonomy of its own has no related posts', () => {
+    expect(getRelatedPosts(makePost({ slug: 't' }), all)).toEqual([]);
+  });
+});

--- a/app/src/lib/blog-discovery.test.ts
+++ b/app/src/lib/blog-discovery.test.ts
@@ -30,9 +30,17 @@ describe('taxonomySlug', () => {
     expect(taxonomySlug('--Edge--')).toBe('edge');
   });
 
-  it('returns empty for unusable / non-string input', () => {
+  it('NFKD-folds accents and fullwidth so they slugify to base Latin', () => {
+    expect(taxonomySlug('Café Montessori')).toBe('cafe-montessori'); // é → e
+    expect(taxonomySlug('Crème')).toBe('creme');
+    expect(taxonomySlug('Ｐｌａｙ')).toBe('play'); // fullwidth → ASCII
+  });
+
+  it('returns empty for unusable / non-string / non-Latin-only input', () => {
     expect(taxonomySlug('')).toBe('');
     expect(taxonomySlug('!!!')).toBe('');
+    expect(taxonomySlug('日本語')).toBe(''); // no Latin-alphanumeric after folding → dropped
+    expect(taxonomySlug('🌱')).toBe('');
     expect(taxonomySlug(undefined)).toBe('');
     expect(taxonomySlug(123 as unknown)).toBe('');
   });
@@ -172,5 +180,21 @@ describe('getRelatedPosts', () => {
 
   it('a post with no taxonomy of its own has no related posts', () => {
     expect(getRelatedPosts(makePost({ slug: 't' }), all)).toEqual([]);
+  });
+
+  it('counts DISTINCT shared keys — duplicate/variant labels do not inflate the overlap score', () => {
+    const tgt = makePost({ slug: 'tgt', categories: ['Montessori'], tags: ['play'] });
+    const distinctTwo = makePost({
+      slug: 'distinct-two',
+      categories: ['Montessori'],
+      tags: ['play']
+    }); // 2 distinct
+    const dupOne = makePost({
+      slug: 'dup-one',
+      categories: ['Montessori', 'montessori', 'MONTESSORI']
+    }); // still 1
+    // distinctTwo (shared 2) must outrank dupOne (shared 1) despite dupOne's three raw entries.
+    const related = getRelatedPosts(tgt, [tgt, distinctTwo, dupOne]).map(p => p.slug);
+    expect(related).toEqual(['distinct-two', 'dup-one']);
   });
 });

--- a/app/src/lib/blog-discovery.ts
+++ b/app/src/lib/blog-discovery.ts
@@ -30,13 +30,19 @@ export type Taxonomy = {
 };
 
 /**
- * Canonical taxonomy slug from a free-text label: lowercase, spaces→hyphens, strip to `[a-z0-9-]`,
- * collapse and trim hyphens. Returns `''` for an unusable label (the caller drops it). Mirrors the
- * testimonials category-token rule so taxonomy slugs are consistent across the site.
+ * Canonical taxonomy slug from a free-text label: NFKD-fold accents/width (so `café` → `cafe`,
+ * fullwidth `Ｐｌａｙ` → `play`), lowercase, spaces→hyphens, strip remaining non-`[a-z0-9-]`, collapse
+ * and trim hyphens. Mirrors the testimonials category-token rule so slugs are consistent site-wide.
+ *
+ * Returns `''` for a label with no Latin-alphanumeric content after folding (e.g. a purely non-Latin
+ * or emoji-only label) — the caller drops it. So "canonicalized on read, never rejected" (R1-F3) holds
+ * for the realistic English/accented-Latin corpus; a label that folds to nothing is the one exception.
  */
 export function taxonomySlug(value: unknown): string {
   if (typeof value !== 'string') return '';
   return value
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip combining diacritics left by NFKD
     .trim()
     .toLowerCase()
     .replace(/\s+/g, '-')
@@ -169,14 +175,21 @@ export function getRelatedPosts(post: BlogPost, all: BlogPost[], limit = 3): Blo
   return all
     .filter(candidate => candidate.slug !== post.slug)
     .map((candidate, index) => {
-      let shared = 0;
+      // Count DISTINCT shared taxonomy keys — dedupe the candidate's own variants/duplicates first,
+      // mirroring buildTaxonomy's per-slug dedup. Counting raw entries would let a post with
+      // duplicate/variant labels (`['Montessori','montessori']`) inflate its overlap score.
+      const candidateKeys = new Set<string>();
       for (const field of ['categories', 'tags'] as const) {
         const values = candidate[field];
         if (!Array.isArray(values)) continue;
         for (const raw of values) {
           const slug = taxonomySlug(raw);
-          if (slug && own.has(`${field}:${slug}`)) shared += 1;
+          if (slug) candidateKeys.add(`${field}:${slug}`);
         }
+      }
+      let shared = 0;
+      for (const key of candidateKeys) {
+        if (own.has(key)) shared += 1;
       }
       return { post: candidate, shared, index };
     })

--- a/app/src/lib/blog-discovery.ts
+++ b/app/src/lib/blog-discovery.ts
@@ -1,0 +1,187 @@
+/**
+ * Public blog discovery helpers (Phase 3): taxonomy (categories/tags) aggregation + canonicalization,
+ * pagination, and related posts. Pure functions over an already-published, already-sorted
+ * `BlogPost[]` (the read path filters status and applies `compareBlogPosts` before calling here), so
+ * this module never touches the DB and is fully unit-testable.
+ *
+ * Taxonomy is CANONICALIZED on read, never rejected (R1-F3): a free-text label is slugified for the
+ * URL and grouped; the display label is chosen deterministically by a collision rule so variant
+ * spellings collapse to one stable group. Category index pages are PATH segments
+ * (`/blog/category/[slug]`), so the slug here is the route segment (R4-F15).
+ */
+import type { BlogPost } from './blog-content';
+
+// A category needs ≥2 published members to be a real, indexable/sitemapped page (R1-F31); below the
+// threshold it is thin content and the route renders `noindex`.
+export const CATEGORY_INDEX_THRESHOLD = 2;
+
+// Page size for the public index (R4-F10): ≥10 so the 6-post corpus never paginates — `/blog`
+// (page 1) surfaces all six post cards and `blog.spec.ts` test 18's `>=6` count holds.
+export const BLOG_PAGE_SIZE = 10;
+
+export type Taxonomy = {
+  /** Canonical URL slug (the `/blog/category/[slug]` route segment). */
+  slug: string;
+  /** Canonical display label (collision rule: most frequent raw label, ties alphabetical). */
+  display: string;
+  /** Published members, preserving the input order (already recency-sorted). */
+  posts: BlogPost[];
+  count: number;
+};
+
+/**
+ * Canonical taxonomy slug from a free-text label: lowercase, spaces→hyphens, strip to `[a-z0-9-]`,
+ * collapse and trim hyphens. Returns `''` for an unusable label (the caller drops it). Mirrors the
+ * testimonials category-token rule so taxonomy slugs are consistent across the site.
+ */
+export function taxonomySlug(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build taxonomy groups for a field (`categories` | `tags`) over published posts. Each label is
+ * slugified and posts sharing a slug are grouped; a post counts once per slug even if it lists two
+ * variants that canonicalize the same. The display label is the most frequent raw label (ties broken
+ * alphabetically) — a stable collision rule. Groups are sorted by descending member count then slug;
+ * each group's members preserve the input order.
+ */
+export function buildTaxonomy(posts: BlogPost[], field: 'categories' | 'tags'): Taxonomy[] {
+  const groups = new Map<string, { posts: BlogPost[]; labelCounts: Map<string, number> }>();
+
+  for (const post of posts) {
+    const values = post[field];
+    if (!Array.isArray(values)) continue;
+    const seenForPost = new Set<string>();
+    for (const raw of values) {
+      const slug = taxonomySlug(raw);
+      if (!slug || seenForPost.has(slug)) continue;
+      seenForPost.add(slug);
+      let group = groups.get(slug);
+      if (!group) {
+        group = { posts: [], labelCounts: new Map() };
+        groups.set(slug, group);
+      }
+      group.posts.push(post);
+      const label = typeof raw === 'string' ? raw.trim() : '';
+      if (label) group.labelCounts.set(label, (group.labelCounts.get(label) ?? 0) + 1);
+    }
+  }
+
+  const result: Taxonomy[] = [];
+  for (const [slug, { posts: members, labelCounts }] of groups) {
+    let display = slug;
+    let best = -1;
+    for (const [label, count] of [...labelCounts].sort((a, b) => a[0].localeCompare(b[0]))) {
+      if (count > best) {
+        best = count;
+        display = label;
+      }
+    }
+    result.push({ slug, display, posts: members, count: members.length });
+  }
+
+  return result.sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug));
+}
+
+/** Categories meeting the indexable threshold (≥2 members) — R1-F31, used for the sitemap/index set. */
+export function indexableCategories(posts: BlogPost[]): Taxonomy[] {
+  return buildTaxonomy(posts, 'categories').filter(c => c.count >= CATEGORY_INDEX_THRESHOLD);
+}
+
+/** Resolve one taxonomy group by slug for the category/tag route; `null` on miss. */
+export function findTaxonomy(
+  posts: BlogPost[],
+  field: 'categories' | 'tags',
+  slug: string
+): Taxonomy | null {
+  const target = taxonomySlug(slug);
+  if (!target) return null;
+  return buildTaxonomy(posts, field).find(t => t.slug === target) ?? null;
+}
+
+export type Pagination<T> = {
+  /** The slice for the resolved page. */
+  items: T[];
+  /** 1-based, clamped to [1, totalPages]. */
+  page: number;
+  /** Always ≥1 (an empty list is one empty page). */
+  totalPages: number;
+  pageSize: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+  /** False when the REQUESTED page was out of range / malformed — the route should 404 (R3-F19). */
+  isValidPage: boolean;
+};
+
+/**
+ * Paginate a list. `requestedPage` is 1-based. An out-of-range or non-integer page is reported via
+ * `isValidPage=false` (the route 404s) while still returning a clamped, renderable page. With the
+ * 6-post corpus and the default size ≥10 there is exactly one page and no prev/next (R3-F19/R4-F10).
+ */
+export function paginate<T>(
+  items: T[],
+  requestedPage: number,
+  pageSize: number = BLOG_PAGE_SIZE
+): Pagination<T> {
+  const size = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : BLOG_PAGE_SIZE;
+  const totalPages = Math.max(1, Math.ceil(items.length / size));
+  const isValidPage =
+    Number.isInteger(requestedPage) && requestedPage >= 1 && requestedPage <= totalPages;
+  const page = isValidPage
+    ? requestedPage
+    : Math.min(Math.max(1, Number.isInteger(requestedPage) ? requestedPage : 1), totalPages);
+  const start = (page - 1) * size;
+  return {
+    items: items.slice(start, start + size),
+    page,
+    totalPages,
+    pageSize: size,
+    hasPrev: page > 1,
+    hasNext: page < totalPages,
+    isValidPage
+  };
+}
+
+/**
+ * Related posts: other published posts sharing the most categories/tags with `post` (excluding
+ * itself), ranked by shared-taxonomy count then the input order (recency). Posts with zero overlap
+ * are excluded; returns up to `limit`. A post with no taxonomy of its own has no related posts.
+ */
+export function getRelatedPosts(post: BlogPost, all: BlogPost[], limit = 3): BlogPost[] {
+  const own = new Set<string>();
+  for (const field of ['categories', 'tags'] as const) {
+    const values = post[field];
+    if (!Array.isArray(values)) continue;
+    for (const raw of values) {
+      const slug = taxonomySlug(raw);
+      if (slug) own.add(`${field}:${slug}`);
+    }
+  }
+  if (own.size === 0) return [];
+
+  return all
+    .filter(candidate => candidate.slug !== post.slug)
+    .map((candidate, index) => {
+      let shared = 0;
+      for (const field of ['categories', 'tags'] as const) {
+        const values = candidate[field];
+        if (!Array.isArray(values)) continue;
+        for (const raw of values) {
+          const slug = taxonomySlug(raw);
+          if (slug && own.has(`${field}:${slug}`)) shared += 1;
+        }
+      }
+      return { post: candidate, shared, index };
+    })
+    .filter(entry => entry.shared > 0)
+    .sort((a, b) => b.shared - a.shared || a.index - b.index)
+    .slice(0, Math.max(0, limit))
+    .map(entry => entry.post);
+}

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -368,6 +368,26 @@ legacy `data.author` string (default `'Spicebush Team'`). The 6 live posts carry
 byte-for-byte (6-byline regression test). Ordering tiebreak: posts sharing a calendar `date` order by
 `data.publishedAt` DESC before the slug tiebreak (R1-F17), a no-op for legacy posts that carry none.
 
+### Public discovery helpers (`blog-discovery.ts`) — Phase 3
+
+Pure functions over the already-published, already-sorted `BlogPost[]`:
+
+- **Taxonomy canonicalization (R1-F3).** `taxonomySlug(label)` slugifies a free-text category/tag
+  (lowercase → hyphenate spaces → strip to `[a-z0-9-]` → collapse/trim hyphens). `buildTaxonomy`
+  groups posts by slug — variant spellings collapse to one group; a post counts once per slug — and
+  picks the display label by a stable **collision rule**: most frequent raw label, ties alphabetical.
+  Taxonomy is canonicalized on read, never rejected.
+- **Category index threshold (R1-F31).** `indexableCategories` keeps categories with
+  `≥ CATEGORY_INDEX_THRESHOLD` (= 2) members; below that a category route renders `noindex` (thin
+  content). Category routes are PATH segments `/blog/category/[slug]` (R4-F15). Tags are a click-filter
+  and `noindex` (R1-F21) — never sitemapped index routes.
+- **Pagination (R3-F19 / R4-F10).** `paginate(items, page, BLOG_PAGE_SIZE)` with `BLOG_PAGE_SIZE` = 10
+  (≥10 so the 6-post corpus is a single page — `/blog` shows all 6). An out-of-range / non-integer
+  page is flagged `isValidPage:false` (the route 404s) while still returning a clamped renderable page;
+  a one-page list reports no prev/next.
+- **Related posts.** `getRelatedPosts(post, all, limit)` ranks other posts by shared category/tag
+  count, then input (recency) order; excludes self and zero-overlap; a post with no taxonomy gets none.
+
 ### Validation rules (`validateBlogData`)
 
 - **Always:** explicit status (checked first); valid slug (`^[a-z0-9-_]{1,100}$` AND not


### PR DESCRIPTION
## Phase 3 · PR1 — public-discovery lib helpers (lib-only)

Pure, unit-tested foundation for Phase 3 (public discovery). **Surface-inert** — nothing imports `blog-discovery.ts` yet; the category/tag/pagination routes and the related/share/bio post-page changes land in PR2/PR3.

### New `blog-discovery.ts`
- **`taxonomySlug` + `buildTaxonomy`** — canonicalize categories/tags on read (R1-F3): variant spellings collapse to one slug, a post counts once per slug, and the display label is chosen by a stable **collision rule** (most frequent raw label, ties alphabetical).
- **`indexableCategories`** — ≥2-member threshold (R1-F31, `CATEGORY_INDEX_THRESHOLD = 2`); category routes are PATH segments `/blog/category/[slug]` (R4-F15), tags are click-filter/`noindex` (R1-F21).
- **`paginate`** — `BLOG_PAGE_SIZE = 10` so the 6-post corpus is a single page (R4-F10); an out-of-range/non-integer page is `isValidPage:false` for the route to 404 (R3-F19); a one-page list reports no prev/next; empty list = one empty page.
- **`getRelatedPosts`** — rank by shared category/tag count then recency; exclude self + zero-overlap; a post with no taxonomy gets none.

### Gates
lint `--max-warnings=0` clean · typecheck 0 errors · format clean · **427 tests pass** (16 new) · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added blog discovery utilities supporting taxonomy organization, pagination, and related posts recommendations
  * Implemented automatic category and tag canonicalization with slug normalization

* **Tests**
  * Added comprehensive test coverage for blog discovery functionality

* **Documentation**
  * Added specifications for blog discovery helpers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->