### PR TITLE
feat(blog): Phase-3 PR1b — site-wide robots three-state (soft noindex,follow)

### DIFF
--- a/app/src/layouts/Layout.astro
+++ b/app/src/layouts/Layout.astro
@@ -16,6 +16,12 @@ export interface Props {
   ogImageAlt?: string;
   ogType?: string;
   publishedTime?: string;
+  /**
+   * Request a soft `noindex, follow` for thin/duplicate routes (paginated lists, tag filters,
+   * below-threshold category pages). Defaults to `'index'`; a hard noindex (site-wide kill switch or
+   * a per-page DB override) still wins. Pages that don't pass this render exactly as before.
+   */
+  robots?: 'index' | 'noindex-follow';
 }
 
 const {
@@ -26,7 +32,8 @@ const {
   ogImage,
   ogImageAlt,
   ogType = 'website',
-  publishedTime
+  publishedTime,
+  robots = 'index'
 } = Astro.props;
 
 const seoMetadata = await resolveSeoMetadata({
@@ -34,7 +41,8 @@ const seoMetadata = await resolveSeoMetadata({
   title,
   description,
   keywords,
-  site: Astro.site
+  site: Astro.site,
+  softNoIndex: robots === 'noindex-follow'
 });
 
 const canonicalURL = seoMetadata.canonicalUrl;
@@ -63,7 +71,7 @@ const preloadLinks = preloadImages ? generatePreloadLinks(CRITICAL_IMAGES) : '';
     <meta name="keywords" content={seoMetadata.keywords} />
     <link rel="canonical" href={canonicalURL} />
     <meta name="robots" content={seoMetadata.robotsContent} />
-    {seoMetadata.noIndex && <meta name="googlebot" content="noindex, nofollow" />}
+    {seoMetadata.googlebotContent && <meta name="googlebot" content={seoMetadata.googlebotContent} />}
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content={ogType} />

--- a/app/src/lib/seo-config.test.ts
+++ b/app/src/lib/seo-config.test.ts
@@ -197,6 +197,27 @@ describe('seo config helpers', () => {
       });
     };
 
+    // The site-wide kill switch — the other (more catastrophic) hard-noindex source besides a
+    // per-page override.
+    const mockKillSwitchConfig = () => {
+      getSettingMock.mockImplementation(async (key: string) => {
+        if (key === SEO_GLOBAL_KEY) {
+          return {
+            defaultTitle: 'Spicebush Montessori School',
+            titleSuffix: 'Spicebush',
+            defaultDescription: 'Default description',
+            defaultKeywords: 'default, keywords',
+            ogImageUrl: '/default-og.png',
+            twitterCard: 'summary_large_image',
+            siteNoIndex: true,
+            robotsDisallowPaths: []
+          };
+        }
+        if (key === SEO_PAGE_OVERRIDES_KEY) return {};
+        return null;
+      });
+    };
+
     const resolve = (overrides: { pathname?: string; softNoIndex?: boolean } = {}) =>
       resolveSeoMetadata({
         pathname: overrides.pathname ?? '/blog/page/2',
@@ -228,6 +249,14 @@ describe('seo config helpers', () => {
     it('INVERSE: a hard per-page noindex BEATS a soft request — stays noindex,nofollow', async () => {
       mockHardOverrideConfig();
       const metadata = await resolve({ pathname: '/blog', softNoIndex: true });
+      expect(metadata.noIndex).toBe(true);
+      expect(metadata.robotsContent).toBe('noindex, nofollow');
+      expect(metadata.googlebotContent).toBe('noindex, nofollow');
+    });
+
+    it('INVERSE: the site-wide kill switch BEATS a soft request — stays noindex,nofollow', async () => {
+      mockKillSwitchConfig();
+      const metadata = await resolve({ softNoIndex: true });
       expect(metadata.noIndex).toBe(true);
       expect(metadata.robotsContent).toBe('noindex, nofollow');
       expect(metadata.googlebotContent).toBe('noindex, nofollow');

--- a/app/src/lib/seo-config.test.ts
+++ b/app/src/lib/seo-config.test.ts
@@ -150,5 +150,99 @@ describe('seo config helpers', () => {
     expect(metadata.ogImageUrl).toBe('https://spicebushmontessori.org/contact-og.png');
     expect(metadata.noIndex).toBe(true);
     expect(metadata.robotsContent).toBe('noindex, nofollow');
+    expect(metadata.googlebotContent).toBe('noindex, nofollow');
+  });
+
+  describe('robots three-state (index / soft noindex,follow / hard noindex,nofollow)', () => {
+    // A plain, indexable global config (no site-wide kill switch) with no per-page overrides — the
+    // realistic shape for blog list / category / tag routes.
+    const mockIndexableConfig = () => {
+      getSettingMock.mockImplementation(async (key: string) => {
+        if (key === SEO_GLOBAL_KEY) {
+          return {
+            defaultTitle: 'Spicebush Montessori School',
+            titleSuffix: 'Spicebush',
+            defaultDescription: 'Default description',
+            defaultKeywords: 'default, keywords',
+            ogImageUrl: '/default-og.png',
+            twitterCard: 'summary_large_image',
+            siteNoIndex: false,
+            robotsDisallowPaths: []
+          };
+        }
+        if (key === SEO_PAGE_OVERRIDES_KEY) return {};
+        return null;
+      });
+    };
+
+    // A per-page DB override that hard-noindexes one path (the other hard source besides siteNoIndex).
+    const mockHardOverrideConfig = () => {
+      getSettingMock.mockImplementation(async (key: string) => {
+        if (key === SEO_GLOBAL_KEY) {
+          return {
+            defaultTitle: 'Spicebush Montessori School',
+            titleSuffix: 'Spicebush',
+            defaultDescription: 'Default description',
+            defaultKeywords: 'default, keywords',
+            ogImageUrl: '/default-og.png',
+            twitterCard: 'summary_large_image',
+            siteNoIndex: false,
+            robotsDisallowPaths: []
+          };
+        }
+        if (key === SEO_PAGE_OVERRIDES_KEY) {
+          return { '/blog': { title: 'Blog', noIndex: true } };
+        }
+        return null;
+      });
+    };
+
+    const resolve = (overrides: { pathname?: string; softNoIndex?: boolean } = {}) =>
+      resolveSeoMetadata({
+        pathname: overrides.pathname ?? '/blog/page/2',
+        title: 'List',
+        description: 'desc',
+        keywords: 'kw',
+        site: 'https://spicebushmontessori.org',
+        softNoIndex: overrides.softNoIndex
+      });
+
+    it('default (no softNoIndex, indexable page) → index,follow and NO googlebot tag', async () => {
+      mockIndexableConfig();
+      const metadata = await resolve();
+      expect(metadata.noIndex).toBe(false);
+      expect(metadata.robotsContent).toBe('index, follow');
+      expect(metadata.googlebotContent).toBeNull();
+    });
+
+    it('softNoIndex on an otherwise-indexable page → soft noindex,follow on BOTH tags', async () => {
+      mockIndexableConfig();
+      const metadata = await resolve({ softNoIndex: true });
+      // `noIndex` reports HARD noindex only, so it stays false for a soft request…
+      expect(metadata.noIndex).toBe(false);
+      // …but the rendered robots/googlebot both carry the crawl-but-don't-index directive.
+      expect(metadata.robotsContent).toBe('noindex, follow');
+      expect(metadata.googlebotContent).toBe('noindex, follow');
+    });
+
+    it('INVERSE: a hard per-page noindex BEATS a soft request — stays noindex,nofollow', async () => {
+      mockHardOverrideConfig();
+      const metadata = await resolve({ pathname: '/blog', softNoIndex: true });
+      expect(metadata.noIndex).toBe(true);
+      expect(metadata.robotsContent).toBe('noindex, nofollow');
+      expect(metadata.googlebotContent).toBe('noindex, nofollow');
+    });
+
+    it('googlebotContent can never disagree with robotsContent', async () => {
+      mockIndexableConfig();
+      for (const softNoIndex of [undefined, true]) {
+        const metadata = await resolve({ softNoIndex });
+        if (metadata.robotsContent.startsWith('noindex')) {
+          expect(metadata.googlebotContent).toBe(metadata.robotsContent);
+        } else {
+          expect(metadata.googlebotContent).toBeNull();
+        }
+      }
+    });
   });
 });

--- a/app/src/lib/seo-config.ts
+++ b/app/src/lib/seo-config.ts
@@ -98,6 +98,13 @@ export type ResolveSeoMetadataInput = {
   description: string;
   keywords: string;
   site?: URL | string;
+  /**
+   * Request a soft `noindex, follow` for this render (thin/duplicate pages such as paginated lists,
+   * tag filters, or below-threshold category pages — R1-F21/R1-F31). A hard noindex (site-wide kill
+   * switch or a per-page DB override) always wins; soft only applies when the page would otherwise be
+   * indexable. Defaults to `false` so every existing caller renders `index, follow` exactly as before.
+   */
+  softNoIndex?: boolean;
 };
 
 export type ResolvedSeoMetadata = {
@@ -107,8 +114,15 @@ export type ResolvedSeoMetadata = {
   canonicalUrl: string;
   ogImageUrl: string;
   twitterCard: TwitterCardType;
+  /** Hard noindex only (site-wide kill switch or per-page DB override) — unchanged meaning. */
   noIndex: boolean;
+  /** `index, follow` | `noindex, follow` (soft) | `noindex, nofollow` (hard). */
   robotsContent: string;
+  /**
+   * The explicit `googlebot` meta value, or `null` when the page is indexable (no tag rendered).
+   * Mirrors `robotsContent` whenever it carries a noindex so the two can never drift.
+   */
+  googlebotContent: string | null;
 };
 
 const asTrimmedString = (value: unknown): string => {
@@ -373,7 +387,8 @@ export const resolveSeoMetadata = async ({
   title,
   description,
   keywords,
-  site
+  site,
+  softNoIndex: requestSoftNoIndex
 }: ResolveSeoMetadataInput): Promise<ResolvedSeoMetadata> => {
   const siteOrigin = resolveSiteOrigin(site);
   const seoSettings = await getSeoSettings(siteOrigin);
@@ -406,7 +421,16 @@ export const resolveSeoMetadata = async ({
     seoSettings.global.ogImageUrl ||
     toAbsoluteUrl(FALLBACK_OG_IMAGE_PATH, siteOrigin);
 
+  // Hard noindex (site-wide kill switch or per-page DB override) keeps its exact prior meaning and is
+  // what `noIndex` reports. Soft noindex is a per-render request for thin/duplicate pages and only
+  // applies when the page is NOT already hard-noindexed — hard always wins.
   const noIndex = seoSettings.global.siteNoIndex || Boolean(override?.noIndex);
+  const softNoIndex = Boolean(requestSoftNoIndex) && !noIndex;
+  const robotsContent = noIndex
+    ? 'noindex, nofollow'
+    : softNoIndex
+      ? 'noindex, follow'
+      : 'index, follow';
 
   return {
     title: resolvedTitle,
@@ -416,7 +440,10 @@ export const resolveSeoMetadata = async ({
     ogImageUrl,
     twitterCard: seoSettings.global.twitterCard,
     noIndex,
-    robotsContent: noIndex ? 'noindex, nofollow' : 'index, follow'
+    robotsContent,
+    // Derived from robotsContent so the googlebot tag can never disagree: rendered only when the page
+    // carries a noindex, omitted (null) when it is indexable.
+    googlebotContent: robotsContent.startsWith('noindex') ? robotsContent : null
   };
 };
 

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -340,7 +340,14 @@ curl -s "$SITE/blog" | grep -E 'name="robots"|googlebot'        # index,follow; 
 #     (added in PR2): robots="noindex, follow" AND googlebot="noindex, follow".
 #   • Hard noindex (site-wide kill switch or a per-page DB override): both tags "noindex, nofollow".
 # INVERSE spot-check — a known hard-noindex NON-blog page must STILL be hard noindex after the
-# refactor (proves googlebotContent didn't weaken hard noindex anywhere site-wide):
+# refactor (proves googlebotContent didn't weaken hard noindex anywhere site-wide).
+# PRECONDITION: this proves something only if the target is genuinely hard-noindex in prod RIGHT NOW.
+# /contact-success was verified hard-noindex (both tags "noindex, nofollow") at PR1b time, but that
+# rests on a per-page override row in the prod SEO config (set in /admin/seo), NOT on committed code —
+# so confirm the row still exists, OR substitute any page you know carries a saved hard-noindex
+# override. Note `grep` prints nothing AND exits 0 on a miss, so empty output ≠ pass: you must SEE
+# both "noindex, nofollow" lines. If the page now renders "index, follow", the override was removed —
+# that's a config drift, not a refactor regression.
 curl -s "$SITE/contact-success" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, nofollow"
 # Soft spot-check (once PR2 routes ship) — a tag filter or page ≥2 must be crawl-but-don't-index:
 curl -s "$SITE/blog/tag/montessori" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, follow"

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -333,6 +333,18 @@ curl -s "$SITE/blog/nurturing-growth-gardening-program" \
 #   - robots = "index, follow"; no <meta name="googlebot" ... noindex> (also check /blog)
 curl -s "$SITE/blog" | grep -E 'name="robots"|googlebot'        # index,follow; no googlebot-noindex
 
+# Robots three-state — Layout now emits index / soft noindex,follow / hard noindex,nofollow via
+# resolveSeoMetadata.googlebotContent (PR1b). Both meta tags always agree.
+#   • Indexable (blog list/post, marketing pages): robots="index, follow", NO googlebot tag.
+#   • Soft thin/dup routes — paginated pages (?/page/N), tag filters, below-threshold categories
+#     (added in PR2): robots="noindex, follow" AND googlebot="noindex, follow".
+#   • Hard noindex (site-wide kill switch or a per-page DB override): both tags "noindex, nofollow".
+# INVERSE spot-check — a known hard-noindex NON-blog page must STILL be hard noindex after the
+# refactor (proves googlebotContent didn't weaken hard noindex anywhere site-wide):
+curl -s "$SITE/contact-success" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, nofollow"
+# Soft spot-check (once PR2 routes ship) — a tag filter or page ≥2 must be crawl-but-don't-index:
+curl -s "$SITE/blog/tag/montessori" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, follow"
+
 # Sitemap + robots (prod origin, exact slashless <loc>, draft-free)
 curl -s "$SITE/sitemap-blog.xml"                                # 200, XML; <loc>$SITE/blog</loc> and <loc>$SITE/blog/<slug></loc>; ≥6 posts; no drafts
 curl -s "$SITE/robots.txt" | grep sitemap-blog                  # Sitemap: $SITE/sitemap-blog.xml

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -381,6 +381,15 @@ Pure functions over the already-published, already-sorted `BlogPost[]`:
   `≥ CATEGORY_INDEX_THRESHOLD` (= 2) members; below that a category route renders `noindex` (thin
   content). Category routes are PATH segments `/blog/category/[slug]` (R4-F15). Tags are a click-filter
   and `noindex` (R1-F21) — never sitemapped index routes.
+- **Robots three-state (`softNoIndex`).** `resolveSeoMetadata` resolves one of three robots states:
+  `index, follow` (default), soft `noindex, follow` (crawl links but don't index — thin/duplicate
+  routes: paginated pages, tag filters, below-threshold categories), or hard `noindex, nofollow`
+  (site-wide kill switch or a per-page DB override). A page opts into soft via the `Layout`
+  `robots="noindex-follow"` prop, which passes `softNoIndex: true`. **Hard always wins** — `softNoIndex`
+  only applies when the page isn't already hard-noindexed, and `ResolvedSeoMetadata.noIndex` keeps its
+  prior meaning (hard only). The rendered `<meta name="googlebot">` is derived from `robotsContent`
+  (`googlebotContent`, rendered only when noindex), so the two tags can never disagree. PR1b adds the
+  machinery as a no-op (no route passes the prop yet); routes opt in in PR2.
 - **Pagination (R3-F19 / R4-F10).** `paginate(items, page, BLOG_PAGE_SIZE)` with `BLOG_PAGE_SIZE` = 10
   (≥10 so the 6-post corpus is a single page — `/blog` shows all 6). An out-of-range / non-integer
   page is flagged `isValidPage:false` (the route 404s) while still returning a clamped renderable page;


### PR DESCRIPTION
## Phase 3 · PR1b — site-wide SEO machinery (the delicate one)

Adds a **third robots state** to the site-wide SEO resolver so that Phase-3's thin/duplicate routes (paginated lists, tag filters, below-threshold category pages — landing in PR2) can be marked **`noindex, follow`** (crawl the links, don't index the page) — without touching how any *existing* page renders.

### The three states
| State | `robots` / `googlebot` | Who |
|---|---|---|
| index | `index, follow` / *(no tag)* | blog list, posts, marketing pages |
| **soft** | `noindex, follow` / `noindex, follow` | paginated pages, tag filters, thin categories (PR2 opts in) |
| hard | `noindex, nofollow` / `noindex, nofollow` | site-wide kill switch or per-page DB override |

**Hard always wins** — `softNoIndex` only applies to a page that isn't already hard-noindexed. `ResolvedSeoMetadata.noIndex` keeps its exact prior meaning (hard only).

### Why this is safe to merge on green CI
- **No-op on every existing page.** No route passes the new `robots` prop in this PR, so `softNoIndex` is always `false`. `<meta name="robots">` (Layout:65) is byte-identical for all non-soft pages, and the new `<meta name="googlebot">` (Layout:66) renders the *same literal* for hard-noindex pages (`googlebotContent='noindex, nofollow'`) and *nothing* for indexable pages (`googlebotContent=null`) — exactly the old `noIndex &&` behavior.
- **The two meta tags can't drift.** `googlebotContent` is derived from `robotsContent` (rendered only when it carries a noindex), not computed independently.
- **`NetlifyAuthLayout.astro` and `coming-soon.astro` deliberately untouched** — they stay on `noIndex &&`, byte-preserved.

### Tests
`seo-config.test.ts` gains a `robots three-state` block:
- default indexable → `index, follow`, no googlebot tag
- soft on indexable → both tags `noindex, follow`
- **INVERSE:** a hard per-page override **beats** a soft request → stays `noindex, nofollow`
- `googlebotContent` can never disagree with `robotsContent`

Plus the existing hard-noindex test now asserts `googlebotContent`.

### Docs
- `deploy.md §9.2`: hard-noindex INVERSE spot-check (`/contact-success`, confirmed genuinely `noindex, nofollow` on prod right now) + soft spot-check for the PR2 routes.
- `blog.md`: documents the `softNoIndex` three-state contract.

### Gates
lint (0 warnings) · typecheck (0 errors) · 433 tests green · prod build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)