### PR TITLE
feat(blog): Phase-3 PR2 — category/tag/pagination discovery routes

### DIFF
--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -59,12 +59,23 @@ test.describe('Blog V1 — public routes + SEO', () => {
 
     await expect(page.locator('h1')).toHaveText('Blog');
 
-    const postLinks = page.locator('a[href^="/blog/"]');
+    // Count only post-DETAIL links (R4-F10 lockstep): PR2 added /blog/category/ and /blog/tag/
+    // discovery chips that also start with /blog/, so exclude them to keep ">=6 posts" honest.
+    const postLinks = page.locator(
+      'a[href^="/blog/"]:not([href*="/category/"]):not([href*="/tag/"]):not([href*="/page/"])'
+    );
     expect(await postLinks.count(), 'at least 6 published posts').toBeGreaterThanOrEqual(6);
     await expect(
       page.locator(`a[href="/blog/${PINNED_SLUG}"]`),
       'pinned gardening post link present'
     ).toHaveCount(1);
+
+    // PR2 discovery surface: post cards carry category (and tag) chip links so visitors can browse
+    // by taxonomy. At least one category chip must render.
+    expect(
+      await page.locator('a[href^="/blog/category/"]').count(),
+      'category discovery chips present'
+    ).toBeGreaterThanOrEqual(1);
 
     // R4-F18 metadata-contrast pin (POSITIVE assertion): the date/byline/excerpt text must compute
     // to text-earth-brown/80 (rgba(46,46,46,0.8), ~6.4:1), NOT a failing token. The byline <p>

--- a/app/src/components/blog/Pagination.astro
+++ b/app/src/components/blog/Pagination.astro
@@ -1,0 +1,71 @@
+---
+import { blogPageHref } from '@lib/blog-routes';
+
+interface Props {
+  page: number;
+  totalPages: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+const { page, totalPages, hasPrev, hasNext } = Astro.props;
+
+// Numbered page links 1..totalPages (page 1 → /blog, n>=2 → /blog/page/n). Small corpus keeps the
+// list short; if it ever grows large this is the seam to add a windowed range.
+const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+---
+
+{
+  totalPages > 1 && (
+    <nav aria-label="Blog pagination" class="mt-12 max-w-3xl">
+      <ul class="flex flex-wrap items-center gap-4">
+        <li>
+          {hasPrev ? (
+            <a
+              rel="prev"
+              href={blogPageHref(page - 1)}
+              class="text-forest-canopy underline hover:text-moss-green"
+            >
+              ← Newer posts
+            </a>
+          ) : (
+            <span aria-disabled="true" class="text-earth-brown/40">
+              ← Newer posts
+            </span>
+          )}
+        </li>
+        {pageNumbers.map(p => (
+          <li>
+            {p === page ? (
+              // Active page: bold + underline is the non-color affordance (R2-F25) alongside
+              // aria-current so it is not signalled by color alone.
+              <span aria-current="page" class="font-bold underline text-earth-brown">
+                {p}
+                <span class="sr-only"> (current page)</span>
+              </span>
+            ) : (
+              <a href={blogPageHref(p)} class="text-forest-canopy underline hover:text-moss-green">
+                {p}
+              </a>
+            )}
+          </li>
+        ))}
+        <li>
+          {hasNext ? (
+            <a
+              rel="next"
+              href={blogPageHref(page + 1)}
+              class="text-forest-canopy underline hover:text-moss-green"
+            >
+              Older posts →
+            </a>
+          ) : (
+            <span aria-disabled="true" class="text-earth-brown/40">
+              Older posts →
+            </span>
+          )}
+        </li>
+      </ul>
+    </nav>
+  )
+}

--- a/app/src/components/blog/PostCardList.astro
+++ b/app/src/components/blog/PostCardList.astro
@@ -1,0 +1,94 @@
+---
+import type { BlogPost } from '@lib/blog-content';
+import { categoryHref, tagHref } from '@lib/blog-routes';
+
+interface Props {
+  posts: BlogPost[];
+}
+
+const { posts } = Astro.props;
+
+const formatDate = (date: string | undefined): string | null => {
+  if (!date) return null;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC'
+  });
+};
+---
+
+<div class="space-y-12 max-w-3xl">
+  {
+    posts.map(post => {
+      const formattedDate = formatDate(post.date);
+      const categories = post.categories ?? [];
+      const tags = post.tags ?? [];
+      return (
+        <article>
+          {post.image && (
+            <img
+              loading="lazy"
+              alt={post.imageAlt}
+              src={post.image}
+              class="w-full rounded-lg mb-4"
+            />
+          )}
+          {/* H2 keeps the heading outline continuous under each page's single H1 (R3-F21). */}
+          <h2 class="text-2xl lg:text-3xl font-heading font-semibold mb-2">
+            <a href={`/blog/${post.slug}`} class="text-forest-canopy hover:text-moss-green">
+              {post.title}
+            </a>
+          </h2>
+          {/* Byline <p>: the ONLY `article p:has(time)` — blog.spec test 18 pins its
+              text-earth-brown/80 contrast token. Do not move <time> out or drop the class. */}
+          <p class="text-sm text-earth-brown/80 mb-3">
+            {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
+            {formattedDate && <span class="mx-2">·</span>}
+            <span>By {post.author}</span>
+          </p>
+          <p class="text-earth-brown/80">{post.excerpt}</p>
+          {(categories.length > 0 || tags.length > 0) && (
+            <div class="mt-3 text-sm">
+              {categories.length > 0 && (
+                <p class="text-earth-brown/80">
+                  <span class="font-semibold">Categories:</span>{' '}
+                  {categories.map((cat, i) => (
+                    <>
+                      {i > 0 && <span aria-hidden="true">, </span>}
+                      <a
+                        href={categoryHref(cat)}
+                        class="text-forest-canopy underline hover:text-moss-green"
+                      >
+                        {cat}
+                      </a>
+                    </>
+                  ))}
+                </p>
+              )}
+              {tags.length > 0 && (
+                <p class="text-earth-brown/80 mt-1">
+                  <span class="font-semibold">Tags:</span>{' '}
+                  {tags.map((tag, i) => (
+                    <>
+                      {i > 0 && <span aria-hidden="true">, </span>}
+                      <a
+                        href={tagHref(tag)}
+                        class="text-forest-canopy underline hover:text-moss-green"
+                      >
+                        {tag}
+                      </a>
+                    </>
+                  ))}
+                </p>
+              )}
+            </div>
+          )}
+        </article>
+      );
+    })
+  }
+</div>

--- a/app/src/lib/blog-routes.test.ts
+++ b/app/src/lib/blog-routes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blogPageHref,
+  categoryHref,
+  isCanonicalTaxonomyParam,
+  parseBlogPageParam,
+  tagHref
+} from './blog-routes';
+
+describe('blogPageHref', () => {
+  it('collapses page 1 (and anything <2) to /blog, never /blog/page/1 (R3-F19)', () => {
+    expect(blogPageHref(1)).toBe('/blog');
+    expect(blogPageHref(0)).toBe('/blog');
+    expect(blogPageHref(-3)).toBe('/blog');
+    expect(blogPageHref(1.5)).toBe('/blog');
+  });
+
+  it('builds /blog/page/[n] for n>=2', () => {
+    expect(blogPageHref(2)).toBe('/blog/page/2');
+    expect(blogPageHref(10)).toBe('/blog/page/10');
+  });
+});
+
+describe('parseBlogPageParam (R3-F19)', () => {
+  it("redirects '1' to /blog (page 1 is the index, never a self-canonical duplicate)", () => {
+    expect(parseBlogPageParam('1')).toEqual({ kind: 'redirect' });
+  });
+
+  it('accepts a clean integer >=2 as a page to render', () => {
+    expect(parseBlogPageParam('2')).toEqual({ kind: 'page', n: 2 });
+    expect(parseBlogPageParam('42')).toEqual({ kind: 'page', n: 42 });
+  });
+
+  it('rejects non-integer, out-of-domain, and leading-zero forms as invalid (404)', () => {
+    for (const bad of ['0', '-1', '1.5', '02', '2a', 'abc', '', ' 2', '2 ', undefined]) {
+      expect(parseBlogPageParam(bad), `"${bad}"`).toEqual({ kind: 'invalid' });
+    }
+  });
+});
+
+describe('categoryHref / tagHref', () => {
+  it('slugify the label into the canonical path segment', () => {
+    expect(categoryHref('Cosmic Curriculum')).toBe('/blog/category/cosmic-curriculum');
+    expect(categoryHref('Special Needs')).toBe('/blog/category/special-needs');
+    expect(tagHref('ADHD')).toBe('/blog/tag/adhd');
+    expect(tagHref('positive behavior support')).toBe('/blog/tag/positive-behavior-support');
+  });
+});
+
+describe('isCanonicalTaxonomyParam', () => {
+  it('accepts an already-canonical slug (what categoryHref/tagHref emit)', () => {
+    expect(isCanonicalTaxonomyParam('education')).toBe(true);
+    expect(isCanonicalTaxonomyParam('cosmic-curriculum')).toBe(true);
+    expect(isCanonicalTaxonomyParam('special-needs')).toBe(true);
+  });
+
+  it('rejects every non-canonical form (so only ONE indexable URL per taxonomy renders)', () => {
+    // Capitalization, spaces, hyphen noise, empty, and injection-shaped params all 404.
+    for (const bad of [
+      'Education', // capital
+      'Cosmic Curriculum', // space
+      'play--time', // double hyphen
+      '-edge-', // leading/trailing hyphen
+      'café', // un-folded accent
+      '', // empty
+      '../admin', // traversal-shaped
+      undefined
+    ]) {
+      expect(isCanonicalTaxonomyParam(bad), `"${bad}"`).toBe(false);
+    }
+  });
+
+  it('round-trips: every href the app emits has a canonical param', () => {
+    for (const label of ['Education', 'Cosmic Curriculum', 'ADHD', 'Special Needs', 'Nature']) {
+      const slug = categoryHref(label).split('/').pop()!;
+      expect(isCanonicalTaxonomyParam(slug), label).toBe(true);
+    }
+  });
+});

--- a/app/src/lib/blog-routes.ts
+++ b/app/src/lib/blog-routes.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure URL/route helpers for the public blog discovery routes (Phase 3 PR2). These build and validate
+ * the `/blog`, `/blog/page/[n]`, `/blog/category/[slug]`, `/blog/tag/[slug]` URL contracts. They are
+ * view-less and fully unit-testable; the `.astro` routes call them to decide 200 / 301 / 404 and to
+ * emit canonical-safe links. Taxonomy slugs go through `taxonomySlug` (blog-discovery) so links here
+ * and groups there agree.
+ */
+import { taxonomySlug } from './blog-discovery';
+
+/**
+ * Href for blog index page `n`. Page 1 is `/blog` itself (NOT `/blog/page/1`, which 301s to `/blog`
+ * — R3-F19), so the two never coexist as duplicate self-canonicals. `n <= 1` collapses to `/blog`.
+ */
+export function blogPageHref(n: number): string {
+  return Number.isInteger(n) && n >= 2 ? `/blog/page/${n}` : '/blog';
+}
+
+export type BlogPageParam =
+  | { kind: 'redirect' } // `/blog/page/1` → 301 `/blog`
+  | { kind: 'page'; n: number } // a real n>=2 page to paginate
+  | { kind: 'invalid' }; // 404 (non-integer, <1, leading zeros, etc.)
+
+/**
+ * Classify the `[n]` param of `/blog/page/[n]`. `'1'` redirects to `/blog` (R3-F19 — page 1 is the
+ * index, never a self-canonical duplicate). A clean integer ≥2 is a page to render (whether it's in
+ * range is `paginate`'s job). Everything else (non-numeric, `'0'`, `'-1'`, `'1.5'`, leading-zero
+ * `'02'`) is invalid → the route 404s.
+ */
+export function parseBlogPageParam(raw: string | undefined): BlogPageParam {
+  if (typeof raw !== 'string' || !/^[1-9][0-9]*$/.test(raw)) return { kind: 'invalid' };
+  const n = Number(raw);
+  if (n === 1) return { kind: 'redirect' };
+  return { kind: 'page', n };
+}
+
+/** Canonical href for a category index page from a free-text label. */
+export function categoryHref(label: string): string {
+  return `/blog/category/${taxonomySlug(label)}`;
+}
+
+/** Canonical href for a tag filter page from a free-text label. */
+export function tagHref(label: string): string {
+  return `/blog/tag/${taxonomySlug(label)}`;
+}
+
+/**
+ * True only when `raw` is ALREADY the canonical taxonomy slug — i.e. the URL the route should serve.
+ * `taxonomySlug` is idempotent (its output is lowercase `[a-z0-9-]`, collapsed and trimmed), so a
+ * value equal to its own slug is canonical, and a non-canonical form (`Montessori`, `play--time`,
+ * `-edge-`) is not. The category/tag routes 404 any non-canonical param, so there is exactly ONE
+ * indexable URL per taxonomy and its self-referential canonical is always correct — no duplicate
+ * content from capitalization or hyphen noise. Links built via `categoryHref`/`tagHref` always pass.
+ */
+export function isCanonicalTaxonomyParam(raw: string | undefined): boolean {
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  return taxonomySlug(raw) === raw;
+}

--- a/app/src/pages/blog.astro
+++ b/app/src/pages/blog.astro
@@ -2,21 +2,17 @@
 import Layout from '@layouts/Layout.astro';
 import Header from '@components/Header.astro';
 import Footer from '@components/Footer.astro';
+import PostCardList from '@components/blog/PostCardList.astro';
+import Pagination from '@components/blog/Pagination.astro';
 import { getPublishedPosts } from '@lib/blog-content';
+import { paginate } from '@lib/blog-discovery';
 
 const posts = await getPublishedPosts();
 
-const formatDate = (date: string | undefined): string | null => {
-  if (!date) return null;
-  const parsed = new Date(date);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'UTC'
-  });
-};
+// `/blog` is page 1 of the paginated index. With the pinned page size (>=10) the 6-post corpus is a
+// single page, so all six cards show here and no prev/next renders — the `/blog/page/[n]` route only
+// matters once the corpus outgrows one page (R3-F19 / R4-F10).
+const pagination = paginate(posts, 1);
 ---
 
 <Layout title="Blog">
@@ -34,7 +30,7 @@ const formatDate = (date: string | undefined): string | null => {
             We're growing new stories. Check back soon for news, reflections, and updates from the
             Spicebush Montessori community.
           </p>
-          <h3 class="text-xl font-heading font-semibold text-earth-brown mb-3">In the meantime</h3>
+          <h2 class="text-xl font-heading font-semibold text-earth-brown mb-3">In the meantime</h2>
           <p class="text-earth-brown/80">
             Have a question or want to learn more about our school?{' '}
             <a href="/contact" class="text-forest-canopy underline hover:text-moss-green">
@@ -44,34 +40,15 @@ const formatDate = (date: string | undefined): string | null => {
           </p>
         </div>
       ) : (
-        <div class="space-y-12 max-w-3xl">
-          {posts.map(post => {
-            const formattedDate = formatDate(post.date);
-            return (
-              <article>
-                {post.image && (
-                  <img
-                    loading="lazy"
-                    alt={post.imageAlt}
-                    src={post.image}
-                    class="w-full rounded-lg mb-4"
-                  />
-                )}
-                <h2 class="text-2xl lg:text-3xl font-heading font-semibold mb-2">
-                  <a href={`/blog/${post.slug}`} class="text-forest-canopy hover:text-moss-green">
-                    {post.title}
-                  </a>
-                </h2>
-                <p class="text-sm text-earth-brown/80 mb-3">
-                  {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
-                  {formattedDate && <span class="mx-2">·</span>}
-                  <span>By {post.author}</span>
-                </p>
-                <p class="text-earth-brown/80">{post.excerpt}</p>
-              </article>
-            );
-          })}
-        </div>
+        <>
+          <PostCardList posts={pagination.items} />
+          <Pagination
+            page={pagination.page}
+            totalPages={pagination.totalPages}
+            hasPrev={pagination.hasPrev}
+            hasNext={pagination.hasNext}
+          />
+        </>
       )
     }
   </main>

--- a/app/src/pages/blog/category/[slug].astro
+++ b/app/src/pages/blog/category/[slug].astro
@@ -1,0 +1,52 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
+import PostCardList from '@components/blog/PostCardList.astro';
+import { getPublishedPosts } from '@lib/blog-content';
+import { CATEGORY_INDEX_THRESHOLD, findTaxonomy } from '@lib/blog-discovery';
+import { isCanonicalTaxonomyParam } from '@lib/blog-routes';
+
+// Only the already-canonical slug renders, so the route's self-referential canonical is always
+// correct and there is exactly one indexable URL per category (R4-F15). A capital, spaced, or
+// hyphen-noisy param 404s rather than serving a duplicate.
+const slug = Astro.params.slug;
+if (!isCanonicalTaxonomyParam(slug)) {
+  return new Response(null, { status: 404 });
+}
+
+const posts = await getPublishedPosts();
+const group = findTaxonomy(posts, 'categories', slug as string);
+if (!group) {
+  return new Response(null, { status: 404 });
+}
+
+// A category with fewer than the threshold members is thin content: render it (so its in-bound links
+// don't 404) but `noindex, follow` so it is not indexed or sitemapped (R1-F31). The `follow` keeps
+// link equity flowing to the posts.
+const isIndexable = group.count >= CATEGORY_INDEX_THRESHOLD;
+const postLabel = group.count === 1 ? 'post' : 'posts';
+---
+
+<Layout
+  title={`${group.display} — Blog Category`}
+  description={`Spicebush Montessori blog posts in the ${group.display} category.`}
+  robots={isIndexable ? 'index' : 'noindex-follow'}
+>
+  <Header />
+
+  <main id="main-content" class="container mx-auto px-4 py-12">
+    <p class="text-sm mb-4">
+      <a href="/blog" class="text-forest-canopy underline hover:text-moss-green">← All posts</a>
+    </p>
+    <h1 class="text-4xl lg:text-5xl font-heading font-bold text-earth-brown mb-2 tracking-tight">
+      Category: {group.display}
+    </h1>
+    {/* In-flow count (not an aria-live region — this is a full-nav route, not a client filter). */}
+    <p class="text-earth-brown/80 mb-10">{group.count} {postLabel}</p>
+
+    <PostCardList posts={group.posts} />
+  </main>
+
+  <Footer />
+</Layout>

--- a/app/src/pages/blog/page/[n].astro
+++ b/app/src/pages/blog/page/[n].astro
@@ -1,0 +1,50 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
+import PostCardList from '@components/blog/PostCardList.astro';
+import Pagination from '@components/blog/Pagination.astro';
+import { getPublishedPosts } from '@lib/blog-content';
+import { paginate } from '@lib/blog-discovery';
+import { parseBlogPageParam } from '@lib/blog-routes';
+
+// `/blog/page/1` 301s to `/blog` (page 1 is the index, never a self-canonical duplicate — R3-F19);
+// a non-integer / out-of-domain `[n]` 404s before any DB read.
+const parsed = parseBlogPageParam(Astro.params.n);
+if (parsed.kind === 'redirect') {
+  return Astro.redirect('/blog', 301);
+}
+if (parsed.kind === 'invalid') {
+  return new Response(null, { status: 404 });
+}
+
+const posts = await getPublishedPosts();
+const pagination = paginate(posts, parsed.n);
+
+// An out-of-range page (e.g. `/blog/page/9` on a one-page corpus) 404s — no thin/empty page that
+// would self-canonical to a non-existent slice.
+if (!pagination.isValidPage) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<Layout title={`Blog — Page ${pagination.page}`}>
+  <Header />
+
+  <main id="main-content" class="container mx-auto px-4 py-12">
+    <h1 class="text-4xl lg:text-5xl font-heading font-bold text-earth-brown mb-2 tracking-tight">
+      Blog
+    </h1>
+    <p class="text-earth-brown/80 mb-10">Page {pagination.page} of {pagination.totalPages}</p>
+
+    <PostCardList posts={pagination.items} />
+    <Pagination
+      page={pagination.page}
+      totalPages={pagination.totalPages}
+      hasPrev={pagination.hasPrev}
+      hasNext={pagination.hasNext}
+    />
+  </main>
+
+  <Footer />
+</Layout>

--- a/app/src/pages/blog/tag/[slug].astro
+++ b/app/src/pages/blog/tag/[slug].astro
@@ -1,0 +1,50 @@
+---
+import Layout from '@layouts/Layout.astro';
+import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
+import PostCardList from '@components/blog/PostCardList.astro';
+import { getPublishedPosts } from '@lib/blog-content';
+import { findTaxonomy } from '@lib/blog-discovery';
+import { isCanonicalTaxonomyParam } from '@lib/blog-routes';
+
+// Same canonical-param guard as categories: only the canonical slug renders.
+const slug = Astro.params.slug;
+if (!isCanonicalTaxonomyParam(slug)) {
+  return new Response(null, { status: 404 });
+}
+
+const posts = await getPublishedPosts();
+const group = findTaxonomy(posts, 'tags', slug as string);
+if (!group) {
+  return new Response(null, { status: 404 });
+}
+
+// Tags are a discovery CONVENIENCE, never indexable: every tag page is `noindex, follow` and is
+// excluded from the sitemap (R1-F21). They self-canonical so the noindex page is unambiguous.
+const postLabel = group.count === 1 ? 'post' : 'posts';
+---
+
+<Layout
+  title={`${group.display} — Blog Tag`}
+  description={`Spicebush Montessori blog posts tagged ${group.display}.`}
+  robots="noindex-follow"
+>
+  <Header />
+
+  <main id="main-content" class="container mx-auto px-4 py-12">
+    <p class="text-sm mb-4">
+      <a href="/blog" class="text-forest-canopy underline hover:text-moss-green">← All posts</a>
+    </p>
+    <h1 class="text-4xl lg:text-5xl font-heading font-bold text-earth-brown mb-2 tracking-tight">
+      Tag: {group.display}
+    </h1>
+    {
+      /* In-flow count read in document order by assistive tech (no client filter → no aria-live). */
+    }
+    <p class="text-earth-brown/80 mb-10">{group.count} {postLabel}</p>
+
+    <PostCardList posts={group.posts} />
+  </main>
+
+  <Footer />
+</Layout>

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -349,8 +349,19 @@ curl -s "$SITE/blog" | grep -E 'name="robots"|googlebot'        # index,follow; 
 # both "noindex, nofollow" lines. If the page now renders "index, follow", the override was removed —
 # that's a config drift, not a refactor regression.
 curl -s "$SITE/contact-success" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, nofollow"
-# Soft spot-check (once PR2 routes ship) — a tag filter or page ≥2 must be crawl-but-don't-index:
-curl -s "$SITE/blog/tag/montessori" | grep -E 'name="robots"|googlebot'  # BOTH "noindex, follow"
+
+# PR2 discovery routes (status + robots + self-canonical). Slugs below are REAL live-corpus values
+# (categories: Education×3, Philosophy/Programs/Nature×2 = indexable; Values/Inclusion/News×1 = soft;
+# tags are ALWAYS soft). taxonomySlug lowercases + hyphenates, so the URL is the canonical slug.
+curl -sI "$SITE/blog/category/education"                         # 200 (indexable, ≥2 members)
+curl -s  "$SITE/blog/category/education" | grep -E 'name="robots"|googlebot|rel="canonical"'
+#   → robots="index, follow", NO googlebot tag, canonical = $SITE/blog/category/education (SELF, not /blog)
+curl -s  "$SITE/blog/category/values"   | grep -E 'name="robots"|googlebot'  # BOTH "noindex, follow" (1 member → soft)
+curl -s  "$SITE/blog/tag/inclusion"     | grep -E 'name="robots"|googlebot'  # BOTH "noindex, follow" (tags always soft)
+curl -sI "$SITE/blog/category/Education"                         # 404 (capital → non-canonical param, no dup content)
+curl -sI "$SITE/blog/page/1"                                     # 301 → /blog (page 1 is the index)
+curl -sI "$SITE/blog/page/9"                                     # 404 (out of range on the 1-page corpus)
+curl -sI "$SITE/blog/page/abc"                                   # 404 (non-integer param)
 
 # Sitemap + robots (prod origin, exact slashless <loc>, draft-free)
 curl -s "$SITE/sitemap-blog.xml"                                # 200, XML; <loc>$SITE/blog</loc> and <loc>$SITE/blog/<slug></loc>; ≥6 posts; no drafts

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -41,23 +41,23 @@ PR1) — nothing ever read or wrote it.
 
 ### Row shape for a blog post
 
-| Column / JSONB key | Value |
-|---|---|
-| `type` | `'blog'` |
-| `slug` | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI |
-| `title` (column) | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`) |
-| `status` | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish |
-| `data.date` | `'YYYY-MM-DD'` string — display and sort date |
-| `data.author` | string, default `'Spicebush Team'` |
-| `data.excerpt` | string, ≤ 1,000 chars, trimmed |
-| `data.body` | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML |
-| `data.image` | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)` |
-| `data.imageAlt` | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word |
-| `data.seoTitle` | optional per-post `<title>` / OG override |
-| `data.seoDescription` | optional per-post meta-description / OG override |
-| `data.categories`, `data.tags` | legacy import keys, carried **opaquely** by the generic `baseDataJson` edit passthrough; no blog code reads, validates, or reshapes them |
-| `author_email` | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator) |
-| `created_at` / `updated_at` | imported rows use `{date}T12:00:00Z`; auto-managed otherwise |
+| Column / JSONB key             | Value                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                         | `'blog'`                                                                                                                                                                                                                                                                                                                                           |
+| `slug`                         | URL slug, matches `^[a-z0-9-_]{1,100}$`; must NOT match `^\d{4}-\d{2}-\d{2}-` (that prefix shape is reserved for the legacy-redirect namespace); immutable after creation in the admin UI                                                                                                                                                          |
+| `title` (column)               | Post title, ≤ 300 chars. Overrides `data.title` on read (via `toContentEntry`)                                                                                                                                                                                                                                                                     |
+| `status`                       | `'published'` or `'draft'` — the entire draft/published representation. Blog POSTs must carry an **explicit** status; a missing/empty value is a 400, never a silent publish                                                                                                                                                                       |
+| `data.date`                    | `'YYYY-MM-DD'` string — display and sort date                                                                                                                                                                                                                                                                                                      |
+| `data.author`                  | string, default `'Spicebush Team'`                                                                                                                                                                                                                                                                                                                 |
+| `data.excerpt`                 | string, ≤ 1,000 chars, trimmed                                                                                                                                                                                                                                                                                                                     |
+| `data.body`                    | raw **Markdown** string, ≤ 200,000 chars (~200 KB), trimmed of leading/trailing whitespace; never HTML                                                                                                                                                                                                                                             |
+| `data.image`                   | optional featured-image URL; must be site-relative or HTTPS absolute, matching `^(\/(?![/\\])\|https:\/\/)`                                                                                                                                                                                                                                        |
+| `data.imageAlt`                | alt text; required when `image` is set and status is `published`; must be ≥ 6 chars, not filename-like, not a generic word                                                                                                                                                                                                                         |
+| `data.seoTitle`                | optional per-post `<title>` / OG override                                                                                                                                                                                                                                                                                                          |
+| `data.seoDescription`          | optional per-post meta-description / OG override                                                                                                                                                                                                                                                                                                   |
+| `data.categories`, `data.tags` | string arrays, carried losslessly through the edit passthrough (never mutated on write — R1-F12). The Phase-3 public discovery layer (`blog-discovery.ts`) **reads** them, canonicalizing each label to a slug on read for the `/blog/category/[slug]` + `/blog/tag/[slug]` routes and related-posts ranking; the stored values are never reshaped |
+| `author_email`                 | set automatically to the admin's session email on save; `NULL` on the imported legacy rows (rollback discriminator)                                                                                                                                                                                                                                |
+| `created_at` / `updated_at`    | imported rows use `{date}T12:00:00Z`; auto-managed otherwise                                                                                                                                                                                                                                                                                       |
 
 ### Empty-string semantics
 
@@ -105,7 +105,7 @@ seed-created blog rows.
 Migration 015 **reconciles then imports**, all in one transaction:
 
 1. **Reconcile** — `DELETE` the seed-pipeline rows (targets only `author_email =
-   'seed@spicebushmontessori.org'` AND date-prefixed slugs).
+'seed@spicebushmontessori.org'` AND date-prefixed slugs).
 2. **Import** — six `INSERT … ON CONFLICT (type, slug) DO NOTHING`, using the **clean** slugs (file
    name with the date prefix stripped, or the explicit frontmatter `slug`), `author_email = NULL`,
    and `created_at`/`updated_at` of `{date}T12:00:00Z`.
@@ -121,12 +121,36 @@ Markdown remains recoverable via git history.
 
 ## Public Routes
 
-| Route | Description |
-|-------|-------------|
-| `/blog` | Blog index — vertical list of published posts (featured image, title link, date, author, excerpt). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
-| `/blog/[slug]` | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro` |
-| `/resources/blog` | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro` |
-| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro` |
+| Route                    | Description                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/blog`                  | Blog index = **page 1** of the paginated list. Published-post cards (featured image, title link, date, author, excerpt, category/tag chips). Friendly branded empty state at HTTP 200 when no posts. File: `app/src/pages/blog.astro` |
+| `/blog/page/[n]`         | Pagination for **n ≥ 2** only; `/blog/page/1` `301`s to `/blog`; an out-of-range or non-integer `[n]` `404`s. Each `n ≥ 2` self-canonicals and is indexable. File: `app/src/pages/blog/page/[n].astro`                                |
+| `/blog/category/[slug]`  | Category index (PATH segment, never query params — R4-F15). Indexable at **≥2 members** (`CATEGORY_INDEX_THRESHOLD`); below that, `noindex, follow` (thin content). Self-canonical. File: `app/src/pages/blog/category/[slug].astro`  |
+| `/blog/tag/[slug]`       | Tag click-filter — **always `noindex, follow`** and excluded from the sitemap (R1-F21). Self-canonical. File: `app/src/pages/blog/tag/[slug].astro`                                                                                   |
+| `/blog/[slug]`           | Individual post page — SSR, sanitized body. File: `app/src/pages/blog/[slug].astro`                                                                                                                                                   |
+| `/resources/blog`        | 301 redirect to `/blog`. File: `app/src/pages/resources/blog.astro`                                                                                                                                                                   |
+| `/resources/blog/[slug]` | Trivial 301 redirect to `/blog/[slug]`. File: `app/src/pages/resources/blog/[slug].astro`                                                                                                                                             |
+
+### Discovery route behavior (Phase 3 PR2)
+
+- **Canonical-param guard.** Category/tag routes render only when the `[slug]` is ALREADY the
+  canonical taxonomy slug (`isCanonicalTaxonomyParam` — `taxonomySlug(raw) === raw`, blog-routes.ts).
+  A capital, spaced, or hyphen-noisy param (`/blog/category/Education`) `404`s rather than serving a
+  duplicate, so there is exactly ONE indexable URL per taxonomy and its self-referential canonical
+  (built path-only by `resolveSeoMetadata`) is always correct.
+- **Pagination param.** `parseBlogPageParam` classifies `[n]`: `'1'` → `301 /blog`; a clean integer
+  `≥2` → render (range checked by `paginate.isValidPage`, else `404`); everything else (non-integer,
+  `'0'`, leading-zero `'02'`) → `404`. `blogPageHref(n)` collapses page 1 to `/blog`.
+- **Soft noindex** is driven by the Layout `robots="noindex-follow"` prop (PR1b machinery): tag pages
+  always; category pages only below the ≥2 threshold. Indexable pages pass no prop (`index, follow`).
+- **a11y (R2-F25).** `Pagination.astro` is a `<nav aria-label="Blog pagination">` of real anchors with
+  `aria-current="page"` + bold/underline (non-color affordance) on the active page and `aria-disabled`
+  prev/next at the boundaries. Taxonomy/count text is rendered in document order (no `aria-live` — these
+  are full-nav routes, not client filters, so a live region would be a no-op).
+- **Heading outline (R3-F21).** Each route has a single `<h1>`; `PostCardList` cards use `<h2>` titles
+  — no skipped levels.
+- **Shared components.** `app/src/components/blog/PostCardList.astro` (cards + chips) and
+  `Pagination.astro` are reused by `/blog`, `/blog/page/[n]`, and the category/tag routes.
 
 ### Post page behavior
 
@@ -146,10 +170,10 @@ real fixes the previously-broken link that 301'd to `/contact`.
 
 ## Admin Routes
 
-| Route | Description |
-|-------|-------------|
-| `/admin/blog` | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
-| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts` |
+| Route                     | Description                                                                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/admin/blog`             | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
+| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts`                       |
 
 The admin page is a structural clone of `app/src/pages/admin/faq.astro` (AdminLayout wrapper,
 `?saved=` / `?error=` flash params, `<details>` add-form + collapsible per-item edit forms). A link
@@ -277,25 +301,25 @@ The blog uses the existing generic content endpoint `POST /api/admin/content` (w
 enter the request path of all existing admin collections — a regression test confirms an existing
 collection still saves and deletes (including the header-absent fail-open case).
 
-| Change | Behavior |
-|---|---|
-| Allowlist | `'blog'` added to `ALLOWED_COLLECTIONS` |
-| Origin check | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense |
-| `_raw` field suffix | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
-| Blog normalize/validate hook | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status |
-| `createOnly` guard | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form) |
-| Form-based delete | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat` |
-| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])` |
+| Change                        | Behavior                                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Allowlist                     | `'blog'` added to `ALLOWED_COLLECTIONS`                                                                                                                                                         |
+| Origin check                  | Defense-in-depth CSRF: a mismatched `Origin` or `Sec-Fetch-Site: cross-site` → `403`; **fails open** when both headers are absent. SameSite=Lax remains the primary CSRF defense                |
+| `_raw` field suffix           | A `data.*_raw` field bypasses `parseSimpleValue` type-coercion and is stored as the raw string (used by `data.body_raw`, `data.excerpt_raw`); follows the existing `_csv` / `_lines` convention |
+| Blog normalize/validate hook  | When `collection='blog'`, runs `normalizeBlogData` then `validateBlogData` (wired like the existing faq/testimonials hooks), passing the **raw pre-default** status                             |
+| `createOnly` guard            | When truthy, `INSERT … ON CONFLICT (type, slug) DO NOTHING` + rowCount check; rowCount 0 → `400` "A post with this address already exists…" (used by the blog add-form)                         |
+| Form-based delete             | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat`                                                                    |
+| `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])`                                                                                                   |
 
 ### Auth
 
 The middleware protects `/admin` and `/api/admin` prefixes:
 
-| Request | Result |
-|---|---|
-| Unauthenticated JSON request | `401` |
+| Request                             | Result                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| Unauthenticated JSON request        | `401`                                                                                  |
 | Unauthenticated `Accept: text/html` | `302` to `/auth/sign-in` (middleware `context.redirect` default — verified; not `303`) |
-| Authenticated, non-admin session | `403` (the endpoint's own check) |
+| Authenticated, non-admin session    | `403` (the endpoint's own check)                                                       |
 
 ### Status requirement
 
@@ -419,18 +443,18 @@ All error messages use plain language and surface through the focused error flas
 Blog logic lives in one lib file. It consumes `ContentEntry` as-is and does not motivate any change
 to `ContentEntry` / `toContentEntry`. Exports:
 
-| Export | Purpose |
-|---|---|
-| `type BlogPost` | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }` |
-| `normalizeBlogEntry(entry)` | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
-| `compareBlogPosts(a, b)` | The single ordering implementation (date DESC, slug DESC, undated-last) |
-| `getPublishedPosts()` | `db.content.getCollection('blog')` → normalize → sort (public index) |
-| `getPublishedPost(slug)` | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL) |
-| `getManagedBlogPosts()` | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached |
-| `resolveLegacyBlogRedirect(slug)` | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target) |
-| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate |
-| `renderPostBody(markdown)` | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization)) |
-| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)` | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell) |
+| Export                                                                 | Purpose                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type BlogPost`                                                        | `{ slug, title, date, author, excerpt, body, image?, imageAlt?, seoTitle?, seoDescription?, status }`                                                                                                                  |
+| `normalizeBlogEntry(entry)`                                            | Read-path trust boundary — skips rows with bad slug / missing title-date-excerpt; coerces `''` optionals to `undefined`; nulls `data.image` failing the scheme regex (covers index `<img>`, post `<img>`, and ogImage) |
+| `compareBlogPosts(a, b)`                                               | The single ordering implementation (date DESC, slug DESC, undated-last)                                                                                                                                                |
+| `getPublishedPosts()`                                                  | `db.content.getCollection('blog')` → normalize → sort (public index)                                                                                                                                                   |
+| `getPublishedPost(slug)`                                               | `db.content.getEntry('blog', slug)` (drafts are `null` via SQL)                                                                                                                                                        |
+| `getManagedBlogPosts()`                                                | `queryRows` for `type='blog'` with **no status filter** (admin list), uncached                                                                                                                                         |
+| `resolveLegacyBlogRedirect(slug)`                                      | Returns the stripped slug when `slug` is date-prefixed AND the stripped target is a published post; `null` otherwise (miss or draft target)                                                                            |
+| `normalizeBlogData(data)` / `validateBlogData(data, title, rawStatus)` | Write-path normalize / validate                                                                                                                                                                                        |
+| `renderPostBody(markdown)`                                             | Markdown → sanitized HTML (see [Rendering & Sanitization](#rendering--sanitization))                                                                                                                                   |
+| `escapeXml(s)` / `renderBlogSitemapXml(posts, origin)`                 | Sitemap urlset builder (kept in-lib so the endpoint is a thin shell)                                                                                                                                                   |
 
 ## Rendering & Sanitization
 
@@ -457,18 +481,44 @@ blog code (plus the admin preview call site).
 
 ```typescript
 DOMPurify.sanitize(html, {
-  ALLOWED_TAGS: ['h2','h3','h4','h5','h6','p','a','ul','ol','li','strong','em','b','i',
-                 'blockquote','code','pre','img','hr','br',
-                 'table','thead','tbody','tr','th','td','del'],
-  ALLOWED_ATTR: ['href','src','alt','title'],   // NO 'id' — heading anchors are cut, so author
-                                                // ids must never reach the public page; DOMPurify
-                                                // strips every author-supplied id (no DOM-clobbering
-                                                // surface; resolved by removal)
-  ALLOW_DATA_ATTR: false,   // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
-  ALLOW_ARIA_ATTR: false,   // an authored <p data-admin-alert> survives "strict" sanitization and
-                            // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
-                            // screen-reader users
-  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i
+  ALLOWED_TAGS: [
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "blockquote",
+    "code",
+    "pre",
+    "img",
+    "hr",
+    "br",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "del",
+  ],
+  ALLOWED_ATTR: ["href", "src", "alt", "title"], // NO 'id' — heading anchors are cut, so author
+  // ids must never reach the public page; DOMPurify
+  // strips every author-supplied id (no DOM-clobbering
+  // surface; resolved by removal)
+  ALLOW_DATA_ATTR: false, // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
+  ALLOW_ARIA_ATTR: false, // an authored <p data-admin-alert> survives "strict" sanitization and
+  // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
+  // screen-reader users
+  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i,
   // HTTPS-only for body links/images (unifies the body trust boundary with the featured-image
   // policy); NO '#'/fragment alternative (heading anchors cut, so fragment links have no targets);
   // blocks javascript:, data:, vbscript:, protocol-relative, AND the backslash form '/\evil.com'
@@ -478,16 +528,16 @@ DOMPurify.sanitize(html, {
 
 ### URI policy
 
-| Form | Behavior |
-|---|---|
-| `http:` body links/images | **Blocked** (HTTPS-only) |
-| `https:`, `mailto:`, `tel:` | Allowed |
-| Site-relative `/page` | Allowed |
-| `www.`-leading | Normalized to `https://` (walkTokens) |
-| Fragment-only `#section` | **Stripped** (no in-post id targets exist) |
-| Non-slash relative `images/x.png`, `../page` | **Blocked** |
-| Backslash-leading `/\evil.com` | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
-| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked** |
+| Form                                             | Behavior                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `http:` body links/images                        | **Blocked** (HTTPS-only)                                                              |
+| `https:`, `mailto:`, `tel:`                      | Allowed                                                                               |
+| Site-relative `/page`                            | Allowed                                                                               |
+| `www.`-leading                                   | Normalized to `https://` (walkTokens)                                                 |
+| Fragment-only `#section`                         | **Stripped** (no in-post id targets exist)                                            |
+| Non-slash relative `images/x.png`, `../page`     | **Blocked**                                                                           |
+| Backslash-leading `/\evil.com`                   | **Blocked** (in the sanitizer, the write-path image scheme, and the read-path mapper) |
+| `javascript:` / `data:` / `vbscript:` / `//evil` | **Blocked**                                                                           |
 
 The featured-image URL is validated by the same backslash-aware scheme on the write path
 (`validateBlogData`) and re-checked on the read path (`normalizeBlogEntry`); the slug charset is
@@ -546,13 +596,13 @@ The post page passes `title={post.seoTitle || post.title}` and
 `description={post.seoDescription || post.excerpt}` (using `||`, not `??`). `Layout.astro` accepts
 optional props `ogImage`, `ogImageAlt`, `ogType` (default `'website'`), and `publishedTime`:
 
-| Tag | Source |
-|---|---|
-| `og:image` and `twitter:image` | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL) |
+| Tag                                    | Source                                                                                       |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `og:image` and `twitter:image`         | `ogImage ?? seoMetadata.ogImageUrl` (post featured image, absolute prod-origin URL)          |
 | `og:image:alt` and `twitter:image:alt` | `ogImageAlt` (post `imageAlt`) — Twitter/X does not read `og:image:alt`, so both are emitted |
-| `og:type` | `'article'` for posts |
-| `article:published_time` | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set |
-| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed) |
+| `og:type`                              | `'article'` for posts                                                                        |
+| `article:published_time`               | `{date}T12:00:00Z` ISO value, when `ogType='article'` and set                                |
+| `rel="canonical"`, `meta[name=robots]` | prod-origin canonical; `index, follow` (asserted, not assumed)                               |
 
 `/blog` is added to `SEO_MANAGED_PAGES` (owner-tunable index meta via `/admin/seo`); individual posts
 are not added. Indexability is asserted, not assumed — `meta[name=robots]` must be `index, follow`
@@ -621,21 +671,21 @@ redirect entries.
 Each item below is intentionally **out of V1**. The generic content pipeline already does ~90% of the
 work; every deferred item would add files, migrations, or UI that the maintainability gate penalizes.
 
-| Deferred | Rationale |
-|---|---|
-| Categories / tags UI | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them |
-| RSS | No `@astrojs/rss` dependency; a new surface for zero current demand |
-| Pagination | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise |
-| Scheduled publishing | Draft → manual publish covers the owner workflow |
-| Related posts, search, comments, newsletter integration | Each is a feature in itself |
-| In-post heading anchors / table of contents / "back to top" fragment links | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
-| Rich-text / WYSIWYG editor | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle |
-| Client-side autosave / restore | Prevention (client validation) replaces recovery; the residual loss risk is recorded below |
-| Body-image-alt client scanner | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish |
-| Featured-image thumbnail preview in the editor | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate |
-| `BlogPosting` JSON-LD structured data | Per-post meta + OG/Twitter tags cover V1; a V2 candidate |
-| Meta-description length capping / bespoke index meta | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo` |
-| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo) |
+| Deferred                                                                                | Rationale                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Categories / tags UI                                                                    | Owner-deferred; legacy keys are carried opaquely by `baseDataJson`. No blog code names them                                                                                 |
+| RSS                                                                                     | No `@astrojs/rss` dependency; a new surface for zero current demand                                                                                                         |
+| Pagination                                                                              | 6 posts + a slow cadence; a single list page is correct until post count demands otherwise                                                                                  |
+| Scheduled publishing                                                                    | Draft → manual publish covers the owner workflow                                                                                                                            |
+| Related posts, search, comments, newsletter integration                                 | Each is a feature in itself                                                                                                                                                 |
+| In-post heading anchors / table of contents / "back to top" fragment links              | Documentation-grade for a low-volume school blog, and the root of an author-controlled-`id` security surface; the renderer emits no ids and DOMPurify strips all author ids |
+| Rich-text / WYSIWYG editor                                                              | A new dependency + a new XSS surface; Markdown + server preview achieves owner confidence within MVP. A V2 candidate only if owners struggle                                |
+| Client-side autosave / restore                                                          | Prevention (client validation) replaces recovery; the residual loss risk is recorded below                                                                                  |
+| Body-image-alt client scanner                                                           | A per-keystroke parallel validation engine with no admin-surface precedent; the server enforces body-image alt quality at publish                                           |
+| Featured-image thumbnail preview in the editor                                          | Additive UI with its own load/error/empty states and a11y; the field is text-box-only, matching the staff/media clone source. A high-value V2 candidate                     |
+| `BlogPosting` JSON-LD structured data                                                   | Per-post meta + OG/Twitter tags cover V1; a V2 candidate                                                                                                                    |
+| Meta-description length capping / bespoke index meta                                    | Search engines truncate gracefully; the `/blog` index meta is owner-tunable via `/admin/seo`                                                                                |
+| Cross-instance cache invalidation, CDN caching of blog pages, full-site sitemap rebuild | Risk decisions; see [Caching](#caching) and [SEO](#seo)                                                                                                                     |
 
 ## Accepted Residual Risks
 


### PR DESCRIPTION
## Phase 3 · PR2 — public discovery routes

Builds the visitor-facing discovery surface on top of PR1's discovery lib (#97) and PR1b's robots three-state (#98).

### New routes
| Route | Behavior |
|---|---|
| `/blog` | **Page 1** of the paginated index. Cards now carry category/tag chips. |
| `/blog/page/[n]` | `n ≥ 2` only; `/blog/page/1` → **301 /blog**; out-of-range / non-integer → **404** (R3-F19). Indexable, self-canonical. |
| `/blog/category/[slug]` | PATH segment (never query params — R4-F15). **Indexable at ≥2 members**; below → `noindex, follow` (R1-F31). Self-canonical. |
| `/blog/tag/[slug]` | **Always `noindex, follow`** + sitemap-excluded (R1-F21). Self-canonical. |

### The canonical-param guard (no duplicate content, for free)
`isCanonicalTaxonomyParam(raw)` = `taxonomySlug(raw) === raw`. Because `taxonomySlug` is idempotent, the route renders **only** when `[slug]` is already its canonical form — `/blog/category/Education` (capital), `play--time`, `-edge-` all 404. So there's exactly one indexable URL per taxonomy and the path-only `resolveSeoMetadata` self-canonical is always correct. Chip links (built via `categoryHref`/`tagHref`) always pass.

### Pure, CI-tested logic — `app/src/lib/blog-routes.ts` (9 cases)
`parseBlogPageParam` (`'1'`→redirect / clean `n≥2`→page / non-integer·`'0'`·leading-zero→invalid), `blogPageHref` (page 1 collapses to `/blog`), `categoryHref`/`tagHref`, `isCanonicalTaxonomyParam`.

### Shared components
- `PostCardList.astro` — `<h2>` titles (heading outline R3-F21), labeled category/tag chips, **byline `<p>` class preserved** (blog.spec test 18 contrast pin).
- `Pagination.astro` — `<nav aria-label="Blog pagination">`, real keyboard anchors, `aria-current` + bold/underline (non-color affordance), `aria-disabled` boundaries (R2-F25). No `aria-live` — these are full-nav routes, not client filters, so a live region would be a no-op (count rendered in document order instead).

### Verification
- **Local SSR dev server** (against read-only prod DB): `/blog/page/1`→301, `/blog/page/abc`·`/blog/page/02`·`/blog/category/Education`→404, `/blog`→200 `index,follow`. ✅ routing/guards proven end-to-end.
- **Taxonomy render** (200 + `noindex` meta with live posts) is post-deploy per R4-F21 — `deploy.md §9.2` gains real-corpus curl checks (`education` indexable, `values`/`inclusion` soft, capital→404, page/1→301).
- Both halves of the robots wiring are unit-tested (count→indexable in blog-discovery; prop→meta in seo-config); the prop wiring is typecheck-validated.
- `blog.spec.ts` test 18: post-link locator tightened to exclude discovery chips (keeps `>=6` honest) + asserts category chips render.

### Docs
`blog.md` — route table + discovery-behavior section; `data.categories/tags` row updated (discovery now reads them). `deploy.md` — PR2 curl checks.

### Gates
lint 0-warn · format clean · typecheck 0-err · **443 tests** · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)