### PR TITLE
feat(blog): Phase-3 PR3 — post page related/share/chips (bio deferred)

### DIFF
--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -130,6 +130,26 @@ test.describe('Blog V1 — public routes + SEO', () => {
     expect(metaContent(html, 'robots', 'name')?.toLowerCase()).toContain('index');
     expect(/<meta[^>]*name=["']googlebot["'][^>]*noindex/i.test(html)).toBe(false);
 
+    // PR3 post-page surfaces (render-present; the copy-link CLICK is client-JS, browser-only).
+    // Share section with NAMED anchors (R3-F23) + the copy-link button + its aria-live status region.
+    expect(html, 'share section heading').toContain('Share this post');
+    expect(html, 'named share anchor').toContain(
+      'aria-label="Share on Facebook (opens in a new tab)"'
+    );
+    expect(html, 'copy-link button').toContain('id="copy-link-btn"');
+    expect(/aria-live=["']polite["']/i.test(html), 'copy-link status is a polite live region').toBe(
+      true
+    );
+    // Related posts: the pinned post shares categories (Education/Nature/Programs) with others, so the
+    // section renders and links a DIFFERENT published post.
+    expect(html, 'related posts heading').toContain('Related posts');
+    expect(
+      /<a[^>]*href=["']\/blog\/(?!nurturing-growth-gardening-program)[a-z0-9-]+["']/i.test(html),
+      'related section links another post'
+    ).toBe(true);
+    // Post's own taxonomy chips (discovery parity with the index cards).
+    expect(html, 'taxonomy chips on post').toMatch(/href=["']\/blog\/category\/[a-z0-9-]+["']/i);
+
     // Same robots discipline on /blog index.
     const indexHtml = await (await request.get('/blog')).text();
     expect(metaContent(indexHtml, 'robots', 'name')?.toLowerCase()).toContain('index');

--- a/app/src/components/blog/PostCardList.astro
+++ b/app/src/components/blog/PostCardList.astro
@@ -1,6 +1,6 @@
 ---
 import type { BlogPost } from '@lib/blog-content';
-import { categoryHref, tagHref } from '@lib/blog-routes';
+import TaxonomyChips from '@components/blog/TaxonomyChips.astro';
 
 interface Props {
   posts: BlogPost[];
@@ -25,8 +25,6 @@ const formatDate = (date: string | undefined): string | null => {
   {
     posts.map(post => {
       const formattedDate = formatDate(post.date);
-      const categories = post.categories ?? [];
-      const tags = post.tags ?? [];
       return (
         <article>
           {post.image && (
@@ -51,42 +49,7 @@ const formatDate = (date: string | undefined): string | null => {
             <span>By {post.author}</span>
           </p>
           <p class="text-earth-brown/80">{post.excerpt}</p>
-          {(categories.length > 0 || tags.length > 0) && (
-            <div class="mt-3 text-sm">
-              {categories.length > 0 && (
-                <p class="text-earth-brown/80">
-                  <span class="font-semibold">Categories:</span>{' '}
-                  {categories.map((cat, i) => (
-                    <>
-                      {i > 0 && <span aria-hidden="true">, </span>}
-                      <a
-                        href={categoryHref(cat)}
-                        class="text-forest-canopy underline hover:text-moss-green"
-                      >
-                        {cat}
-                      </a>
-                    </>
-                  ))}
-                </p>
-              )}
-              {tags.length > 0 && (
-                <p class="text-earth-brown/80 mt-1">
-                  <span class="font-semibold">Tags:</span>{' '}
-                  {tags.map((tag, i) => (
-                    <>
-                      {i > 0 && <span aria-hidden="true">, </span>}
-                      <a
-                        href={tagHref(tag)}
-                        class="text-forest-canopy underline hover:text-moss-green"
-                      >
-                        {tag}
-                      </a>
-                    </>
-                  ))}
-                </p>
-              )}
-            </div>
-          )}
+          <TaxonomyChips categories={post.categories} tags={post.tags} class="mt-3" />
         </article>
       );
     })

--- a/app/src/components/blog/RelatedPosts.astro
+++ b/app/src/components/blog/RelatedPosts.astro
@@ -1,0 +1,35 @@
+---
+import type { BlogPost } from '@lib/blog-content';
+
+interface Props {
+  posts: BlogPost[];
+}
+
+const { posts } = Astro.props;
+---
+
+{
+  posts.length > 0 && (
+    <section aria-labelledby="related-heading" class="mt-12 border-t border-stone-beige pt-8">
+      <h2
+        id="related-heading"
+        class="text-2xl font-heading font-semibold text-earth-brown mb-4 tracking-tight"
+      >
+        Related posts
+      </h2>
+      <ul class="space-y-4">
+        {posts.map(p => (
+          <li>
+            <a
+              href={`/blog/${p.slug}`}
+              class="text-forest-canopy underline hover:text-moss-green font-heading font-semibold"
+            >
+              {p.title}
+            </a>
+            {p.excerpt && <p class="text-sm text-earth-brown/80 mt-1">{p.excerpt}</p>}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/app/src/components/blog/ShareButtons.astro
+++ b/app/src/components/blog/ShareButtons.astro
@@ -1,0 +1,80 @@
+---
+import { buildShareLinks } from '@lib/blog-share';
+
+interface Props {
+  /** Absolute canonical post URL to share. */
+  url: string;
+  title: string;
+}
+
+const { url, title } = Astro.props;
+const links = buildShareLinks(url, title);
+
+const linkClass = 'text-forest-canopy underline hover:text-moss-green';
+---
+
+<section aria-labelledby="share-heading" class="mt-12 border-t border-stone-beige pt-8">
+  <h2 id="share-heading" class="text-lg font-heading font-semibold text-earth-brown mb-3">
+    Share this post
+  </h2>
+  <ul class="flex flex-wrap items-center gap-5">
+    <li>
+      <a
+        href={links.x}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on X (opens in a new tab)"
+        class={linkClass}
+      >
+        X
+      </a>
+    </li>
+    <li>
+      <a
+        href={links.facebook}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on Facebook (opens in a new tab)"
+        class={linkClass}
+      >
+        Facebook
+      </a>
+    </li>
+    <li>
+      <a href={links.email} aria-label="Share by email" class={linkClass}>Email</a>
+    </li>
+    <li>
+      {
+        /* Copy-link needs navigator.clipboard (secure context). Named anchors above work without JS;
+          this button degrades to a no-op if the clipboard API is unavailable. */
+      }
+      <button
+        type="button"
+        id="copy-link-btn"
+        data-share-url={url}
+        class="text-forest-canopy underline hover:text-moss-green"
+      >
+        Copy link
+      </button>
+    </li>
+  </ul>
+  {/* Empty at load so the polite live region announces the post-click status change (R3-F23). */}
+  <p id="copy-link-status" aria-live="polite" class="mt-2 text-sm text-earth-brown/80"></p>
+</section>
+
+<script>
+  const btn = document.getElementById('copy-link-btn');
+  const status = document.getElementById('copy-link-status');
+  if (btn && status) {
+    btn.addEventListener('click', async () => {
+      const url = btn.getAttribute('data-share-url') || window.location.href;
+      try {
+        if (!navigator.clipboard) throw new Error('clipboard unavailable');
+        await navigator.clipboard.writeText(url);
+        status.textContent = 'Link copied to clipboard.';
+      } catch {
+        status.textContent = 'Could not copy automatically — press Ctrl/Cmd + C to copy the URL.';
+      }
+    });
+  }
+</script>

--- a/app/src/components/blog/TaxonomyChips.astro
+++ b/app/src/components/blog/TaxonomyChips.astro
@@ -1,0 +1,47 @@
+---
+import { categoryHref, tagHref } from '@lib/blog-routes';
+
+interface Props {
+  categories?: string[];
+  tags?: string[];
+  class?: string;
+}
+
+const { categories = [], tags = [], class: className = '' } = Astro.props;
+---
+
+{
+  (categories.length > 0 || tags.length > 0) && (
+    <div class={`text-sm ${className}`.trim()}>
+      {categories.length > 0 && (
+        <p class="text-earth-brown/80">
+          <span class="font-semibold">Categories:</span>{' '}
+          {categories.map((cat, i) => (
+            <>
+              {i > 0 && <span aria-hidden="true">, </span>}
+              <a
+                href={categoryHref(cat)}
+                class="text-forest-canopy underline hover:text-moss-green"
+              >
+                {cat}
+              </a>
+            </>
+          ))}
+        </p>
+      )}
+      {tags.length > 0 && (
+        <p class="text-earth-brown/80 mt-1">
+          <span class="font-semibold">Tags:</span>{' '}
+          {tags.map((tag, i) => (
+            <>
+              {i > 0 && <span aria-hidden="true">, </span>}
+              <a href={tagHref(tag)} class="text-forest-canopy underline hover:text-moss-green">
+                {tag}
+              </a>
+            </>
+          ))}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/src/lib/blog-share.test.ts
+++ b/app/src/lib/blog-share.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildShareLinks } from './blog-share';
+
+describe('buildShareLinks', () => {
+  const url = 'https://spicebushmontessori.org/blog/nurturing-growth-gardening-program';
+  const title = 'Nurturing Growth: Our Gardening Program';
+
+  it('builds X / Facebook / email intents from the absolute url + title', () => {
+    const links = buildShareLinks(url, title);
+    expect(links.x).toBe(
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`
+    );
+    expect(links.facebook).toBe(
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`
+    );
+    expect(links.email.startsWith('mailto:?subject=')).toBe(true);
+  });
+
+  it('percent-encodes the url AND title so query-breaking chars cannot escape', () => {
+    const trickyUrl = 'https://example.com/p?a=1&b=2#frag';
+    const trickyTitle = 'Tom & Jerry: 100% fun? yes!';
+    const links = buildShareLinks(trickyUrl, trickyTitle);
+    // No raw separators leak into the query string beyond the ones we placed.
+    expect(links.x).toContain(encodeURIComponent(trickyUrl));
+    expect(links.x).toContain(encodeURIComponent(trickyTitle));
+    expect(links.x).not.toContain('a=1&b=2'); // the raw url query is escaped, not appended
+    expect(links.facebook).toContain(encodeURIComponent(trickyUrl));
+    expect(links.facebook).not.toContain('#frag');
+    // Email body carries the title and the url, both escaped.
+    expect(links.email).toContain(encodeURIComponent(trickyTitle));
+    expect(links.email).toContain(encodeURIComponent(`${trickyTitle}\n\n${trickyUrl}`));
+  });
+});

--- a/app/src/lib/blog-share.ts
+++ b/app/src/lib/blog-share.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure share-link builder for the public post page (Phase 3 PR3). Given the ABSOLUTE canonical post
+ * URL and the post title, returns the share-intent hrefs for X, Facebook, and email. Both the URL and
+ * the title are `encodeURIComponent`-escaped so a `&`, `?`, space, or `#` in either can't break out of
+ * the query string. View-less and fully unit-testable; the named `<a>` anchors work without JS (only
+ * the separate copy-link button needs the clipboard API).
+ */
+export type ShareLinks = {
+  /** X / Twitter web intent (prefilled text + url). */
+  x: string;
+  /** Facebook sharer (url only — FB ignores prefilled text). */
+  facebook: string;
+  /** `mailto:` with the title as subject and the title + url as the body. */
+  email: string;
+};
+
+export function buildShareLinks(url: string, title: string): ShareLinks {
+  const u = encodeURIComponent(url);
+  const t = encodeURIComponent(title);
+  return {
+    x: `https://twitter.com/intent/tweet?url=${u}&text=${t}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${u}`,
+    email: `mailto:?subject=${t}&body=${encodeURIComponent(`${title}\n\n${url}`)}`
+  };
+}

--- a/app/src/pages/blog/[slug].astro
+++ b/app/src/pages/blog/[slug].astro
@@ -2,7 +2,16 @@
 import Layout from '@layouts/Layout.astro';
 import Header from '@components/Header.astro';
 import Footer from '@components/Footer.astro';
-import { getPublishedPost, resolveLegacyBlogRedirect, renderPostBody } from '@lib/blog-content';
+import TaxonomyChips from '@components/blog/TaxonomyChips.astro';
+import ShareButtons from '@components/blog/ShareButtons.astro';
+import RelatedPosts from '@components/blog/RelatedPosts.astro';
+import {
+  getPublishedPost,
+  getPublishedPosts,
+  resolveLegacyBlogRedirect,
+  renderPostBody
+} from '@lib/blog-content';
+import { getRelatedPosts } from '@lib/blog-discovery';
 import { resolveSiteOrigin } from '@lib/site-origin';
 
 const slug = Astro.params.slug ?? '';
@@ -24,6 +33,14 @@ if (!post) {
   return new Response(null, { status: 404 });
 }
 
+// Related posts share the most categories/tags (excludes self + zero-overlap; recency tiebreak).
+const allPosts = await getPublishedPosts();
+const relatedPosts = getRelatedPosts(post, allPosts, 3);
+
+// Absolute canonical post URL for the share intents (share the canonical, not a relative path).
+const siteOrigin = resolveSiteOrigin(Astro.site);
+const postUrl = new URL(`/blog/${post.slug}`, siteOrigin).href;
+
 const formatDate = (date: string | undefined): string | null => {
   if (!date) return null;
   const parsed = new Date(date);
@@ -44,7 +61,7 @@ const bodyHtml = renderPostBody(post.body);
   title={post.seoTitle || post.title}
   description={post.seoDescription || post.excerpt}
   ogType="article"
-  ogImage={post.image ? new URL(post.image, resolveSiteOrigin(Astro.site)).href : undefined}
+  ogImage={post.image ? new URL(post.image, siteOrigin).href : undefined}
   ogImageAlt={post.imageAlt}
   publishedTime={post.date ? `${post.date}T12:00:00Z` : undefined}
 >
@@ -76,6 +93,12 @@ const bodyHtml = renderPostBody(post.body);
       }
 
       <div class="blog-body" set:html={bodyHtml} />
+
+      <TaxonomyChips categories={post.categories} tags={post.tags} class="mt-8" />
+
+      <ShareButtons url={postUrl} title={post.title} />
+
+      <RelatedPosts posts={relatedPosts} />
 
       <p class="mt-12">
         <a href="/blog" class="text-forest-canopy underline hover:text-moss-green">

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -161,9 +161,24 @@ Markdown remains recoverable via git history.
   to a **published** post (no loops, no draft leakage, no redirect-to-404). The write path can never
   mint slugs in this namespace.
 - **Missing or draft** → `404` (drafts are indistinguishable from missing by design).
-- The post renders `<article>` with a single `<h1>` title, a `<time datetime>` + author byline, an
+- The post renders `<article>` with a single `<h1>` title, a `<time datetime>` + author byline (the
+  byline string is already resolver-resolved on the read path — `resolveAuthorByline`, R4-F9), an
   optional featured `<img>`, then `<div class="blog-body" set:html={renderPostBody(post.body)} />` —
   the only `set:html` in the feature.
+- **Post-page surfaces (Phase 3 PR3)**, appended after the body, each an `<h2>` section under the
+  single `<h1>` (heading outline continuous — R3-F21):
+  - **Taxonomy chips** (`TaxonomyChips.astro`) — the post's own category/tag links (same component the
+    index cards use).
+  - **Share** (`ShareButtons.astro`) — NAMED anchors for X / Facebook / email, each with an accessible
+    name (R3-F23); links are built from the ABSOLUTE canonical URL with `encodeURIComponent` on both
+    URL and title (`buildShareLinks`, blog-share.ts) and work without JS. A **Copy-link** button uses
+    `navigator.clipboard` (secure context) and announces success/failure into a `aria-live="polite"`
+    status region; with no JS / no clipboard it degrades to a no-op (the named anchors still work).
+  - **Related posts** (`RelatedPosts.astro`) — up to 3 from `getRelatedPosts` (shared taxonomy, recency
+    tiebreak, self + zero-overlap excluded); the section is omitted when there are none.
+- **Author bios are deferred** (issue #100) — no author registry / admin exists yet, so all posts use
+  the `data.author` fallback and no bio block renders. The render-time bio sanitizer is built with that
+  feature, against a real caller.
 
 The Footer link to `/blog` (`app/src/components/Footer.astro:141`) is unchanged — making `/blog`
 real fixes the previously-broken link that 301'd to `/contact`.


### PR DESCRIPTION
## Phase 3 · PR3 — post-page enhancements

Adds the discovery + share surfaces to `/blog/[slug]`, each an `<h2>` section under the single `<h1>` (heading outline continuous — R3-F21).

### What's added
- **Related posts** (`RelatedPosts.astro`) — up to 3 via `getRelatedPosts` (shared taxonomy, recency tiebreak, self + zero-overlap excluded). Section omitted when there are none.
- **Share** (`ShareButtons.astro`) — **named anchors** for X / Facebook / email, each with an accessible name (R3-F23), built from the **absolute canonical URL** with `encodeURIComponent` on both URL and title (new pure `blog-share.ts`, unit-tested for escaping). A **Copy-link** button uses `navigator.clipboard` and announces success/failure into an `aria-live="polite"` region; without JS/clipboard it degrades to a no-op (the named anchors still work).
- **Taxonomy chips** (`TaxonomyChips.astro`) — the post's own category/tag links; extracted as a shared component and reused by `PostCardList` (the card chip markup de-duped, net −42 lines there).

The byline already uses `resolveAuthorByline`'s `data.author` fallback on the read path (R4-F9) — unchanged.

### Deferred: author bios + registry → issue #100
There is no author registry / admin UI yet, so all 6 posts use the `data.author` fallback and **no bio block would render**. Building the registry read + bio sanitizer + conditional block now would ship dead code on every render, untestable end-to-end. Per the advisor, the render-time bio sanitizer (R1-F2) is born **with** the author feature, against a real caller. **No security debt** — the live HTML trust boundary is the body sanitizer (`renderBodyHtml`), already shipped; R1-F2 for bios is conditional on bios existing.

### Verification
- **Unit**: `blog-share` (escaping) + `getRelatedPosts` (already covered).
- **E2E** (`blog.spec.ts` test 19): asserts the share heading, a named anchor, the copy-link button, the `aria-live` region, the related-posts heading + a link to another post, and a taxonomy chip — all render-present.
- **Boundary stated honestly**: the local dev DB can't load (Vite `import.meta.env` dynamic-access quirk → `getPublishedPost` null → 404), so post-page render is **post-deploy** via curl. The copy-link **click** is client-JS — browser-only, not provable by curl.

### Gates
lint 0-warn · format clean · typecheck 0-err · **445 tests** · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added share buttons to blog post pages for X, Facebook, and email
  * Added "Copy link" button to easily copy post URL to clipboard
  * Added related posts section displaying up to 3 related articles
  * Improved category and tag display with taxonomy chips

* **Tests**
  * Added end-to-end tests verifying new blog post UI elements
  * Added unit tests for share link generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->