### PR TITLE
feat(blog): Phase-4 PR1 — RSS 2.0 feed at /blog/rss.xml

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -939,9 +939,17 @@ describe('toRfc822Date (R1-F30)', () => {
   it('returns "" for a missing or malformed date (caller omits <pubDate>)', () => {
     expect(toRfc822Date('')).toBe('');
     expect(toRfc822Date(undefined)).toBe('');
-    expect(toRfc822Date('2024-5-20')).toBe(''); // not zero-padded → not our format
+    expect(toRfc822Date('2024-5-20')).toBe(''); // not zero-padded → fails DATE_FORMAT_REGEX
     expect(toRfc822Date('not-a-date')).toBe('');
-    expect(toRfc822Date('2024-13-40')).toBe(''); // calendar-invalid (Date NaN)
+    expect(toRfc822Date('2024-13-40')).toBe(''); // month 13 out of range → Date NaN → ''
+  });
+
+  it('faithfully formats a day-overflow date (V8 rolls it forward, matching the write validator)', () => {
+    // The NaN guard does NOT reject day overflow — `new Date('2024-02-30…')` rolls to Mar 1. This
+    // mirrors the write-path validator (which also accepts these), so a saved date is formatted as
+    // stored; the contract is only "never emit Invalid Date", which holds.
+    expect(toRfc822Date('2024-02-30')).toBe('Fri, 01 Mar 2024 12:00:00 GMT');
+    expect(toRfc822Date('2024-02-30')).not.toContain('Invalid');
   });
 });
 
@@ -977,21 +985,21 @@ describe('renderBlogRssXml (R1-F30)', () => {
     expect(xml).toContain('<lastBuildDate>Mon, 20 May 2024 12:00:00 GMT</lastBuildDate>');
   });
 
-  it('XML-escapes titles and excerpts so markup cannot break the feed', () => {
+  it('XML-escapes titles and excerpts (all 5 entities) so markup cannot break the feed', () => {
     const xml = renderBlogRssXml(
       [
         makePost({
           slug: 's',
-          title: 'Tom & Jerry <b>',
+          title: `Tom & Jerry <b> 'q'`,
           excerpt: 'a < b & "c"',
           date: '2024-05-20'
         })
       ],
       origin
     );
-    expect(xml).toContain('<title>Tom &amp; Jerry &lt;b&gt;</title>');
+    expect(xml).toContain('<title>Tom &amp; Jerry &lt;b&gt; &apos;q&apos;</title>');
     expect(xml).toContain('<description>a &lt; b &amp; &quot;c&quot;</description>');
-    expect(xml).not.toContain('<title>Tom & Jerry <b></title>');
+    expect(xml).not.toContain('<title>Tom & Jerry <b>');
   });
 
   it('omits the ITEM <description>/<pubDate> when absent rather than emitting empty/invalid values', () => {

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -29,8 +29,10 @@ import {
   getPublishedPosts,
   normalizeBlogData,
   normalizeBlogEntry,
+  renderBlogRssXml,
   renderBlogSitemapXml,
   renderPostBody,
+  toRfc822Date,
   resolveAuthorByline,
   resolveLegacyBlogRedirect,
   validateBlogData,
@@ -926,6 +928,86 @@ describe('escapeXml + renderBlogSitemapXml', () => {
     expect(xml).toContain('<loc>https://spicebushmontessori.org/blog/second</loc>');
     expect(xml).not.toContain('<loc>https://spicebushmontessori.org/blog/</loc>');
     expect(xml).not.toContain('/blog/first/</loc>');
+  });
+});
+
+describe('toRfc822Date (R1-F30)', () => {
+  it('formats a YYYY-MM-DD date at noon UTC as RFC-822', () => {
+    expect(toRfc822Date('2024-05-20')).toBe('Mon, 20 May 2024 12:00:00 GMT');
+  });
+
+  it('returns "" for a missing or malformed date (caller omits <pubDate>)', () => {
+    expect(toRfc822Date('')).toBe('');
+    expect(toRfc822Date(undefined)).toBe('');
+    expect(toRfc822Date('2024-5-20')).toBe(''); // not zero-padded → not our format
+    expect(toRfc822Date('not-a-date')).toBe('');
+    expect(toRfc822Date('2024-13-40')).toBe(''); // calendar-invalid (Date NaN)
+  });
+});
+
+describe('renderBlogRssXml (R1-F30)', () => {
+  const origin = 'https://spicebushmontessori.org';
+
+  it('is well-formed RSS 2.0 with an atom self-link to /blog/rss.xml', () => {
+    const xml = renderBlogRssXml([makePost({ slug: 'first', date: '2024-05-20' })], origin);
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain('<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain(
+      `<atom:link href="${origin}/blog/rss.xml" rel="self" type="application/rss+xml" />`
+    );
+    expect(xml).toContain(`<link>${origin}/blog</link>`);
+    expect(xml.trimEnd().endsWith('</rss>')).toBe(true);
+  });
+
+  it('emits one item per post with permalink guid, link, and RFC-822 pubDate', () => {
+    const xml = renderBlogRssXml(
+      [
+        makePost({ slug: 'first', title: 'First Post', excerpt: 'Hello', date: '2024-05-20' }),
+        makePost({ slug: 'second', title: 'Second', excerpt: 'World', date: '2024-04-01' })
+      ],
+      origin
+    );
+    expect((xml.match(/<item>/g) ?? []).length).toBe(2);
+    expect(xml).toContain('<title>First Post</title>');
+    expect(xml).toContain(`<link>${origin}/blog/first</link>`);
+    expect(xml).toContain(`<guid isPermaLink="true">${origin}/blog/first</guid>`);
+    expect(xml).toContain('<description>Hello</description>');
+    expect(xml).toContain('<pubDate>Mon, 20 May 2024 12:00:00 GMT</pubDate>');
+    // lastBuildDate = the newest post (input is date-DESC sorted upstream).
+    expect(xml).toContain('<lastBuildDate>Mon, 20 May 2024 12:00:00 GMT</lastBuildDate>');
+  });
+
+  it('XML-escapes titles and excerpts so markup cannot break the feed', () => {
+    const xml = renderBlogRssXml(
+      [
+        makePost({
+          slug: 's',
+          title: 'Tom & Jerry <b>',
+          excerpt: 'a < b & "c"',
+          date: '2024-05-20'
+        })
+      ],
+      origin
+    );
+    expect(xml).toContain('<title>Tom &amp; Jerry &lt;b&gt;</title>');
+    expect(xml).toContain('<description>a &lt; b &amp; &quot;c&quot;</description>');
+    expect(xml).not.toContain('<title>Tom & Jerry <b></title>');
+  });
+
+  it('omits the ITEM <description>/<pubDate> when absent rather than emitting empty/invalid values', () => {
+    const xml = renderBlogRssXml([makePost({ slug: 's', excerpt: '', date: '' })], origin);
+    // The channel always carries one <description>; the item must not add a second.
+    expect((xml.match(/<description>/g) ?? []).length).toBe(1);
+    expect(xml).not.toContain('<pubDate>');
+    expect(xml).not.toContain('Invalid Date');
+    expect(xml).not.toContain('<lastBuildDate>'); // no datable post → no channel build date
+  });
+
+  it('renders an empty but valid channel for no posts', () => {
+    const xml = renderBlogRssXml([], origin);
+    expect(xml).toContain('<channel>');
+    expect((xml.match(/<item>/g) ?? []).length).toBe(0);
+    expect(xml.trimEnd().endsWith('</rss>')).toBe(true);
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -644,3 +644,66 @@ export function renderBlogSitemapXml(posts: BlogPost[], origin: string): string 
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>`;
 }
+
+/**
+ * RFC-822 date for an RSS `<pubDate>` from a `YYYY-MM-DD` post date. Posts have no time component, so
+ * we pin noon UTC (matching the imported rows' `{date}T12:00:00Z`); `toUTCString()` emits the exact
+ * RFC-822/1123 shape RSS wants (`Mon, 20 May 2024 12:00:00 GMT`). Returns `''` for an unparseable date
+ * so the caller can omit `<pubDate>` rather than emit `Invalid Date`.
+ */
+export function toRfc822Date(date: string | undefined): string {
+  if (typeof date !== 'string' || !DATE_FORMAT_REGEX.test(date)) return '';
+  const parsed = new Date(`${date}T12:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ? '' : parsed.toUTCString();
+}
+
+/**
+ * Build the blog RSS 2.0 feed. Channel + `atom:self` self-link (R1-F30), one `<item>` per published
+ * post (the caller passes already-filtered, already-sorted posts) with title, link, a permalink
+ * `<guid>`, the excerpt as `<description>`, and an RFC-822 `<pubDate>`. Every text value is XML-escaped.
+ * `<lastBuildDate>` is derived from the newest post (posts are date-DESC) so the document is
+ * deterministic and unit-testable — no `Date.now()`.
+ */
+export function renderBlogRssXml(posts: BlogPost[], origin: string): string {
+  const feedUrl = `${origin}/blog/rss.xml`;
+  const blogUrl = `${origin}/blog`;
+  const title = 'Spicebush Montessori Blog';
+  const description = 'News, reflections, and updates from the Spicebush Montessori community.';
+
+  const newestPubDate = posts.map(p => toRfc822Date(p.date)).find(d => d.length > 0);
+
+  const items = posts.map(post => {
+    const link = `${origin}/blog/${post.slug}`;
+    const pubDate = toRfc822Date(post.date);
+    return [
+      '    <item>',
+      `      <title>${escapeXml(post.title)}</title>`,
+      `      <link>${escapeXml(link)}</link>`,
+      `      <guid isPermaLink="true">${escapeXml(link)}</guid>`,
+      post.excerpt ? `      <description>${escapeXml(post.excerpt)}</description>` : '',
+      pubDate ? `      <pubDate>${pubDate}</pubDate>` : '',
+      '    </item>'
+    ]
+      .filter(line => line.length > 0)
+      .join('\n');
+  });
+
+  const channelHead = [
+    `    <title>${escapeXml(title)}</title>`,
+    `    <link>${escapeXml(blogUrl)}</link>`,
+    `    <description>${escapeXml(description)}</description>`,
+    '    <language>en-us</language>',
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
+    newestPubDate ? `    <lastBuildDate>${newestPubDate}</lastBuildDate>` : ''
+  ].filter(line => line.length > 0);
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    ...channelHead,
+    ...items,
+    '  </channel>',
+    '</rss>'
+  ].join('\n');
+}

--- a/app/src/pages/blog/rss.xml.ts
+++ b/app/src/pages/blog/rss.xml.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { getPublishedPosts, renderBlogRssXml } from '@lib/blog-content';
+import { resolveSiteOrigin } from '@lib/site-origin';
+
+// Static route — takes precedence over the dynamic `/blog/[slug]` for the exact path `/blog/rss.xml`.
+export const prerender = false;
+
+export const GET: APIRoute = async ({ site }) => {
+  const posts = await getPublishedPosts();
+  const body = renderBlogRssXml(posts, resolveSiteOrigin(site));
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=300'
+    }
+  });
+};


### PR DESCRIPTION
## Phase 4 · PR1 — RSS feed

Adds the blog RSS 2.0 feed (R1-F30).

- **`renderBlogRssXml(posts, origin)`** + **`toRfc822Date(date)`** in `blog-content.ts` — channel with an `atom:self` self-link, one `<item>` per published post (title, link, permalink `<guid>`, excerpt `<description>`, RFC-822 `<pubDate>` via `toUTCString()` at noon UTC), every text value XML-escaped through the existing `escapeXml`. `<lastBuildDate>` is derived from the newest post (input is date-DESC) so the document is **deterministic and unit-testable** — no `Date.now()`. Absent `<description>`/`<pubDate>` are omitted rather than emitted empty / `Invalid Date`.
- **Route** `app/src/pages/blog/rss.xml.ts` (SSR) — the static path wins over the dynamic `/blog/[slug]`; `Content-Type: application/rss+xml`, 5-min cache.

### Tests (CI string-builder, R4-F21)
RFC-822 formatting + malformed-date omission; channel + atom-self shape; per-item fields; XML-escaping of titles/excerpts (markup can't break the feed); empty-field omission; empty-corpus valid channel. **452 tests pass.**

### Verification
Route resolves **HTTP 200** with `Content-Type: application/rss+xml` and valid RSS 2.0 structure against a local SSR dev server (empty-DB → valid empty channel; the 6 live items populate post-deploy, confirmed via the §9.2 curl after deploy).

RSS auto-discovery `<link rel="alternate">` in the document `<head>` lands in **PR2** with the shared Layout head slot.

### Gates
lint 0-warn · format clean · typecheck 0-err · 452 tests · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)