### PR TITLE
feat(blog): Phase-4 PR2 — Article JSON-LD + Layout head slot + updated_at plumbing

### DIFF
--- a/app/e2e/blog.spec.ts
+++ b/app/e2e/blog.spec.ts
@@ -150,6 +150,36 @@ test.describe('Blog V1 — public routes + SEO', () => {
     // Post's own taxonomy chips (discovery parity with the index cards).
     expect(html, 'taxonomy chips on post').toMatch(/href=["']\/blog\/category\/[a-z0-9-]+["']/i);
 
+    // PR4 PR2: Article JSON-LD (R1-F29) — extract every ld+json block, find the BlogPosting one, and
+    // confirm it JSON.parses (the inline-script escapes are JSON-valid) with the required fields.
+    const ldBlocks = [
+      ...html.matchAll(/<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g)
+    ].map(m => {
+      try {
+        return JSON.parse(m[1]);
+      } catch {
+        return null;
+      }
+    });
+    const articleLd = ldBlocks.find(o => o && o['@type'] === 'BlogPosting');
+    expect(articleLd, 'BlogPosting JSON-LD present and valid JSON').toBeTruthy();
+    expect(articleLd.headline.length, 'headline <= 110 (R4-F17)').toBeLessThanOrEqual(110);
+    expect(articleLd.datePublished, 'datePublished ISO').toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(articleLd.dateModified, 'dateModified ISO (R3-F18)').toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(articleLd.author['@type']).toBe('Organization');
+    expect(articleLd.publisher['@type']).toBe('Organization');
+    expect(articleLd.mainEntityOfPage['@id']?.startsWith(origin)).toBe(true);
+    // The org block still coexists (R2-F24).
+    expect(
+      ldBlocks.some(o => o && o['@type'] === 'EducationalOrganization'),
+      'org JSON-LD still present alongside the article block'
+    ).toBe(true);
+    // RSS auto-discovery + article:modified_time.
+    expect(html, 'RSS auto-discovery link').toContain('type="application/rss+xml"');
+    expect(metaContent(html, 'article:modified_time'), 'article:modified_time ISO').toMatch(
+      /^\d{4}-\d{2}-\d{2}T/
+    );
+
     // Same robots discipline on /blog index.
     const indexHtml = await (await request.get('/blog')).text();
     expect(metaContent(indexHtml, 'robots', 'name')?.toLowerCase()).toContain('index');

--- a/app/src/layouts/Layout.astro
+++ b/app/src/layouts/Layout.astro
@@ -16,6 +16,15 @@ export interface Props {
   ogImageAlt?: string;
   ogType?: string;
   publishedTime?: string;
+  /** ISO `article:modified_time` OG tag (post pages — pairs with `publishedTime`). */
+  modifiedTime?: string;
+  /**
+   * Pre-serialized, inline-script-safe JSON-LD (e.g. `buildArticleJsonLd`). Rendered as an additional
+   * `application/ld+json` block ALONGSIDE the site-wide organization block (R2-F24).
+   */
+  jsonLd?: string;
+  /** RSS feed URL for an auto-discovery `<link rel="alternate">` (blog pages). */
+  feedUrl?: string;
   /**
    * Request a soft `noindex, follow` for thin/duplicate routes (paginated lists, tag filters,
    * below-threshold category pages). Defaults to `'index'`; a hard noindex (site-wide kill switch or
@@ -33,6 +42,9 @@ const {
   ogImageAlt,
   ogType = 'website',
   publishedTime,
+  modifiedTime,
+  jsonLd,
+  feedUrl,
   robots = 'index'
 } = Astro.props;
 
@@ -72,6 +84,7 @@ const preloadLinks = preloadImages ? generatePreloadLinks(CRITICAL_IMAGES) : '';
     <link rel="canonical" href={canonicalURL} />
     <meta name="robots" content={seoMetadata.robotsContent} />
     {seoMetadata.googlebotContent && <meta name="googlebot" content={seoMetadata.googlebotContent} />}
+    {feedUrl && <link rel="alternate" type="application/rss+xml" title="Spicebush Montessori Blog" href={feedUrl} />}
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content={ogType} />
@@ -81,6 +94,7 @@ const preloadLinks = preloadImages ? generatePreloadLinks(CRITICAL_IMAGES) : '';
     <meta property="og:image" content={resolvedOgImage} />
     {ogImage && ogImageAlt && <meta property="og:image:alt" content={ogImageAlt} />}
     {ogType === 'article' && publishedTime && <meta property="article:published_time" content={publishedTime} />}
+    {ogType === 'article' && modifiedTime && <meta property="article:modified_time" content={modifiedTime} />}
 
     <!-- Twitter -->
     <meta property="twitter:card" content={seoMetadata.twitterCard} />
@@ -122,6 +136,10 @@ const preloadLinks = preloadImages ? generatePreloadLinks(CRITICAL_IMAGES) : '';
         }
       }
     </script>
+
+    {/* Per-page structured data (e.g. blog Article), alongside the org block. Already serialized
+        inline-script-safe by `serializeJsonLd` (R1-F29/R2-F24). */}
+    {jsonLd && <script type="application/ld+json" is:inline set:html={jsonLd} />}
 
     {shouldLoadGaScript && (
       <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaMeasurementId)}`}></script>

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -22,9 +22,12 @@ vi.mock('@lib/db/client', () => ({
 import type { ContentEntry } from '@lib/db/types';
 import {
   blogPostToEditData,
+  buildArticleJsonLd,
   compareBlogPosts,
   computeReadingTime,
   escapeXml,
+  isoOrNull,
+  serializeJsonLd,
   getManagedBlogPosts,
   getPublishedPosts,
   normalizeBlogData,
@@ -1016,6 +1019,97 @@ describe('renderBlogRssXml (R1-F30)', () => {
     expect(xml).toContain('<channel>');
     expect((xml.match(/<item>/g) ?? []).length).toBe(0);
     expect(xml.trimEnd().endsWith('</rss>')).toBe(true);
+  });
+});
+
+describe('isoOrNull (R3-F18)', () => {
+  it('normalizes a Postgres-format timestamp (space, not T) to ISO-8601', () => {
+    expect(isoOrNull('2026-06-09 04:32:05.960997+00')).toBe('2026-06-09T04:32:05.960Z');
+  });
+
+  it('passes through an already-ISO value', () => {
+    expect(isoOrNull('2024-05-20T12:00:00Z')).toBe('2024-05-20T12:00:00.000Z');
+  });
+
+  it('returns null for empty/undefined/unparseable', () => {
+    expect(isoOrNull('')).toBeNull();
+    expect(isoOrNull(undefined)).toBeNull();
+    expect(isoOrNull('not-a-date')).toBeNull();
+  });
+});
+
+describe('serializeJsonLd (R1-F29 inline-script safety)', () => {
+  it('escapes <, >, & so the JSON cannot break out of a <script> element', () => {
+    const out = serializeJsonLd({ a: '</script><b>&' });
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<b>');
+    expect(out).toContain('\\u003c'); // <
+    expect(out).toContain('\\u003e'); // >
+    expect(out).toContain('\\u0026'); // &
+  });
+
+  it('round-trips back to the original object via JSON.parse (escapes are JSON-valid)', () => {
+    const obj = { headline: 'Tom & Jerry </script> <b>', n: 1, nested: { x: ['<a>'] } };
+    expect(JSON.parse(serializeJsonLd(obj))).toEqual(obj);
+  });
+
+  it('escapes the U+2028/U+2029 line separators that break inline scripts', () => {
+    const out = serializeJsonLd({ a: String.fromCharCode(0x2028, 0x2029) });
+    expect(out).toContain('\\u2028');
+    expect(out).toContain('\\u2029');
+  });
+});
+
+describe('buildArticleJsonLd (R1-F29 / R3-F18 / R4-F17)', () => {
+  const origin = 'https://spicebushmontessori.org';
+
+  it('emits a valid BlogPosting with required schema.org fields that JSON.parse round-trips', () => {
+    const post = makePost({
+      slug: 'gardening',
+      title: 'Our Gardening Program',
+      excerpt: 'Excerpt',
+      date: '2024-05-20',
+      updatedAt: '2026-06-09 04:32:05.96+00'
+    });
+    const parsed = JSON.parse(buildArticleJsonLd(post, origin));
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@type']).toBe('BlogPosting');
+    expect(parsed.headline).toBe('Our Gardening Program');
+    expect(parsed.url).toBe(`${origin}/blog/gardening`);
+    expect(parsed.mainEntityOfPage['@id']).toBe(`${origin}/blog/gardening`);
+    expect(parsed.author).toEqual({ '@type': 'Organization', name: 'Spicebush Team' });
+    expect(parsed.publisher['@type']).toBe('Organization');
+    expect(parsed.publisher.logo.url).toBe(`${origin}/SpicebushLogo-03.png`);
+    expect(parsed.datePublished).toBe('2024-05-20T12:00:00.000Z');
+    // dateModified is the NORMALIZED updated_at (R3-F18), not the raw Postgres string.
+    expect(parsed.dateModified).toBe('2026-06-09T04:32:05.960Z');
+  });
+
+  it('falls back dateModified to datePublished when updated_at is absent', () => {
+    const parsed = JSON.parse(buildArticleJsonLd(makePost({ date: '2024-05-20' }), origin));
+    expect(parsed.dateModified).toBe(parsed.datePublished);
+  });
+
+  it('clamps headline to <=110 chars from the TITLE, not the 160-cap seoTitle (R4-F17)', () => {
+    const longTitle = 'A'.repeat(150);
+    const post = makePost({ title: longTitle, seoTitle: 'B'.repeat(160) });
+    const parsed = JSON.parse(buildArticleJsonLd(post, origin));
+    expect(parsed.headline.length).toBe(110);
+    expect(parsed.headline.startsWith('A')).toBe(true); // from title, never seoTitle
+    expect(parsed.headline.endsWith('…')).toBe(true);
+  });
+
+  it('includes an absolutized image only when the post has a featured image', () => {
+    const withImg = JSON.parse(
+      buildArticleJsonLd(makePost({ image: '/images/blog/x.webp' }), origin)
+    );
+    expect(withImg.image).toBe(`${origin}/images/blog/x.webp`);
+    const httpsImg = JSON.parse(
+      buildArticleJsonLd(makePost({ image: 'https://cdn.example.com/x.webp' }), origin)
+    );
+    expect(httpsImg.image).toBe('https://cdn.example.com/x.webp');
+    const noImg = JSON.parse(buildArticleJsonLd(makePost({ image: undefined }), origin));
+    expect('image' in noImg).toBe(false);
   });
 });
 

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -28,6 +28,8 @@ export type BlogPost = {
   status: string;
   /** Precise scheduled-publish instant (ISO-8601 w/ zone) for `status='scheduled'` posts (R4-F1). */
   publishedAt?: string;
+  /** Raw `content.updated_at` (Postgres format) for JSON-LD `dateModified` (R3-F18); normalize on use. */
+  updatedAt?: string;
   categories?: string[];
   tags?: string[];
   readingTime?: number;
@@ -146,6 +148,7 @@ function mapEntryToBlogPost(entry: ContentEntry): BlogPost | null {
     seoDescription: emptyToUndefined(asTrimmedString(data.seoDescription)),
     status: 'published',
     publishedAt: emptyToUndefined(asTrimmedString(data.publishedAt)),
+    updatedAt: emptyToUndefined(asTrimmedString(entry.updatedAt)),
     categories: asStringArray(data.categories),
     tags: asStringArray(data.tags),
     // Prefer the value stored on save; fall back to computing from the body so the 6 legacy posts
@@ -706,4 +709,75 @@ export function renderBlogRssXml(posts: BlogPost[], origin: string): string {
     '  </channel>',
     '</rss>'
   ].join('\n');
+}
+
+// Publisher logo for Article structured data — the same brand asset the SEO fallback OG uses.
+const PUBLISHER_LOGO_PATH = '/SpicebushLogo-03.png';
+const PUBLISHER_NAME = 'Spicebush Montessori School';
+// schema.org `headline` SHOULD be ≤110 chars (Google truncates beyond ~110); clamp from the TITLE,
+// never the 160-cap `seoTitle` (R4-F17).
+const JSONLD_HEADLINE_MAX = 110;
+
+/**
+ * Best-effort ISO-8601 from a possibly Postgres-format (`2024-05-20 16:04:05+00`, space not `T`) or
+ * `Date`-stringified value; `null` when unparseable. JSON-LD dates must be ISO-8601, and the DB
+ * driver's `updated_at` shape is not guaranteed, so normalize at the point of use (R3-F18).
+ */
+export function isoOrNull(value: string | undefined): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+/**
+ * Serialize an object for safe embedding in an inline `<script type="application/ld+json">` (R1-F29).
+ * `JSON.stringify` (NEVER `escapeXml`, which would corrupt the JSON), then neutralize the only chars
+ * that can break out of a `<script>` element (`<` → `</script>`/`<!--`) or a JS string literal
+ * (U+2028/U+2029). These never appear as JSON STRUCTURAL characters, so the result still
+ * `JSON.parse`s back to the original object.
+ */
+export function serializeJsonLd(obj: unknown): string {
+  return JSON.stringify(obj).replace(
+    /[<>&\u2028\u2029]/g,
+    ch => `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`
+  );
+}
+
+/**
+ * Build the schema.org `BlogPosting` JSON-LD for a post, serialized inline-script-safe. `headline` is
+ * clamped to ≤110 chars FROM THE TITLE (R4-F17). `datePublished` is the post date at noon UTC;
+ * `dateModified` is the normalized `updated_at`, falling back to `datePublished` (R3-F18). `image`
+ * (absolutized) is included only when the post has a featured image. `author`/`publisher` are
+ * Organizations (the live byline is the school team, not a person).
+ */
+export function buildArticleJsonLd(post: BlogPost, origin: string): string {
+  const url = `${origin}/blog/${post.slug}`;
+  const headline =
+    post.title.length <= JSONLD_HEADLINE_MAX
+      ? post.title
+      : `${post.title.slice(0, JSONLD_HEADLINE_MAX - 1)}…`;
+  const datePublished = isoOrNull(post.date ? `${post.date}T12:00:00Z` : undefined);
+  const dateModified = isoOrNull(post.updatedAt) ?? datePublished;
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    url,
+    description: post.seoDescription || post.excerpt,
+    author: { '@type': 'Organization', name: post.author },
+    publisher: {
+      '@type': 'Organization',
+      name: PUBLISHER_NAME,
+      logo: { '@type': 'ImageObject', url: `${origin}${PUBLISHER_LOGO_PATH}` }
+    }
+  };
+  if (datePublished) jsonLd.datePublished = datePublished;
+  if (dateModified) jsonLd.dateModified = dateModified;
+  if (post.image) {
+    jsonLd.image = /^https?:\/\//.test(post.image) ? post.image : `${origin}${post.image}`;
+  }
+
+  return serializeJsonLd(jsonLd);
 }

--- a/app/src/lib/db/__tests__/content.test.ts
+++ b/app/src/lib/db/__tests__/content.test.ts
@@ -36,7 +36,9 @@ describe('db.content facade', () => {
         body: 'Hello world'
       },
       status: 'published',
-      created_at: '2024-01-01T00:00:00.000Z'
+      created_at: '2024-01-01T00:00:00.000Z',
+      // Postgres-format (space, not `T`) — toContentEntry passes it through raw as `updatedAt`.
+      updated_at: '2024-01-02 03:04:05+00'
     };
 
     const secondRow = {
@@ -62,7 +64,9 @@ describe('db.content facade', () => {
           title: 'Welcome Override',
           body: 'Hello world'
         },
-        body: 'Hello world'
+        body: 'Hello world',
+        // Raw passthrough of content.updated_at (R3-F18 plumbing) — not normalized at this layer.
+        updatedAt: '2024-01-02 03:04:05+00'
       }
     ]);
 

--- a/app/src/lib/db/content.ts
+++ b/app/src/lib/db/content.ts
@@ -48,7 +48,11 @@ const toContentEntry = (row: ContentRow): ContentEntry => {
     slug: row.slug,
     collection: row.type,
     data: mergedData,
-    body: bodyValue
+    body: bodyValue,
+    // Raw passthrough (not normalized here — the generic layer stays generic; the blog JSON-LD
+    // normalizes to ISO at the point of use). Coerce to string so a driver that hands back a `Date`
+    // still round-trips through `new Date(...)`. `undefined` when the row/mock omits it.
+    updatedAt: row.updated_at != null ? String(row.updated_at) : undefined
   };
 };
 

--- a/app/src/lib/db/types.ts
+++ b/app/src/lib/db/types.ts
@@ -304,4 +304,11 @@ export interface ContentEntry<T = Record<string, unknown>> {
   collection: string;
   data: T & { title?: string };
   body?: string;
+  /**
+   * Raw `content.updated_at` carried through for consumers that need a modified timestamp (e.g. the
+   * blog's JSON-LD `dateModified`). The DB driver may return a Postgres-format string (space, not
+   * `T`) or a `Date`, so callers that need ISO-8601 MUST normalize (`new Date(v).toISOString()`).
+   * Optional: absent when the row/mocks don't provide it.
+   */
+  updatedAt?: string;
 }

--- a/app/src/pages/blog.astro
+++ b/app/src/pages/blog.astro
@@ -15,7 +15,7 @@ const posts = await getPublishedPosts();
 const pagination = paginate(posts, 1);
 ---
 
-<Layout title="Blog">
+<Layout title="Blog" feedUrl="/blog/rss.xml">
   <Header />
 
   <main id="main-content" class="container mx-auto px-4 py-12">

--- a/app/src/pages/blog/[slug].astro
+++ b/app/src/pages/blog/[slug].astro
@@ -6,8 +6,10 @@ import TaxonomyChips from '@components/blog/TaxonomyChips.astro';
 import ShareButtons from '@components/blog/ShareButtons.astro';
 import RelatedPosts from '@components/blog/RelatedPosts.astro';
 import {
+  buildArticleJsonLd,
   getPublishedPost,
   getPublishedPosts,
+  isoOrNull,
   resolveLegacyBlogRedirect,
   renderPostBody
 } from '@lib/blog-content';
@@ -41,6 +43,11 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
 const siteOrigin = resolveSiteOrigin(Astro.site);
 const postUrl = new URL(`/blog/${post.slug}`, siteOrigin).href;
 
+// Article structured data (R1-F29) + the OG modified-time (R3-F18), both normalized to ISO-8601.
+const articleJsonLd = buildArticleJsonLd(post, siteOrigin);
+const modifiedTime =
+  isoOrNull(post.updatedAt) ?? (post.date ? `${post.date}T12:00:00Z` : undefined);
+
 const formatDate = (date: string | undefined): string | null => {
   if (!date) return null;
   const parsed = new Date(date);
@@ -64,6 +71,9 @@ const bodyHtml = renderPostBody(post.body);
   ogImage={post.image ? new URL(post.image, siteOrigin).href : undefined}
   ogImageAlt={post.imageAlt}
   publishedTime={post.date ? `${post.date}T12:00:00Z` : undefined}
+  modifiedTime={modifiedTime}
+  jsonLd={articleJsonLd}
+  feedUrl="/blog/rss.xml"
 >
   <Header />
 

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -638,6 +638,28 @@ with no googlebot-noindex tag on `/blog` and post pages.
 - `robots.txt` appends `Sitemap: {origin}/sitemap-blog.xml`. Search Console submission is the
   recovery mechanism for the unwound 301s.
 
+### Feeds & structured data (Phase 4)
+
+- **RSS feed** — `/blog/rss.xml` (`app/src/pages/blog/rss.xml.ts`, `prerender = false`; the static
+  path wins over `/blog/[slug]`). `getPublishedPosts()` → `renderBlogRssXml(posts, origin)` → RSS 2.0
+  with an `atom:self` link, one `<item>` per post (title, link, permalink `<guid>`, excerpt
+  `<description>`, RFC-822 `<pubDate>` from `toRfc822Date` at noon UTC), all XML-escaped.
+  `<lastBuildDate>` is the newest post's date (deterministic, no `Date.now()`). Auto-discovered via a
+  `<link rel="alternate" type="application/rss+xml">` in the blog `<head>` (Layout `feedUrl` prop).
+- **JSON-LD Article** — each post page emits a `BlogPosting` block (`buildArticleJsonLd(post, origin)`)
+  ALONGSIDE the site-wide `EducationalOrganization` block (R2-F24), via the Layout `jsonLd` prop.
+  Serialized with `serializeJsonLd` = `JSON.stringify` + `<`/`>`/`&`/U+2028/U+2029 → `\uXXXX`
+  (inline-`<script>`-safe, NOT `escapeXml`; round-trips through `JSON.parse` — R1-F29). `headline` is
+  clamped ≤110 chars from the **title** (never the 160-cap `seoTitle` — R4-F17); `datePublished` =
+  post date at noon UTC; `dateModified` = the normalized `updated_at` (`isoOrNull`, falling back to
+  `datePublished` — R3-F18); `image` (absolutized) only when a featured image exists; `author` and
+  `publisher` are Organizations. A paired `article:modified_time` OG tag uses the same value.
+- **`updated_at` plumbing (R3-F18)** — `content.updated_at` is carried through the generic
+  `toContentEntry` as `ContentEntry.updatedAt` (raw passthrough; the DB driver's format is not
+  guaranteed) and surfaced as `BlogPost.updatedAt`; ISO normalization happens only at the JSON-LD
+  point of use. The 6 legacy posts' `updated_at` reflects the cutover date, so their `dateModified`
+  is the cutover instant (semantically correct — the body was rewritten then).
+
 ### Legacy URL preservation
 
 Three layers preserve historical URLs: (1) the six clean slugs restore the Markdown-era URLs; (2) the


### PR DESCRIPTION
## Phase 4 · PR2 — JSON-LD Article + structured-data head slot

Adds per-post structured data + RSS auto-discovery and plumbs `updated_at` through for `dateModified` (R3-F18).

### `blog-content.ts`
- **`serializeJsonLd(obj)`** — `JSON.stringify` then neutralize `<`/`>`/`&`/U+2028/U+2029 → `\uXXXX` for safe inline `<script type="application/ld+json">` (**R1-F29** — NOT `escapeXml`; the escapes are JSON-valid so it round-trips through `JSON.parse`).
- **`buildArticleJsonLd(post, origin)`** — schema.org `BlogPosting`. `headline` clamped **≤110 from the title**, never the 160-cap `seoTitle` (**R4-F17**); `datePublished` at noon UTC; `dateModified` = normalized `updated_at` (`isoOrNull`) `?? datePublished` (**R3-F18**); absolutized `image` only when present; `author`/`publisher` are Organizations.
- **`isoOrNull(v)`** — best-effort ISO-8601 from a Postgres-format (`2024-05-20 16:04:05+00`, space not `T`) or `Date`-stringified value; `null` when unparseable. (The driver's `updated_at` shape isn't guaranteed — confirmed prod returns the space form.)

### `updated_at` plumbing (R3-F18)
`ContentEntry` gains optional `updatedAt` (**raw passthrough** in `toContentEntry` — the generic layer stays generic, robust to a `Date` via `String()`), surfaced as `BlogPost.updatedAt`; ISO normalization happens only at the JSON-LD point of use. `db/__tests__/content.test.ts` updated to mock + assert the passthrough.

### `Layout.astro` (mirrors the PR1b prop pattern)
New optional props: `jsonLd` (renders an additional ld+json block **alongside** the org block — R2-F24), `feedUrl` (RSS `<link rel="alternate">`), `modifiedTime` (`article:modified_time` OG). All no-op when omitted. Post page passes all three; `/blog` index passes `feedUrl`.

### Verification
- **CI units** (R4-F21): `isoOrNull` normalization; `serializeJsonLd` escaping + `JSON.parse` round-trip + U+2028/U+2029; `buildArticleJsonLd` required fields / headline-clamp / dateModified-fallback / image. **463 tests.**
- **E2E test 19** asserts the post-page `BlogPosting` JSON-LD parses, coexists with the org block, plus the RSS link + `article:modified_time` (post-deploy render per R4-F21).
- **Live/dev**: PR1 RSS feed serves 6 items; `/blog` renders the RSS alternate link + org block (dev). Post-page JSON-LD render is verified post-deploy via §9.2 curl.

### Note (expected, not a bug)
The 6 legacy posts' `updated_at` = the cutover date, so their `dateModified` is the cutover instant against a 2024 `datePublished` — semantically correct (the body was rewritten at cutover).

### Gates
lint 0-warn · format clean · typecheck 0-err · 463 tests · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)