### PR TITLE
feat(blog): Phase-4 PR3 — dynamic sitemap adds indexable categories + pagination

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -957,8 +957,10 @@ describe('escapeXml + renderBlogSitemapXml', () => {
     const xml = renderBlogSitemapXml(many, origin);
     expect(xml).toContain(`<loc>${origin}/blog/page/2</loc>`);
     expect(xml).toContain(`<loc>${origin}/blog/page/3</loc>`);
-    expect(xml).not.toContain('/blog/page/1');
-    expect(xml).not.toContain('/blog/page/4');
+    // Exact <loc> (not a substring) — `/blog/page/1` must be absent even once the corpus reaches
+    // ≥10 pages, where `/blog/page/10` would contain the bare substring `/blog/page/1`.
+    expect(xml).not.toContain(`<loc>${origin}/blog/page/1</loc>`);
+    expect(xml).not.toContain(`<loc>${origin}/blog/page/4</loc>`);
   });
 
   it('the 6-post corpus paginates to a single page — no /blog/page/* in the sitemap (R4-F10)', () => {

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -932,6 +932,60 @@ describe('escapeXml + renderBlogSitemapXml', () => {
     expect(xml).not.toContain('<loc>https://spicebushmontessori.org/blog/</loc>');
     expect(xml).not.toContain('/blog/first/</loc>');
   });
+
+  it('includes INDEXABLE categories (≥2), excludes thin categories AND all tags (R1-F31/R1-F21)', () => {
+    const origin = 'https://spicebushmontessori.org';
+    const xml = renderBlogSitemapXml(
+      [
+        makePost({ slug: 'a', categories: ['Education', 'Lonely'], tags: ['play'] }),
+        makePost({ slug: 'b', categories: ['Education'], tags: ['play'] })
+      ],
+      origin
+    );
+    // Education has 2 members → indexable → present.
+    expect(xml).toContain(`<loc>${origin}/blog/category/education</loc>`);
+    // "Lonely" has 1 member → thin → absent.
+    expect(xml).not.toContain('/blog/category/lonely');
+    // Tags are never sitemapped (noindex).
+    expect(xml).not.toContain('/blog/tag/');
+  });
+
+  it('lists pagination pages n≥2 only, never /blog/page/1 (R3-F19)', () => {
+    const origin = 'https://spicebushmontessori.org';
+    // 25 posts on a page size of 10 → 3 pages → /blog (p1), /blog/page/2, /blog/page/3.
+    const many = Array.from({ length: 25 }, (_, i) => makePost({ slug: `post-${i}` }));
+    const xml = renderBlogSitemapXml(many, origin);
+    expect(xml).toContain(`<loc>${origin}/blog/page/2</loc>`);
+    expect(xml).toContain(`<loc>${origin}/blog/page/3</loc>`);
+    expect(xml).not.toContain('/blog/page/1');
+    expect(xml).not.toContain('/blog/page/4');
+  });
+
+  it('the 6-post corpus paginates to a single page — no /blog/page/* in the sitemap (R4-F10)', () => {
+    const six = Array.from({ length: 6 }, (_, i) => makePost({ slug: `p${i}` }));
+    const xml = renderBlogSitemapXml(six, 'https://spicebushmontessori.org');
+    expect(xml).not.toContain('/blog/page/');
+  });
+
+  it('emits each route exactly once (R1-F28)', () => {
+    const origin = 'https://spicebushmontessori.org';
+    const xml = renderBlogSitemapXml(
+      [
+        makePost({ slug: 'a', categories: ['Education'] }),
+        makePost({ slug: 'b', categories: ['Education'] })
+      ],
+      origin
+    );
+    const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+    expect(locs.length).toBe(new Set(locs).size); // no duplicates
+    // /blog + 2 posts + 1 indexable category (1 page → no pagination URLs).
+    expect(locs).toEqual([
+      `${origin}/blog`,
+      `${origin}/blog/a`,
+      `${origin}/blog/b`,
+      `${origin}/blog/category/education`
+    ]);
+  });
 });
 
 describe('toRfc822Date (R1-F30)', () => {

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -12,6 +12,7 @@ import { db } from '@lib/db';
 import { queryRows } from '@lib/db/client';
 import type { ContentEntry } from '@lib/db/types';
 import { collectHtmlImageAlts, renderBodyHtml } from './blog-html';
+import { BLOG_PAGE_SIZE, indexableCategories } from './blog-discovery';
 import { isFutureScheduledPublishAt, isScheduledPublishAtFormat } from './blog-publish-schedule';
 
 export type BlogPost = {
@@ -634,16 +635,28 @@ export function escapeXml(s: string): string {
 }
 
 /**
- * Build the `<urlset>` sitemap document. Emits SLASHLESS URLs (R2-F5/F17): `{origin}/blog`
- * and `{origin}/blog/{slug}` — never `/blog/`. No `lastmod` (R1-F7). Every URL is XML-escaped.
+ * Build the `<urlset>` sitemap document. Emits SLASHLESS URLs (R2-F5/F17): `{origin}/blog`, each
+ * `{origin}/blog/{slug}`, each pagination page `{origin}/blog/page/{n}` for **n ≥ 2** (never
+ * `/blog/page/1` — that 301s to `/blog`, R3-F19), and each **indexable** category
+ * `{origin}/blog/category/{slug}` (≥2 members — R1-F31). TAGS and below-threshold categories are
+ * EXCLUDED (they render `noindex` — R1-F21). Every route appears exactly once (R1-F28). No `lastmod`
+ * (R1-F7). Every URL is XML-escaped.
  */
 export function renderBlogSitemapXml(posts: BlogPost[], origin: string): string {
-  const urls = [
-    `  <url>\n    <loc>${escapeXml(`${origin}/blog`)}</loc>\n  </url>`,
-    ...posts.map(
-      post => `  <url>\n    <loc>${escapeXml(`${origin}/blog/${post.slug}`)}</loc>\n  </url>`
-    )
+  const totalPages = Math.max(1, Math.ceil(posts.length / BLOG_PAGE_SIZE));
+  const paths = [
+    `${origin}/blog`,
+    ...posts.map(post => `${origin}/blog/${post.slug}`),
+    // Pagination n ≥ 2 only — none with the current 6-post corpus on a ≥10 page size.
+    ...Array.from(
+      { length: Math.max(0, totalPages - 1) },
+      (_, i) => `${origin}/blog/page/${i + 2}`
+    ),
+    // Indexable categories only (≥2 members); tags + thin categories are noindex, so absent.
+    ...indexableCategories(posts).map(category => `${origin}/blog/category/${category.slug}`)
   ];
+
+  const urls = paths.map(path => `  <url>\n    <loc>${escapeXml(path)}</loc>\n  </url>`);
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>`;
 }

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -363,8 +363,20 @@ curl -sI "$SITE/blog/page/1"                                     # 301 → /blog
 curl -sI "$SITE/blog/page/9"                                     # 404 (out of range on the 1-page corpus)
 curl -sI "$SITE/blog/page/abc"                                   # 404 (non-integer param)
 
+# RSS feed (Phase-4 PR1): valid RSS 2.0 with the live posts
+curl -s "$SITE/blog/rss.xml" | grep -cE '<item>'                # 6 (one per published post)
+curl -s "$SITE/blog/rss.xml" | grep -E '<atom:link|<pubDate>' | head -2   # atom self-link + RFC-822 pubDate
+curl -s "$SITE/blog/<slug>"  | grep -oE 'rel="alternate"[^>]*application/rss' # RSS auto-discovery <link> in <head>
+
+# Article JSON-LD (Phase-4 PR2): the BlogPosting block coexists with the org block + parses
+curl -s "$SITE/blog/<slug>" | grep -oE '"@type":"BlogPosting"'  # present (alongside EducationalOrganization)
+curl -s "$SITE/blog/<slug>" | grep -oE '"datePublished":"[^"]*"|"dateModified":"[^"]*"'  # both ISO-8601 (dateModified normalized from updated_at)
+#   note: the legacy posts' dateModified = the cutover date — expected, not a bug.
+
 # Sitemap + robots (prod origin, exact slashless <loc>, draft-free)
-curl -s "$SITE/sitemap-blog.xml"                                # 200, XML; <loc>$SITE/blog</loc> and <loc>$SITE/blog/<slug></loc>; ≥6 posts; no drafts
+curl -s "$SITE/sitemap-blog.xml"                                # 200, XML; <loc>$SITE/blog</loc>, each <loc>$SITE/blog/<slug></loc>; ≥6 posts; no drafts
+curl -s "$SITE/sitemap-blog.xml" | grep -oE '<loc>[^<]*/blog/category/[^<]*</loc>'  # INDEXABLE categories only (education/philosophy/programs/nature, ≥2 members)
+curl -s "$SITE/sitemap-blog.xml" | grep -E '/blog/tag/|/blog/category/values|/blog/page/1<'  # expect NO matches (tags + thin cats + page/1 excluded)
 curl -s "$SITE/robots.txt" | grep sitemap-blog                  # Sitemap: $SITE/sitemap-blog.xml
 
 # Static sitemap must EXCLUDE blog / resources-blog / admin / auth

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -629,9 +629,12 @@ with no googlebot-noindex tag on `/blog` and post pages.
   `getPublishedPosts()` → `renderBlogSitemapXml(posts, origin)` → `Response` with
   `Content-Type: application/xml`, `Cache-Control: public, max-age=300`. Drafts never appear; no
   `lastmod`. The urlset builder and `escapeXml` live in `blog-content.ts` (coverage-measured).
-- URLs are **slashless**, matching the canonical form (`normalizePathname`): `{origin}/blog` and
-  `{origin}/blog/{slug}` — asserted as exact `<loc>` strings, not substrings. Every interpolated URL
-  passes through `escapeXml`.
+- URLs are **slashless**, matching the canonical form (`normalizePathname`): `{origin}/blog`, each
+  `{origin}/blog/{slug}`, each pagination page `{origin}/blog/page/{n}` for **n ≥ 2** (never
+  `/blog/page/1` — R3-F19), and each **indexable** category `{origin}/blog/category/{slug}` (≥2
+  members — R1-F31, via `indexableCategories`). **Tags and below-threshold categories are EXCLUDED**
+  (they render `noindex` — R1-F21). Every route appears exactly once (R1-F28). Asserted as exact
+  `<loc>` strings, not substrings; every interpolated URL passes through `escapeXml`.
 - The static `@astrojs/sitemap` `filter` excludes the blog URLs (deduped against the blog sitemap),
   the redirected `/resources/blog` and `/resources/blog/*`, and `/admin`, `/admin/*`, `/auth/*` (the
   live `sitemap-0.xml` already discloses the admin and auth surface — a pre-existing issue).


### PR DESCRIPTION
## Phase 4 · PR3 — dynamic sitemap extension

Extends `renderBlogSitemapXml` (R1-F28) beyond `/blog` + post URLs to the discovery routes that should be indexed.

### What the sitemap now lists
- `{origin}/blog` + each `{origin}/blog/{slug}` (unchanged)
- **Pagination** `{origin}/blog/page/{n}` for **n ≥ 2** only — never `/blog/page/1` (it 301s to `/blog`, R3-F19). None today (6 posts ≤ page size 10); appears as the corpus grows.
- **Indexable categories** `{origin}/blog/category/{slug}` (≥2 members, via `indexableCategories` — R1-F31).

### Excluded (by design)
- **Tags** — always `noindex` (R1-F21).
- **Thin categories** (<2 members) — render `noindex`.
- `/blog/page/1` — that's `/blog`.

Every route appears **exactly once** (R1-F28); still slashless + XML-escaped, no `lastmod`.

### Notes
- `blog-content.ts` imports `BLOG_PAGE_SIZE` + `indexableCategories` from `blog-discovery` — no runtime cycle (blog-discovery's `BlogPost` import is type-only, erased at runtime). Build confirms.
- The static `@astrojs/sitemap` filter already excludes all `/blog/*` via its prefix rule (`pathname.startsWith('/blog/')`), so the new routes are owned solely by the dynamic sitemap — no double-listing.

### Tests
Indexable-only categories + tag/thin-category exclusion; pagination n≥2 + no `page/1`; the 6-post corpus stays single-page (no page URLs); each route once (deduped `<loc>` set + exact ordered list). **467 tests.**

### Docs (closes Phase-4 inline docs)
`blog.md` Sitemap section + `deploy.md` §9.2 curls (RSS item count, JSON-LD coexistence, sitemap category-only / no-tags / no-page1).

### Gates
lint 0-warn · format clean · typecheck 0-err · 467 tests · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)