### PR TITLE
feat(blog): Phase-5 — admin per-post view counts from analytics_events

### DIFF
--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -26,6 +26,7 @@ import {
   compareBlogPosts,
   computeReadingTime,
   escapeXml,
+  getBlogPostViewCounts,
   isoOrNull,
   serializeJsonLd,
   getManagedBlogPosts,
@@ -1199,5 +1200,65 @@ describe('resolveLegacyBlogRedirect', () => {
   it('returns null for a non-date-prefixed slug without querying', async () => {
     expect(await resolveLegacyBlogRedirect('regular-slug')).toBeNull();
     expect(getEntryMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getBlogPostViewCounts (Phase 5, R1-F13/R3-F3)', () => {
+  it('aggregates page_view counts by slug, constrained to /blog/{slug} for the given slugs', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      { page_path: '/blog/first', views: 42 },
+      { page_path: '/blog/second', views: 7 }
+    ]);
+    const counts = await getBlogPostViewCounts(['first', 'second', 'third']);
+    expect(counts.get('first')).toBe(42);
+    expect(counts.get('second')).toBe(7);
+    expect(counts.get('third')).toBe(0); // requested but no events → 0
+    // The SQL constraint is the trust boundary: it queries page_path = ANY([/blog/first, ...]).
+    const [, params] = queryRowsMock.mock.calls[0];
+    expect(params[0]).toEqual(['/blog/first', '/blog/second', '/blog/third']);
+    expect(queryRowsMock.mock.calls[0][0]).toContain("event_name = 'page_view'");
+    expect(queryRowsMock.mock.calls[0][0]).toContain('page_path = ANY($1)');
+  });
+
+  it('does NOT count a fabricated /blog/<phantom> row outside the requested set (R3-F3)', async () => {
+    // Even if the DB returned a phantom row, the map only has the requested slugs.
+    queryRowsMock.mockResolvedValueOnce([
+      { page_path: '/blog/real', views: 5 },
+      { page_path: '/blog/phantom', views: 9999 }
+    ]);
+    const counts = await getBlogPostViewCounts(['real']);
+    expect(counts.get('real')).toBe(5);
+    expect(counts.has('phantom')).toBe(false);
+    expect([...counts.keys()]).toEqual(['real']);
+  });
+
+  it('charset-filters and de-dupes input slugs before querying', async () => {
+    queryRowsMock.mockResolvedValueOnce([]);
+    const counts = await getBlogPostViewCounts(['ok-slug', 'Bad Slug!', '../etc', 'ok-slug']);
+    expect([...counts.keys()]).toEqual(['ok-slug']); // invalid dropped, dup collapsed
+    const [, params] = queryRowsMock.mock.calls[0];
+    expect(params[0]).toEqual(['/blog/ok-slug']);
+  });
+
+  it('returns an empty map and skips the query for no usable slugs', async () => {
+    const counts = await getBlogPostViewCounts([]);
+    expect(counts.size).toBe(0);
+    expect(queryRowsMock).not.toHaveBeenCalled();
+
+    const onlyBad = await getBlogPostViewCounts(['Bad!', '']);
+    expect(onlyBad.size).toBe(0);
+    expect(queryRowsMock).not.toHaveBeenCalled();
+  });
+
+  it('coerces string/zero/negative counts to a non-negative integer', async () => {
+    queryRowsMock.mockResolvedValueOnce([
+      { page_path: '/blog/a', views: '13' },
+      { page_path: '/blog/b', views: 0 },
+      { page_path: '/blog/c', views: -4 }
+    ]);
+    const counts = await getBlogPostViewCounts(['a', 'b', 'c']);
+    expect(counts.get('a')).toBe(13);
+    expect(counts.get('b')).toBe(0);
+    expect(counts.get('c')).toBe(0); // negative coerced to 0
   });
 });

--- a/app/src/lib/blog-content.test.ts
+++ b/app/src/lib/blog-content.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getCollectionMock, getEntryMock, queryRowsMock } = vi.hoisted(() => ({
+const { getCollectionMock, getEntryMock, queryRowsMock, logErrorMock } = vi.hoisted(() => ({
   getCollectionMock: vi.fn(),
   getEntryMock: vi.fn(),
-  queryRowsMock: vi.fn()
+  queryRowsMock: vi.fn(),
+  logErrorMock: vi.fn()
 }));
 
 vi.mock('@lib/db', () => ({
@@ -17,6 +18,10 @@ vi.mock('@lib/db', () => ({
 
 vi.mock('@lib/db/client', () => ({
   queryRows: queryRowsMock
+}));
+
+vi.mock('./error-logger', () => ({
+  logError: logErrorMock
 }));
 
 import type { ContentEntry } from '@lib/db/types';
@@ -1260,5 +1265,19 @@ describe('getBlogPostViewCounts (Phase 5, R1-F13/R3-F3)', () => {
     expect(counts.get('a')).toBe(13);
     expect(counts.get('b')).toBe(0);
     expect(counts.get('c')).toBe(0); // negative coerced to 0
+  });
+
+  it('degrades to the zero-filled map (does NOT throw) when the analytics query fails', async () => {
+    logErrorMock.mockClear();
+    queryRowsMock.mockRejectedValueOnce(new Error('analytics_events unavailable'));
+    const counts = await getBlogPostViewCounts(['a', 'b']);
+    // Best-effort: a DB failure must never take down the admin dashboard.
+    expect(counts.get('a')).toBe(0);
+    expect(counts.get('b')).toBe(0);
+    expect(logErrorMock).toHaveBeenCalledWith(
+      'blog.viewCounts',
+      expect.any(Error),
+      expect.objectContaining({ action: 'getBlogPostViewCounts' })
+    );
   });
 });

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -14,6 +14,7 @@ import type { ContentEntry } from '@lib/db/types';
 import { collectHtmlImageAlts, renderBodyHtml } from './blog-html';
 import { BLOG_PAGE_SIZE, indexableCategories } from './blog-discovery';
 import { isFutureScheduledPublishAt, isScheduledPublishAtFormat } from './blog-publish-schedule';
+import { logError } from './error-logger';
 
 export type BlogPost = {
   slug: string;
@@ -263,20 +264,29 @@ export async function getBlogPostViewCounts(slugs: string[]): Promise<Map<string
   if (cleanSlugs.length === 0) return counts;
 
   const paths = cleanSlugs.map(slug => `/blog/${slug}`);
-  const rows = await queryRows<{ page_path: string | null; views: number | string }>(
-    `SELECT page_path, COUNT(*)::int AS views
-       FROM analytics_events
-      WHERE event_name = 'page_view' AND page_path = ANY($1)
-      GROUP BY page_path`,
-    [paths]
-  );
+  try {
+    const rows = await queryRows<{ page_path: string | null; views: number | string }>(
+      `SELECT page_path, COUNT(*)::int AS views
+         FROM analytics_events
+        WHERE event_name = 'page_view' AND page_path = ANY($1)
+        GROUP BY page_path`,
+      [paths]
+    );
 
-  for (const row of rows) {
-    const slug = typeof row.page_path === 'string' ? row.page_path.replace(/^\/blog\//, '') : '';
-    if (!counts.has(slug)) continue; // ignore anything outside the requested set (belt-and-suspenders)
-    const views =
-      typeof row.views === 'number' ? row.views : Number.parseInt(String(row.views), 10);
-    counts.set(slug, Number.isFinite(views) && views > 0 ? Math.trunc(views) : 0);
+    for (const row of rows) {
+      const slug = typeof row.page_path === 'string' ? row.page_path.replace(/^\/blog\//, '') : '';
+      if (!counts.has(slug)) continue; // ignore anything outside the requested set (belt-and-suspenders)
+      const views =
+        typeof row.views === 'number' ? row.views : Number.parseInt(String(row.views), 10);
+      counts.set(slug, Number.isFinite(views) && views > 0 ? Math.trunc(views) : 0);
+    }
+  } catch (error) {
+    // Analytics is best-effort and must NEVER take down the admin dashboard — degrade to the
+    // zero-filled map (matching the try/catch convention in db/analytics.ts).
+    logError('blog.viewCounts', error, {
+      action: 'getBlogPostViewCounts',
+      count: cleanSlugs.length
+    });
   }
 
   return counts;

--- a/app/src/lib/blog-content.ts
+++ b/app/src/lib/blog-content.ts
@@ -248,6 +248,41 @@ export async function getPublishedPost(slug: string): Promise<BlogPost | null> {
 }
 
 /**
+ * Best-effort per-post view counts (Phase 5, R1-F13/R3-F3) from the EXISTING `analytics_events`
+ * table — no new schema. Aggregates `page_view` events by `page_path`, **constrained to `/blog/{slug}`
+ * for the given slugs** (`page_path = ANY($1)`), so a fabricated `/blog/<phantom>` event row is never
+ * counted (R3-F3); the SQL constraint is the trust boundary. Input slugs are charset-filtered first
+ * (defence in depth — callers pass already-published slugs). Returns slug → count, with `0` for every
+ * requested slug that has no events. Counts are **forgeable/approximate** (client-fired analytics) —
+ * the caller MUST label them as such in the UI.
+ */
+export async function getBlogPostViewCounts(slugs: string[]): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const cleanSlugs = Array.from(new Set(slugs.filter(slug => SLUG_REGEX.test(slug))));
+  for (const slug of cleanSlugs) counts.set(slug, 0);
+  if (cleanSlugs.length === 0) return counts;
+
+  const paths = cleanSlugs.map(slug => `/blog/${slug}`);
+  const rows = await queryRows<{ page_path: string | null; views: number | string }>(
+    `SELECT page_path, COUNT(*)::int AS views
+       FROM analytics_events
+      WHERE event_name = 'page_view' AND page_path = ANY($1)
+      GROUP BY page_path`,
+    [paths]
+  );
+
+  for (const row of rows) {
+    const slug = typeof row.page_path === 'string' ? row.page_path.replace(/^\/blog\//, '') : '';
+    if (!counts.has(slug)) continue; // ignore anything outside the requested set (belt-and-suspenders)
+    const views =
+      typeof row.views === 'number' ? row.views : Number.parseInt(String(row.views), 10);
+    counts.set(slug, Number.isFinite(views) && views > 0 ? Math.trunc(views) : 0);
+  }
+
+  return counts;
+}
+
+/**
  * Admin list read path: ALL `type='blog'` rows with NO status filter (R1-F9) — drafts and
  * stray-status rows included. Uncached (queries directly) so the author always sees their save.
  */

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from '@layouts/AdminLayout.astro';
 import {
+  getBlogPostViewCounts,
   getManagedBlogPosts,
   renderPostBody,
   blogPostToEditData,
@@ -23,6 +24,10 @@ const archivedPosts = posts.filter(p => p.status === 'archived');
 const draftPosts = posts.filter(
   p => p.status !== 'published' && p.status !== 'scheduled' && p.status !== 'archived'
 );
+
+// Best-effort per-post view counts (Phase 5) — only published posts have a public `/blog/{slug}`
+// page, so only they can accrue `page_view` events. Constrained to these slugs in SQL (R3-F3).
+const viewCounts = await getBlogPostViewCounts(publishedPosts.map(p => p.slug));
 
 // Existing-slug list for the client collision check (server-rendered into a data- attribute).
 const existingSlugs = posts.map(p => p.slug);
@@ -517,6 +522,16 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                       <span class="flex flex-wrap items-center justify-between gap-2">
                         <span class="font-semibold text-earth-brown">{post.title}</span>
                         <span class="flex items-center gap-2 text-xs">
+                          {/* Best-effort view count — only published posts are in the map (R3-F3).
+                              The count is a number (auto-escaped); no raw page_path is ever rendered. */}
+                          {viewCounts.has(post.slug) && (
+                            <span
+                              class="text-earth-brown/70"
+                              title="Approximate page views from site analytics — best-effort and can be over- or under-counted; not an authoritative figure."
+                            >
+                              {viewCounts.get(post.slug)} views
+                            </span>
+                          )}
                           <span class={`rounded-full px-2 py-1 ${statusBadgeClass(post)}`}>
                             {statusBadgeLabel(post)}
                           </span>

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -398,6 +398,16 @@ Archive/Delete buttons POST `bulk-archive`/`bulk-delete`; the client adds a **co
 irreversibility-naming `confirm()`** ("Delete N posts? This cannot be undone.", R4-F14) and blocks an
 empty selection. Buttons carry `data-no-loading` so a cancelled confirm never leaves them disabled.
 
+**Per-post view counts (Phase 5, R1-F13/R3-F3).** Each PUBLISHED post's summary shows an
+approximate "N views" badge from `getBlogPostViewCounts(publishedSlugs)`, which aggregates
+`event_name = 'page_view'` rows from the EXISTING `analytics_events` table — **no new schema**. The
+count is **constrained in SQL to `/blog/{slug}` for the published slugs** (`page_path = ANY($1)`), so a
+fabricated `/blog/<phantom>` event row is never counted (R3-F3); the SQL constraint is the trust
+boundary. Only published posts have a public page, so only they carry the badge. The rendered value is
+a NUMBER (Astro auto-escaped) — no raw `page_path` is ever rendered, so there is no hostile-string
+surface. Counts are labelled **best-effort/forgeable** (a `title` tooltip notes they can be over- or
+under-counted) — client-fired analytics, not an authoritative figure.
+
 #### Author byline (`resolveAuthorByline`) — R4-F9
 
 The display byline resolves as: `registry.get(author_ref)` when `data.author_type` + `data.author_ref`


### PR DESCRIPTION
## Phase 5 — admin per-post view counts

Adds best-effort per-post view counts to the `/admin/blog` dashboard from the **existing** `analytics_events` table (R1-F13 — no new schema; R3-F3 — constrained + labelled).

### `getBlogPostViewCounts(slugs)` (blog-content.ts)
Aggregates `event_name = 'page_view'` rows by `page_path`, **constrained in SQL to `/blog/{slug}` for the given slugs** (`page_path = ANY($1)`). A fabricated `/blog/<phantom>` event row is therefore **never counted** (R3-F3) — the SQL constraint is the trust boundary. Input slugs are charset-filtered + de-duped; returns `slug → count` (0 when no events); counts coerced to non-negative integers.

### `/admin/blog` display
Each **published** post's summary shows an "N views" badge (only published posts have a public page, so only they accrue views). The rendered value is a **number** (Astro auto-escaped) — **no raw `page_path` is ever rendered**, so there is no hostile-string surface. A `title` tooltip labels the count **best-effort/forgeable** (client-fired analytics, not authoritative).

### On R3-F3's "hostile page_path escaped" render assertion
N/A by design here: the dashboard renders a **number keyed by the validated slug**, never the raw `page_path`. The plan's render-escape concern presupposed showing `page_path`; this design sidesteps it entirely (stricter than the minimum).

### Tests (CI units)
SQL-constraint shape (`page_view` + `ANY($1)` path list), phantom-row exclusion, charset-filter + dedupe, empty-input query skip, count coercion (string/zero/negative). **472 tests.**

### Docs
`blog.md` dashboard section.

### Gates
lint 0-warn · format clean · typecheck 0-err · 472 tests · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published blog posts in the admin panel now display approximate view counts derived from site analytics events.

* **Documentation**
  * Updated blog specification with per-post view count implementation details and data constraints.

* **Tests**
  * Added test coverage verifying view count aggregation, slug validation, deduplication, and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->