### PR TITLE
feat(blog): Phase-6 PR1 — ticker lib (render-time href/expiry/≤5 + 5-min TTL)

### DIFF
--- a/app/src/lib/db/__tests__/ticker.test.ts
+++ b/app/src/lib/db/__tests__/ticker.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSettingMock } = vi.hoisted(() => ({ getSettingMock: vi.fn() }));
+
+vi.mock('../content', () => ({
+  getSetting: getSettingMock
+}));
+
+import { STRICT_CONFIG_V2 } from '../../blog-html';
+import {
+  LINK_HREF_REGEX,
+  getActiveTickerItems,
+  getTickerEnabled,
+  isSafeTickerHref,
+  type TickerItem
+} from '../ticker';
+
+// Convenience: stub the two settings keys the ticker reads.
+const stubSettings = (enabled: unknown, items: unknown) => {
+  getSettingMock.mockImplementation(async (key: string) => {
+    if (key === 'ticker_enabled') return enabled;
+    if (key === 'ticker_items') return items;
+    return null;
+  });
+};
+
+const NOW = Date.parse('2026-06-09T12:00:00Z');
+
+beforeEach(() => {
+  getSettingMock.mockReset();
+});
+
+describe('isSafeTickerHref (R3-F4)', () => {
+  it('ACCEPTS https / mailto / tel / site-relative (the positive survival cases)', () => {
+    expect(isSafeTickerHref('https://spicebushmontessori.org')).toBe(true);
+    expect(isSafeTickerHref('mailto:hi@spicebushmontessori.org')).toBe(true);
+    expect(isSafeTickerHref('tel:+14842020712')).toBe(true);
+    expect(isSafeTickerHref('/blog')).toBe(true);
+  });
+
+  it('REJECTS javascript: / data: / protocol-relative // and empty', () => {
+    // eslint-disable-next-line no-script-url -- intentional XSS test vector
+    expect(isSafeTickerHref('javascript:alert(1)')).toBe(false);
+    expect(isSafeTickerHref('data:text/html,<script>')).toBe(false);
+    expect(isSafeTickerHref('//evil.com')).toBe(false);
+    expect(isSafeTickerHref('http://insecure')).toBe(false); // http (not https) rejected
+    expect(isSafeTickerHref(undefined)).toBe(false);
+    expect(isSafeTickerHref('')).toBe(false);
+  });
+
+  it('PARITY: the href allowlist is byte-identical to blog-html ALLOWED_URI_REGEXP (R3-F1, no drift)', () => {
+    expect(LINK_HREF_REGEX.source).toBe(STRICT_CONFIG_V2.ALLOWED_URI_REGEXP.source);
+    expect(LINK_HREF_REGEX.flags).toBe(STRICT_CONFIG_V2.ALLOWED_URI_REGEXP.flags);
+  });
+});
+
+describe('getTickerEnabled', () => {
+  it('coerces truthy settings forms to true, everything else to false', async () => {
+    for (const truthy of [true, 'true', 1, '1']) {
+      stubSettings(truthy, []);
+      expect(await getTickerEnabled()).toBe(true);
+    }
+    for (const falsy of [false, 'false', 0, null, undefined, 'yes']) {
+      stubSettings(falsy, []);
+      expect(await getTickerEnabled()).toBe(false);
+    }
+  });
+});
+
+describe('getActiveTickerItems', () => {
+  it('returns [] when the ticker is DISABLED even if items exist', async () => {
+    stubSettings(false, [{ text: 'Hi' }]);
+    expect(await getActiveTickerItems(NOW)).toEqual([]);
+  });
+
+  it('returns [] for empty / missing / non-array items', async () => {
+    stubSettings(true, []);
+    expect(await getActiveTickerItems(NOW)).toEqual([]);
+    stubSettings(true, null);
+    expect(await getActiveTickerItems(NOW)).toEqual([]);
+    stubSettings(true, 'not-an-array');
+    expect(await getActiveTickerItems(NOW)).toEqual([]);
+  });
+
+  it('R3-F4 NEGATIVE: strips an unsafe href but KEEPS the item as inert text', async () => {
+    stubSettings(true, [
+      // eslint-disable-next-line no-script-url -- intentional XSS test vector
+      { text: 'Bad link', href: 'javascript:alert(1)' },
+      { text: 'Data link', href: 'data:text/html,x' },
+      { text: 'Proto-rel', href: '//evil.com' }
+    ]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items.map(i => i.text)).toEqual(['Bad link', 'Data link', 'Proto-rel']);
+    expect(items.every(i => i.href === undefined)).toBe(true);
+  });
+
+  it('R3-F4 POSITIVE: keeps safe https/mailto/tel/site-relative hrefs intact', async () => {
+    stubSettings(true, [
+      { text: 'Site', href: 'https://spicebushmontessori.org' },
+      { text: 'Mail', href: 'mailto:hi@spicebushmontessori.org' },
+      { text: 'Call', href: 'tel:+14842020712' },
+      { text: 'Blog', href: '/blog' }
+    ]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items.map(i => i.href)).toEqual([
+      'https://spicebushmontessori.org',
+      'mailto:hi@spicebushmontessori.org',
+      'tel:+14842020712',
+      '/blog'
+    ]);
+  });
+
+  it('R1-F2 SECURITY: a javascript: href stored by the value-blind endpoint is neutralized at render', async () => {
+    // Simulate the settings-write bypass (D2: the endpoint does NO value validation) — the render
+    // path is the trust boundary, so the live link must never reach the page.
+    // eslint-disable-next-line no-script-url -- intentional XSS test vector
+    stubSettings(true, [{ text: 'Click me', href: 'JavaScript:stealCookies()' }]);
+    const [item] = await getActiveTickerItems(NOW);
+    expect(item.text).toBe('Click me');
+    expect(item.href).toBeUndefined();
+  });
+
+  it('EXPIRY: drops a past expiry, keeps a future or unparseable one (injected now)', async () => {
+    stubSettings(true, [
+      { text: 'Expired', expiresAt: '2026-06-08T12:00:00Z' }, // yesterday → dropped
+      { text: 'Future', expiresAt: '2026-06-10T12:00:00Z' }, // tomorrow → kept
+      { text: 'NoExpiry' }, // kept
+      { text: 'Garbage expiry', expiresAt: 'not-a-date' } // unparseable → kept
+    ]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items.map(i => i.text)).toEqual(['Future', 'NoExpiry', 'Garbage expiry']);
+  });
+
+  it('≤5 ENFORCEMENT: a 7-item array yields exactly 5', async () => {
+    stubSettings(
+      true,
+      Array.from({ length: 7 }, (_, i) => ({ text: `Item ${i}` }))
+    );
+    const items = await getActiveTickerItems(NOW);
+    expect(items).toHaveLength(5);
+    expect(items.map(i => i.text)).toEqual(['Item 0', 'Item 1', 'Item 2', 'Item 3', 'Item 4']);
+  });
+
+  it('drops empty-text items and caps text length to 200', async () => {
+    stubSettings(true, [{ text: '   ' }, { text: 'x'.repeat(250) }, { notText: 1 }]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items).toHaveLength(1);
+    expect(items[0].text).toHaveLength(200);
+  });
+
+  it('preserves admin-only `type` metadata when valid, drops an invalid type', async () => {
+    stubSettings(true, [
+      { text: 'A', type: 'closure' },
+      { text: 'B', type: 'bogus' }
+    ]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items[0].type).toBe('closure');
+    expect(items[1].type).toBeUndefined();
+  });
+
+  it('R4-F11 TTL: reads BOTH keys with the dedicated 5-minute maxAge, never the 30-min default', async () => {
+    stubSettings(true, [{ text: 'Hi' }]);
+    await getActiveTickerItems(NOW);
+    const FIVE_MIN = 5 * 60 * 1000;
+    expect(getSettingMock).toHaveBeenCalledWith('ticker_enabled', FIVE_MIN);
+    expect(getSettingMock).toHaveBeenCalledWith('ticker_items', FIVE_MIN);
+  });
+});
+
+// Type-only smoke: TickerItem shape is exported and usable.
+const _example: TickerItem = { text: 'ok' };
+void _example;

--- a/app/src/lib/db/__tests__/ticker.test.ts
+++ b/app/src/lib/db/__tests__/ticker.test.ts
@@ -48,6 +48,22 @@ describe('isSafeTickerHref (R3-F4)', () => {
     expect(isSafeTickerHref('')).toBe(false);
   });
 
+  it('REJECTS the tab/LF/CR open-redirect bypass (browsers strip them → //host)', () => {
+    // `'/\t/evil.com'` reconstitutes to `'//evil.com'` in a browser → cross-origin. The validator
+    // strips tab/LF/CR before the scheme check, so these must be rejected (R3-F4 open-redirect).
+    expect(isSafeTickerHref('/\t/evil.com')).toBe(false);
+    expect(isSafeTickerHref('/\n/evil.com')).toBe(false);
+    expect(isSafeTickerHref('/\r/evil.com')).toBe(false);
+    expect(isSafeTickerHref('/\t\t/evil.com')).toBe(false);
+  });
+
+  it('ACCEPTS a whitespace-padded safe href and a mixed-case scheme (the /i flag + trim)', () => {
+    expect(isSafeTickerHref('  https://spicebushmontessori.org  ')).toBe(true);
+    expect(isSafeTickerHref('HTTPS://spicebushmontessori.org')).toBe(true);
+    expect(isSafeTickerHref('MailTo:hi@spicebushmontessori.org')).toBe(true);
+    expect(isSafeTickerHref('TEL:+14842020712')).toBe(true);
+  });
+
   it('PARITY: the href allowlist is byte-identical to blog-html ALLOWED_URI_REGEXP (R3-F1, no drift)', () => {
     expect(LINK_HREF_REGEX.source).toBe(STRICT_CONFIG_V2.ALLOWED_URI_REGEXP.source);
     expect(LINK_HREF_REGEX.flags).toBe(STRICT_CONFIG_V2.ALLOWED_URI_REGEXP.flags);
@@ -80,6 +96,26 @@ describe('getActiveTickerItems', () => {
     expect(await getActiveTickerItems(NOW)).toEqual([]);
     stubSettings(true, 'not-an-array');
     expect(await getActiveTickerItems(NOW)).toEqual([]);
+  });
+
+  it('skips null / primitive / array entries without throwing (the entry-type guard)', async () => {
+    // A value-blind endpoint could store a non-object entry; the public render path must not crash.
+    stubSettings(true, [null, 'a string', 42, ['nested'], { text: 'ok' }]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items.map(i => i.text)).toEqual(['ok']);
+  });
+
+  it('strips a tab/LF/CR open-redirect href but keeps the item as inert text', async () => {
+    stubSettings(true, [{ text: 'Sneaky', href: '/\t/evil.com' }]);
+    const [item] = await getActiveTickerItems(NOW);
+    expect(item.text).toBe('Sneaky');
+    expect(item.href).toBeUndefined();
+  });
+
+  it('stores the NORMALIZED (tab/whitespace-stripped) href for a safe link', async () => {
+    stubSettings(true, [{ text: 'Padded', href: '  https://spicebushmontessori.org  ' }]);
+    const [item] = await getActiveTickerItems(NOW);
+    expect(item.href).toBe('https://spicebushmontessori.org');
   });
 
   it('R3-F4 NEGATIVE: strips an unsafe href but KEEPS the item as inert text', async () => {
@@ -141,6 +177,18 @@ describe('getActiveTickerItems', () => {
     expect(items.map(i => i.text)).toEqual(['Item 0', 'Item 1', 'Item 2', 'Item 3', 'Item 4']);
   });
 
+  it('≤5 counts KEPT items, not raw indices — leading filtered entries do not eat the budget', async () => {
+    // 2 expired up front + 6 valid → the cap must yield the first 5 VALID (v1..v5), proving it counts
+    // post-filter survivors, not raw array positions.
+    stubSettings(true, [
+      { text: 'gone1', expiresAt: '2026-06-01T00:00:00Z' },
+      { text: 'gone2', expiresAt: '2026-06-02T00:00:00Z' },
+      ...Array.from({ length: 6 }, (_, i) => ({ text: `v${i + 1}` }))
+    ]);
+    const items = await getActiveTickerItems(NOW);
+    expect(items.map(i => i.text)).toEqual(['v1', 'v2', 'v3', 'v4', 'v5']);
+  });
+
   it('drops empty-text items and caps text length to 200', async () => {
     stubSettings(true, [{ text: '   ' }, { text: 'x'.repeat(250) }, { notText: 1 }]);
     const items = await getActiveTickerItems(NOW);
@@ -148,14 +196,15 @@ describe('getActiveTickerItems', () => {
     expect(items[0].text).toHaveLength(200);
   });
 
-  it('preserves admin-only `type` metadata when valid, drops an invalid type', async () => {
+  it('passes through every valid `type` allowlist member, drops an invalid type', async () => {
     stubSettings(true, [
-      { text: 'A', type: 'closure' },
-      { text: 'B', type: 'bogus' }
+      { text: 'A', type: 'info' },
+      { text: 'B', type: 'event' },
+      { text: 'C', type: 'closure' },
+      { text: 'D', type: 'bogus' }
     ]);
     const items = await getActiveTickerItems(NOW);
-    expect(items[0].type).toBe('closure');
-    expect(items[1].type).toBeUndefined();
+    expect(items.map(i => i.type)).toEqual(['info', 'event', 'closure', undefined]);
   });
 
   it('R4-F11 TTL: reads BOTH keys with the dedicated 5-minute maxAge, never the 30-min default', async () => {

--- a/app/src/lib/db/index.ts
+++ b/app/src/lib/db/index.ts
@@ -44,6 +44,7 @@ import {
   updateScheduleException,
   deleteScheduleException
 } from './announcements';
+import { getActiveTickerItems, getTickerEnabled } from './ticker';
 
 export const db = {
   content: {
@@ -101,6 +102,10 @@ export const db = {
     createScheduleException,
     updateScheduleException,
     deleteScheduleException
+  },
+  ticker: {
+    getActiveTickerItems,
+    getTickerEnabled
   },
   raw: {
     getPublicClient,
@@ -160,4 +165,5 @@ export {
   updateScheduleException,
   deleteScheduleException
 } from './announcements';
+export { getActiveTickerItems, getTickerEnabled, type TickerItem } from './ticker';
 export { getPublicClient, getServiceClient, withServiceClient } from './client';

--- a/app/src/lib/db/ticker.ts
+++ b/app/src/lib/db/ticker.ts
@@ -1,0 +1,100 @@
+/**
+ * Public ticker read path (Phase 6). The ticker is stored as TWO `settings` JSONB keys — no dedicated
+ * table (D1): `ticker_items` (a `TickerItem[]`) and `ticker_enabled` (a bool, default false).
+ *
+ * SECURITY MODEL (D2/R1-F2/R3-F4): the generic `/api/admin/settings` endpoint validates the KEY only,
+ * never the VALUE — so EVERY value-level safety property (href scheme, expiry, ≤5 cap, text-length
+ * cap) is enforced HERE, at render time, self-sufficiently. The endpoint is NOT a trust boundary for
+ * ticker content; this module is. A `javascript:`/`data:` href that the endpoint happily stored is
+ * neutralized here (the href is stripped, the text still renders as inert copy).
+ *
+ * TTL (D3/R4-F11): reads use a dedicated 5-minute `getSetting` TTL — NEVER `getAllSettings()` (whose
+ * `setting:all` blob caches at 30 min) — so the ticker is no staler than the 5-min AnnouncementBar.
+ */
+import { getSetting } from './content';
+
+export interface TickerItem {
+  /** Required display text. Render-time length-capped. */
+  text: string;
+  /** Optional link; render-time scheme-validated (R3-F4) — an unsafe scheme is stripped, not kept. */
+  href?: string;
+  /** Optional ISO-8601 expiry; render-time filtered once `Date.parse(expiresAt) <= now`. */
+  expiresAt?: string;
+  /** Admin-only organisation metadata — NOT surfaced to public visitors (D5). */
+  type?: 'info' | 'event' | 'closure';
+}
+
+const TICKER_ITEMS_KEY = 'ticker_items';
+const TICKER_ENABLED_KEY = 'ticker_enabled';
+// Dedicated 5-min TTL (R4-F11) — not the 30-min default SETTINGS_TTL.
+const TICKER_TTL = 5 * 60 * 1000;
+const MAX_TICKER_ITEMS = 5;
+const MAX_TICKER_TEXT = 200;
+
+/**
+ * Render-time link-href scheme allowlist (R3-F4): `https:`, `mailto:`, `tel:`, and single-slash
+ * site-relative paths; BLOCKS `javascript:`, `data:`, and protocol-relative `//host`.
+ *
+ * DUPLICATED on purpose from `blog-html.ts` `STRICT_CONFIG_V2.ALLOWED_URI_REGEXP` (the live blog-body
+ * sanitizer, R3-F1 "tightening forbidden") — sharing it would widen that sanitizer's blast radius into
+ * shipped posts. Parity with the source is asserted in the test so the two cannot silently drift.
+ * (Note: this is intentionally NOT `IMAGE_SCHEME_REGEX`, which is https+site-relative ONLY and would
+ * wrongly drop the `mailto:`/`tel:` links the ticker must support.)
+ */
+export const LINK_HREF_REGEX = /^(?:https:|mailto:|tel:|\/(?![/\\]))/i;
+
+export function isSafeTickerHref(href: string | undefined): boolean {
+  return typeof href === 'string' && LINK_HREF_REGEX.test(href.trim());
+}
+
+/** Whether the ticker is switched on. Missing/garbage key coerces to `false` (ships off — D-safety). */
+export async function getTickerEnabled(): Promise<boolean> {
+  const raw = await getSetting(TICKER_ENABLED_KEY, TICKER_TTL);
+  return raw === true || raw === 'true' || raw === 1 || raw === '1';
+}
+
+/**
+ * The active, render-safe ticker items. Returns `[]` when the ticker is disabled or empty. Each item
+ * is text-capped; an expired item is dropped; an unsafe href is stripped (the item still renders as
+ * inert text); the result is capped to 5 valid items. `now` is injected for deterministic tests.
+ */
+export async function getActiveTickerItems(now: number = Date.now()): Promise<TickerItem[]> {
+  if (!(await getTickerEnabled())) return [];
+
+  const raw = await getSetting(TICKER_ITEMS_KEY, TICKER_TTL);
+  if (!Array.isArray(raw)) return [];
+
+  const items: TickerItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const candidate = entry as Record<string, unknown>;
+
+    const text = typeof candidate.text === 'string' ? candidate.text.trim() : '';
+    if (!text) continue;
+
+    // Expiry filter — drop only when a parseable expiry is in the past (unparseable → kept).
+    const expiresAt = typeof candidate.expiresAt === 'string' ? candidate.expiresAt.trim() : '';
+    if (expiresAt) {
+      const expiryMs = Date.parse(expiresAt);
+      if (Number.isFinite(expiryMs) && expiryMs <= now) continue;
+    }
+
+    // Strip an unsafe href (keep the item as inert text) — render-time trust boundary (R3-F4).
+    const rawHref = typeof candidate.href === 'string' ? candidate.href.trim() : '';
+    const href = rawHref && isSafeTickerHref(rawHref) ? rawHref : undefined;
+
+    const rawType = candidate.type;
+    const type =
+      rawType === 'info' || rawType === 'event' || rawType === 'closure' ? rawType : undefined;
+
+    const item: TickerItem = { text: text.slice(0, MAX_TICKER_TEXT) };
+    if (href) item.href = href;
+    if (expiresAt) item.expiresAt = expiresAt;
+    if (type) item.type = type;
+    items.push(item);
+
+    if (items.length >= MAX_TICKER_ITEMS) break; // ≤5 enforcement
+  }
+
+  return items;
+}

--- a/app/src/lib/db/ticker.ts
+++ b/app/src/lib/db/ticker.ts
@@ -20,7 +20,12 @@ export interface TickerItem {
   href?: string;
   /** Optional ISO-8601 expiry; render-time filtered once `Date.parse(expiresAt) <= now`. */
   expiresAt?: string;
-  /** Admin-only organisation metadata — NOT surfaced to public visitors (D5). */
+  /**
+   * Organisation metadata, passed through by the read path. Under the current decision (D5=A) the
+   * PUBLIC ticker components do NOT render it — it sidesteps WCAG 1.4.1 color-coding (R4-F20). It is
+   * still emitted here so a future PR can surface it as a per-item indicator (icon + text label,
+   * never color alone — R4-F20) without changing the read contract.
+   */
   type?: 'info' | 'event' | 'closure';
 }
 
@@ -43,8 +48,19 @@ const MAX_TICKER_TEXT = 200;
  */
 export const LINK_HREF_REGEX = /^(?:https:|mailto:|tel:|\/(?![/\\]))/i;
 
+/**
+ * Normalize a href the way a BROWSER will before applying the scheme allowlist. Browsers strip ASCII
+ * tab/LF/CR from the ENTIRE URL before parsing (WHATWG URL spec), so `'/\t/evil.com'` reconstitutes to
+ * a protocol-relative `'//evil.com'` → cross-origin. The naked regex (used inside DOMPurify, which
+ * runs this same ATTR_WHITESPACE stripping first) does NOT account for that on its own — so we strip
+ * those chars here, BEFORE the regex, or the `//host` block is bypassable (open redirect).
+ */
+function normalizeHref(href: string): string {
+  return href.replace(/[\t\n\r]/g, '').trim();
+}
+
 export function isSafeTickerHref(href: string | undefined): boolean {
-  return typeof href === 'string' && LINK_HREF_REGEX.test(href.trim());
+  return typeof href === 'string' && LINK_HREF_REGEX.test(normalizeHref(href));
 }
 
 /** Whether the ticker is switched on. Missing/garbage key coerces to `false` (ships off — D-safety). */
@@ -79,9 +95,10 @@ export async function getActiveTickerItems(now: number = Date.now()): Promise<Ti
       if (Number.isFinite(expiryMs) && expiryMs <= now) continue;
     }
 
-    // Strip an unsafe href (keep the item as inert text) — render-time trust boundary (R3-F4).
-    const rawHref = typeof candidate.href === 'string' ? candidate.href.trim() : '';
-    const href = rawHref && isSafeTickerHref(rawHref) ? rawHref : undefined;
+    // Strip an unsafe href (keep the item as inert text) — render-time trust boundary (R3-F4). Store
+    // the NORMALIZED href (tab/LF/CR removed) so what renders is exactly what was validated.
+    const normalizedHref = typeof candidate.href === 'string' ? normalizeHref(candidate.href) : '';
+    const href = normalizedHref && isSafeTickerHref(normalizedHref) ? normalizedHref : undefined;
 
     const rawType = candidate.type;
     const type =


### PR DESCRIPTION
## Phase 6 · PR1 — ticker render-time lib

The ticker's render-time trust boundary. **Surface-inert** — nothing renders the ticker yet (PR3 mounts it). Stored as two `settings` JSONB keys, **no new table** (D1): `ticker_items` (`TickerItem[]`) + `ticker_enabled` (bool, default **false** → ships off).

### `app/src/lib/db/ticker.ts`
- **`getActiveTickerItems(now?)`** — `[]` when disabled/empty; per item: drops empty-text + past-expiry, **strips an unsafe href (keeps the text as inert copy)**, caps text to 200, caps the list to **5 valid items**. `now` injected for deterministic tests.
- **`getTickerEnabled()`** — coerces the bool key; missing → `false`.
- **`isSafeTickerHref` + `LINK_HREF_REGEX`** = `/^(?:https:|mailto:|tel:|\/(?![/\\]))/i` — allows https/mailto/tel/site-relative, **blocks** `javascript:`/`data:`/protocol-relative `//`. **Duplicated** from `blog-html.ts` `ALLOWED_URI_REGEXP` (R3-F1 "tightening forbidden" — sharing it would widen the live-post sanitizer's blast radius into shipped posts); **parity asserted** in the test so the two can't drift. (Deliberately NOT `IMAGE_SCHEME_REGEX`, which would wrongly drop `mailto:`/`tel:`.)
- **Dedicated 5-min `getSetting` TTL (R4-F11)** — never `getAllSettings()` (its `setting:all` blob caches at 30 min and the per-key cache ignores `maxAge`, so the header strip must not piggyback on Header's existing `getAllSettings` call).

### Security (R1-F2 / R3-F4 / D2)
The generic `/api/admin/settings` endpoint validates the **key** only, never the **value** — so a `javascript:` href it happily stored is **neutralized here at render**. This module is the trust boundary, not the endpoint.

### Tests (14)
Negative href-strip (javascript/data/protocol-rel) keeping inert text; positive mailto/tel/https/site-relative survival; **the value-blind-endpoint-bypass security case**; expiry (past dropped / future + unparseable kept, injected `now`); ≤5 cap; disabled/empty → `[]`; text cap; admin-only `type` passthrough; the **5-min TTL** assertion; and the **blog-html parity** assertion.

### Design note (D5, owner-overridable)
The per-item `type` is **admin-only metadata, not shown to public visitors** — this sidesteps WCAG 1.4.1 color-coding (R4-F20) entirely. A later PR can surface visitor-facing type badges (icon + text label, never color alone) if wanted.

### Gates
lint 0-warn · format clean · typecheck 0-err · 487 tests · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)