### PR TITLE
feat(blog): Phase-6 PR2 — settings CSRF (R2-F1/#85) + /admin/ticker authoring

### DIFF
--- a/app/src/components/AdminNav.astro
+++ b/app/src/components/AdminNav.astro
@@ -12,6 +12,7 @@ import {
   LineChart,
   Tent,
   Bell,
+  Megaphone,
   HandHeart,
   Newspaper
 } from 'lucide-astro';
@@ -134,6 +135,14 @@ const displayName = userEmail.includes('@') ? userEmail.split('@')[0] : userEmai
         >
           <Bell className="w-5 h-5 mr-3" />
           Announcements
+        </a>
+        <a
+          href="/admin/ticker"
+          aria-current={currentPath === '/admin/ticker' ? 'page' : undefined}
+          class="admin-nav-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg"
+        >
+          <Megaphone className="w-5 h-5 mr-3" />
+          Ticker
         </a>
         <a
           href="/admin/contact-submissions"

--- a/app/src/pages/admin/ticker.astro
+++ b/app/src/pages/admin/ticker.astro
@@ -1,0 +1,312 @@
+---
+import AdminLayout from '@layouts/AdminLayout.astro';
+import { db } from '@lib/db';
+import type { TickerItem } from '@lib/db/ticker';
+
+// Admin editing read: the RAW stored items (incl. disabled/expired) so the owner can edit them — NOT
+// getActiveTickerItems (which filters for the public render). The settings POST invalidates the cache,
+// so the post-save 303 redirect re-reads fresh.
+const rawItems = await db.content.getSetting('ticker_items');
+const enabledRaw = await db.content.getSetting('ticker_enabled');
+const enabled =
+  enabledRaw === true || enabledRaw === 'true' || enabledRaw === 1 || enabledRaw === '1';
+
+const TYPES = ['info', 'event', 'closure'] as const;
+
+const items: TickerItem[] = Array.isArray(rawItems)
+  ? rawItems
+      .filter(
+        (entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === 'object'
+      )
+      .map(entry => ({
+        text: typeof entry.text === 'string' ? entry.text : '',
+        href: typeof entry.href === 'string' ? entry.href : '',
+        expiresAt: typeof entry.expiresAt === 'string' ? entry.expiresAt : '',
+        type: TYPES.includes(entry.type as (typeof TYPES)[number])
+          ? (entry.type as (typeof TYPES)[number])
+          : 'info'
+      }))
+  : [];
+
+const savedKey = Astro.url.searchParams.get('saved');
+const errorKey = Astro.url.searchParams.get('error');
+---
+
+<AdminLayout title="Ticker">
+  <div class="mx-auto max-w-3xl px-4 py-8">
+    <h1 class="mb-2 text-2xl font-bold text-earth-brown">News Ticker</h1>
+
+    {
+      savedKey && (
+        <p class="mb-4 rounded-lg border border-moss-green bg-moss-green/10 p-3 text-sm text-earth-brown">
+          Ticker saved.
+        </p>
+      )
+    }
+    {
+      errorKey && (
+        <p class="mb-4 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          Could not save the ticker. Please try again.
+        </p>
+      )
+    }
+
+    {/* R2-F21 — Ticker vs Announcements role distinction. */}
+    <div
+      class="mb-6 rounded-xl border border-stone-beige bg-cloud-gray/40 p-4 text-sm text-earth-brown/90"
+    >
+      <p class="mb-1 font-semibold">Ticker vs. Announcements</p>
+      <p>
+        <strong>Announcements</strong> are for one timely, must-see notice (a closure or alert) shown
+        prominently. The <strong>Ticker</strong> is a rotating strip of up to 5 short items (events,
+        links, reminders). Use Announcements for urgent alerts; use the Ticker for a lighter, rotating
+        set. They are independent — both can appear at once.
+      </p>
+    </div>
+
+    {/* Enable / disable — native form, works without JS. */}
+    <form method="post" action="/api/admin/settings" class="mb-6">
+      <input type="hidden" name="redirectTo" value="/admin/ticker" />
+      <input type="hidden" name="ticker_enabled" value={enabled ? 'false' : 'true'} />
+      <div
+        class="flex items-center justify-between rounded-xl border border-stone-beige bg-white p-4"
+      >
+        <div>
+          <p class="font-semibold text-earth-brown">
+            Ticker is currently {enabled ? 'ON' : 'OFF'}
+          </p>
+          <p class="text-sm text-earth-brown/70">
+            When OFF (or empty), nothing shows on the public site.
+          </p>
+        </div>
+        <button
+          type="submit"
+          class="rounded-lg bg-forest-canopy px-4 py-2 text-sm font-semibold text-white hover:bg-moss-green"
+        >
+          Turn {enabled ? 'OFF' : 'ON'}
+        </button>
+      </div>
+    </form>
+
+    {/* Items editor — JS-driven (the JSON array is serialized on submit). */}
+    <form method="post" action="/api/admin/settings" id="ticker-form" class="space-y-4">
+      <input type="hidden" name="redirectTo" value="/admin/ticker" />
+      <input type="hidden" name="ticker_items" id="ticker-items-input" value="[]" />
+
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-earth-brown">Items</h2>
+        <span id="ticker-count-note" class="text-sm text-earth-brown/70"></span>
+      </div>
+      <p class="text-sm text-earth-brown/70">
+        Up to 5 items show publicly. Links must start with <code>https://</code>, <code
+          >mailto:</code
+        >,
+        <code>tel:</code>, or <code>/</code> — anything else is shown as plain text. An expired item
+        is hidden automatically.
+      </p>
+
+      <ol id="ticker-list" class="space-y-3"></ol>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          id="ticker-add"
+          class="rounded-lg border border-forest-canopy px-4 py-2 text-sm font-semibold text-forest-canopy hover:bg-forest-canopy/10"
+        >
+          + Add item
+        </button>
+        <button
+          type="submit"
+          class="rounded-lg bg-forest-canopy px-5 py-2 text-sm font-semibold text-white hover:bg-moss-green"
+        >
+          Save ticker
+        </button>
+      </div>
+
+      {/* aria-live confirmation for reorder/add/remove (admin page — verbosity is fine). */}
+      <p id="ticker-status" class="sr-only" role="status" aria-live="polite"></p>
+    </form>
+
+    {
+      /* Initial items for the client to hydrate the editor. Passed via a data- attribute (Astro
+        auto-escapes attribute values) NOT an inline <script>, so item text containing `</script>`
+        or quotes can't break out — no admin self-XSS. */
+    }
+    <div id="ticker-initial" data-items={JSON.stringify(items)} hidden></div>
+
+    {/* Row template (cloned by the script per item). */}
+    <template id="ticker-row-template">
+      <li class="ticker-row rounded-xl border border-stone-beige bg-white p-4">
+        <div class="mb-2 flex items-center justify-between">
+          <span class="ticker-row-label text-sm font-semibold text-earth-brown"></span>
+          <span class="flex gap-1">
+            <button
+              type="button"
+              class="ticker-up rounded border border-stone-beige px-2 py-1 text-xs hover:bg-cloud-gray"
+            >
+              ↑<span class="sr-only"> Move up</span>
+            </button>
+            <button
+              type="button"
+              class="ticker-down rounded border border-stone-beige px-2 py-1 text-xs hover:bg-cloud-gray"
+            >
+              ↓<span class="sr-only"> Move down</span>
+            </button>
+            <button
+              type="button"
+              class="ticker-remove rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+            >
+              Remove
+            </button>
+          </span>
+        </div>
+        <label class="block text-sm">
+          <span class="text-earth-brown/80">Text</span>
+          <textarea
+            class="ticker-text mt-1 w-full rounded-lg border border-stone-beige p-2"
+            rows="2"
+            maxlength="200"></textarea>
+        </label>
+        <div class="mt-2 grid gap-2 sm:grid-cols-3">
+          <label class="block text-sm">
+            <span class="text-earth-brown/80">Link (optional)</span>
+            <input
+              type="text"
+              class="ticker-href mt-1 w-full rounded-lg border border-stone-beige p-2"
+              placeholder="https://… or /blog"
+            />
+          </label>
+          <label class="block text-sm">
+            <span class="text-earth-brown/80">Expires (optional)</span>
+            <input
+              type="datetime-local"
+              class="ticker-expires mt-1 w-full rounded-lg border border-stone-beige p-2"
+            />
+          </label>
+          <label class="block text-sm">
+            <span class="text-earth-brown/80">Type</span>
+            <select class="ticker-type mt-1 w-full rounded-lg border border-stone-beige p-2">
+              <option value="info">Info</option>
+              <option value="event">Event</option>
+              <option value="closure">Closure</option>
+            </select>
+          </label>
+        </div>
+      </li>
+    </template>
+  </div>
+</AdminLayout>
+
+<script>
+  // Vanilla editor for the ticker JSON array. The PUBLIC render path (getActiveTickerItems) is the
+  // security boundary (it re-validates hrefs, expiry, ≤5); this script is owner-convenience only.
+  const form = document.getElementById('ticker-form') as HTMLFormElement | null;
+  const list = document.getElementById('ticker-list');
+  const template = document.getElementById('ticker-row-template') as HTMLTemplateElement | null;
+  const hidden = document.getElementById('ticker-items-input') as HTMLInputElement | null;
+  const status = document.getElementById('ticker-status');
+  const countNote = document.getElementById('ticker-count-note');
+  const initialEl = document.getElementById('ticker-initial');
+
+  if (form && list && template && hidden) {
+    const announce = (msg: string) => {
+      if (status) status.textContent = msg;
+    };
+
+    const isoToLocal = (iso: string): string => {
+      if (!iso) return '';
+      const ms = Date.parse(iso);
+      if (!Number.isFinite(ms)) return '';
+      const d = new Date(ms);
+      const pad = (n: number) => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    };
+
+    const relabel = () => {
+      const rows = Array.from(list.querySelectorAll('.ticker-row'));
+      rows.forEach((row, i) => {
+        const label = row.querySelector('.ticker-row-label');
+        if (label) label.textContent = `Item ${i + 1} of ${rows.length}`;
+      });
+      if (countNote) {
+        countNote.textContent =
+          rows.length > 5
+            ? `${rows.length} items — only the first 5 show publicly`
+            : `${rows.length} item(s)`;
+      }
+    };
+
+    const addRow = (item?: { text?: string; href?: string; expiresAt?: string; type?: string }) => {
+      const frag = template.content.cloneNode(true) as DocumentFragment;
+      const row = frag.querySelector('.ticker-row') as HTMLElement;
+      (row.querySelector('.ticker-text') as HTMLTextAreaElement).value = item?.text ?? '';
+      (row.querySelector('.ticker-href') as HTMLInputElement).value = item?.href ?? '';
+      (row.querySelector('.ticker-expires') as HTMLInputElement).value = isoToLocal(
+        item?.expiresAt ?? ''
+      );
+      (row.querySelector('.ticker-type') as HTMLSelectElement).value =
+        item?.type === 'event' || item?.type === 'closure' ? item.type : 'info';
+
+      row.querySelector('.ticker-up')?.addEventListener('click', () => {
+        const prev = row.previousElementSibling;
+        if (prev) {
+          list.insertBefore(row, prev);
+          relabel();
+          announce('Moved item up.');
+        }
+      });
+      row.querySelector('.ticker-down')?.addEventListener('click', () => {
+        const next = row.nextElementSibling;
+        if (next) {
+          list.insertBefore(next, row);
+          relabel();
+          announce('Moved item down.');
+        }
+      });
+      row.querySelector('.ticker-remove')?.addEventListener('click', () => {
+        row.remove();
+        relabel();
+        announce('Item removed.');
+      });
+
+      list.appendChild(row);
+      relabel();
+    };
+
+    // Hydrate from the server-provided initial items (read from the auto-escaped data- attribute).
+    try {
+      const initial = JSON.parse((initialEl as HTMLElement | null)?.dataset.items || '[]');
+      if (Array.isArray(initial)) initial.forEach(addRow);
+    } catch {
+      /* ignore malformed seed — start empty */
+    }
+    if (!list.querySelector('.ticker-row')) addRow();
+
+    document.getElementById('ticker-add')?.addEventListener('click', () => {
+      addRow();
+      announce('Item added.');
+    });
+
+    // Serialize the rows into the hidden ticker_items value on submit.
+    form.addEventListener('submit', () => {
+      const rows = Array.from(list.querySelectorAll('.ticker-row'));
+      const out: Array<Record<string, string>> = [];
+      for (const row of rows) {
+        const text = (row.querySelector('.ticker-text') as HTMLTextAreaElement).value.trim();
+        if (!text) continue; // skip blank rows
+        const href = (row.querySelector('.ticker-href') as HTMLInputElement).value.trim();
+        const expiresLocal = (row.querySelector('.ticker-expires') as HTMLInputElement).value;
+        const type = (row.querySelector('.ticker-type') as HTMLSelectElement).value;
+        const item: Record<string, string> = { text };
+        if (href) item.href = href;
+        if (expiresLocal) {
+          const ms = Date.parse(expiresLocal);
+          if (Number.isFinite(ms)) item.expiresAt = new Date(ms).toISOString();
+        }
+        if (type) item.type = type;
+        out.push(item);
+      }
+      hidden.value = JSON.stringify(out);
+    });
+  }
+</script>

--- a/app/src/pages/api/admin/settings.test.ts
+++ b/app/src/pages/api/admin/settings.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lib/admin-auth-check', () => ({ checkAdminAuth: vi.fn() }));
+vi.mock('@lib/db/client', () => ({ query: vi.fn(), queryRows: vi.fn() }));
+vi.mock('@lib/db', () => ({ db: { cache: { invalidateSettings: vi.fn() } } }));
+
+import { checkAdminAuth } from '@lib/admin-auth-check';
+import { query } from '@lib/db/client';
+import { db } from '@lib/db';
+import { POST } from './settings';
+
+const queryMock = vi.mocked(query);
+const invalidateMock = vi.mocked(db.cache.invalidateSettings);
+const authMock = vi.mocked(checkAdminAuth);
+
+const ENDPOINT = 'http://localhost/api/admin/settings';
+
+const formRequest = (
+  fields: Record<string, string>,
+  headers: Record<string, string> = {}
+): Request => {
+  const body = new URLSearchParams(fields);
+  return new Request(ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
+    body: body.toString()
+  });
+};
+
+const callPost = (request: Request) =>
+  POST({ request, locals: {} } as unknown as Parameters<typeof POST>[0]);
+
+// A representative ticker write (the new caller R2-F1 hardens).
+const tickerFields = (): Record<string, string> => ({
+  redirectTo: '/admin/ticker',
+  ticker_items: JSON.stringify([{ text: 'Hello' }])
+});
+
+beforeEach(() => {
+  queryMock.mockReset();
+  invalidateMock.mockReset();
+  authMock.mockReset();
+  authMock.mockResolvedValue({
+    isAuthenticated: true,
+    isAdmin: true,
+    session: { userEmail: 'admin@spicebush.org' } as never,
+    user: null
+  });
+  queryMock.mockResolvedValue({ rows: [], rowCount: 1 } as never);
+});
+
+describe('POST /api/admin/settings — auth + CSRF origin check (R2-F1 / bug #85)', () => {
+  it('rejects an unauthenticated request with 403 (before any write)', async () => {
+    authMock.mockResolvedValue({ isAuthenticated: false, isAdmin: false } as never);
+    const response = await callPost(formRequest(tickerFields()));
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a mismatched Origin header with 403 (no write)', async () => {
+    const response = await callPost(
+      formRequest(tickerFields(), { origin: 'https://evil.example.com' })
+    );
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects Sec-Fetch-Site: cross-site with 403 (no write)', async () => {
+    const response = await callPost(
+      formRequest(tickerFields(), { 'sec-fetch-site': 'cross-site' })
+    );
+    expect(response.status).toBe(403);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds (303 redirect) when the Origin matches the request origin', async () => {
+    const response = await callPost(formRequest(tickerFields(), { origin: 'http://localhost' }));
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe('/admin/ticker');
+    expect(queryMock).toHaveBeenCalled();
+    expect(invalidateMock).toHaveBeenCalled();
+  });
+
+  it('FAILS OPEN: a same-origin form POST with NO Origin/Sec-Fetch headers still succeeds', async () => {
+    // The 16 existing same-origin settings forms send no Origin on some browsers — must not break.
+    const response = await callPost(formRequest(tickerFields()));
+    expect(response.status).toBe(303);
+    expect(queryMock).toHaveBeenCalled();
+  });
+});

--- a/app/src/pages/api/admin/settings.ts
+++ b/app/src/pages/api/admin/settings.ts
@@ -63,6 +63,19 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return jsonResponse({ error: 'Admin access required' }, 403);
   }
 
+  // Defense-in-depth CSRF check (SameSite=Lax remains the primary defense), mirroring the content
+  // endpoint (R2-F1, closes bug #85). Rejects only on POSITIVE cross-site evidence — fails open when
+  // both headers are absent — so it hardens ALL same-origin admin settings forms (camp, testimonials,
+  // seo, ticker) without breaking any of them.
+  const requestOrigin = new URL(request.url).origin;
+  const origin = request.headers.get('origin');
+  if (
+    (origin && origin !== requestOrigin) ||
+    request.headers.get('sec-fetch-site') === 'cross-site'
+  ) {
+    return jsonResponse({ error: 'Cross-site request rejected' }, 403);
+  }
+
   const contentType = request.headers.get('content-type') ?? '';
   const updates: Record<string, unknown> = {};
   let redirectTo: string | null = null;

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -326,6 +326,14 @@ collection still saves and deletes (including the header-absent fail-open case).
 | Form-based delete             | `action='delete'` runs the existing DELETE (allowlist + slug check + cache invalidation) and responds via `responseByFormat`                                                                    |
 | `parseRedirectPath` hardening | Rejects backslash-leading paths (`/\evil.com`) that browsers resolve off-site: `^\/(?![/\\])`                                                                                                   |
 
+**`/api/admin/settings` CSRF (Phase 6, R2-F1 / closes #85).** The generic settings endpoint now carries
+the **same** defense-in-depth Origin / `Sec-Fetch-Site: cross-site` → `403` check (fails open when both
+headers absent), copied from the content endpoint. This hardens all ~16 same-origin admin settings
+forms (camp, testimonials, seo, ticker) — verified none is cross-origin, so none breaks. The endpoint
+still validates the **key** only (`^[a-zA-Z0-9_]+$`), never the value — so the ticker's value-level
+safety (href scheme, expiry, ≤5) is enforced at render in `getActiveTickerItems`, not here. Authoring
+UI: `/admin/ticker` (full Ticker spec section added in the Phase-6 docs PR).
+
 ### Auth
 
 The middleware protects `/admin` and `/api/admin` prefixes:


### PR DESCRIPTION
## Phase 6 · PR2 — settings CSRF hardening + ticker authoring

### (A) `/api/admin/settings` CSRF (R2-F1, closes #85)
Adds the **same** defense-in-depth `Origin` / `Sec-Fetch-Site: cross-site` → `403` check the content endpoint already has (copied verbatim). **Fails open** when both headers are absent, so all ~16 same-origin admin settings forms (camp, testimonials, seo, ticker) keep working — verified none is cross-origin. **5 CI tests**: unauth→403, mismatched Origin→403, cross-site→403, matching Origin→303 write, header-absent fail-open→303.

### (B) `/admin/ticker` authoring page (mirrors `admin/announcements`)
- Reads the **raw** stored items (incl. disabled/expired) for editing — not the filtered public read. Enable/disable is a **native no-JS** form.
- Items editor: per-item text / link / expiry (`datetime-local`) / type, Add/Remove, and **keyboard Move up/down** (R1-F35) with a `role="status"` `aria-live` confirmation. A vanilla script serializes the rows into the `ticker_items` JSON on submit (D1 = JSON-in-settings, so serialization needs JS — the **public render path stays the security boundary**, D2). Count note warns past 5.
- **R2-F21** Ticker-vs-Announcements explainer copy.
- **Self-XSS-safe**: initial items are passed via an **auto-escaped `data-` attribute**, NOT an inline `<script>` — item text containing `</script>`/quotes can't break out.
- `AdminNav` gains a "Ticker" link (Megaphone) next to Announcements.

### Safety
**Surface-inert**: ships `ticker_enabled=false`; nothing renders publicly until the owner adds items *and* turns it on (PR3 mounts the public strip/section). The admin page itself renders behind auth.

### Gates
lint 0-warn · format clean · typecheck 0-err · **498 tests** · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added News Ticker management to the admin panel, enabling creation, editing, and scheduling of ticker items with expiration controls.

* **Security**
  * Implemented CSRF protection on admin settings endpoints with origin validation.

* **Tests**
  * Added test coverage for admin settings security controls.

* **Documentation**
  * Updated specifications to document CSRF defense implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->