### PR TITLE
feat(blog): Phase-7 — AI writing "Coming Soon" panel (full build deferred → #110)

### DIFF
--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -152,6 +152,35 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
       </p>
     </section>
 
+    {
+      /* Phase 7 placeholder — AI writing is planned but NOT built (issue #110). It activates only once
+        the school supplies its own Anthropic API key. Purely informational: no inputs, no API calls. */
+    }
+    <section
+      class="rounded-2xl border border-dashed border-forest-canopy/40 bg-forest-canopy/5 p-5"
+      aria-label="AI writing assistant — coming soon"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <h2 class="text-lg font-semibold text-earth-brown">AI Writing Assistant</h2>
+        <span
+          class="rounded-full bg-forest-canopy/15 px-2.5 py-0.5 text-xs font-semibold text-forest-canopy"
+        >
+          Coming soon
+        </span>
+      </div>
+      <p class="mt-2 text-sm text-earth-brown/80">
+        Draft generation, rewrite/expand helpers, SEO title &amp; description suggestions, and a
+        school "voice" profile are planned for the editor. They are <strong>not enabled yet</strong
+        >.
+      </p>
+      <p class="mt-2 text-sm text-earth-brown/80">
+        Because the AI runs on a paid service, this feature activates only when the school provides
+        its own <strong>Anthropic API key</strong>. When you're ready to turn it on (or want to talk
+        through whether it's worth it), reach out to your site developer — nothing here needs setup
+        until then.
+      </p>
+    </section>
+
     <section class="space-y-4">
       <details class="rounded-xl border border-gray-200 bg-white shadow-sm">
         <summary class="cursor-pointer px-5 py-4 text-base font-semibold text-earth-brown"

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -781,8 +781,19 @@ the defense-in-depth Origin/CSRF check (R2-F1 / #85 — see Admin API above).
 
 ## Deferred Features
 
-Each item below is intentionally **out of V1**. The generic content pipeline already does ~90% of the
-work; every deferred item would add files, migrations, or UI that the maintainability gate penalizes.
+Each item below was intentionally **out of V1**. The generic content pipeline already did ~90% of the
+work; every deferred item would have added files, migrations, or UI that the maintainability gate
+penalized.
+
+> **V2 update (Phases 2–6, 2026-06).** Blog V2 **shipped** several items once listed below — the
+> TipTap WYSIWYG editor (ADR-009), scheduled publishing, categories/tags discovery + pagination +
+> related posts, RSS, `BlogPosting` JSON-LD, and the ticker. The table is kept as the V1 rationale
+> snapshot; the live behavior is documented in the sections above. **AI writing + voice** remains
+> deferred — see the new row below and issue #110.
+
+| Deferred                         | Rationale                                                                                                                                                                                                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **AI writing + voice (Phase 7)** | Deferred per owner (2026-06-09): the school must supply its own paid **Anthropic API key**, and may not want it. `/admin/blog` shows a non-functional "Coming Soon" panel; the full build-ready spec is **issue #110**. No code, key, or cost until the org commits |
 
 | Deferred                                                                                | Rationale                                                                                                                                                                   |
 | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Phase 7 — AI writing "Coming Soon" (per owner decision)

The heavy AI subsystem is **not built speculatively**. Owner (2026-06-09): the school must supply its own paid **Anthropic API key**, it may take time, and they may not want the feature.

### What ships
- **`/admin/blog`**: a non-functional **"AI Writing Assistant — Coming Soon"** panel listing the planned features (draft generation, rewrite/expand, SEO title/description suggestions, school "voice" profile) and explaining it activates only when the school provides an Anthropic API key. **No inputs, no API calls, no cost** — purely informational, behind admin auth.
- **Issue #110**: the **full build-ready Phase-7 spec** (ADR-010 / §13 — `crypto.ts` + encrypted key store, async `ai_jobs` background-function path, injectable Claude service, spend breaker + rate limit, voice corpus, SSRF-hardened ingestion, the three editor AI modes) + the **two hard prerequisites** (the org's Anthropic key + written confirmation of on-demand background functions) — ready to build the day the org commits.
- **`blog.md` Deferred Features**: added the AI-writing row + a V2-update note flagging that Phases 2–6 shipped several previously-listed deferrals (RSS, pagination, related posts, JSON-LD, scheduled publishing, WYSIWYG, ticker).

### This completes the Blog V2 roadmap (Phases 1–7) as scoped.

### Gates
lint 0-warn · typecheck 0-err · build OK. (No new tests — informational static panel + docs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)