### PR TITLE
feat(blog): dedicated editor pages + scannable list (PR A of #114)

### DIFF
--- a/app/src/components/admin/BlogEditorForm.astro
+++ b/app/src/components/admin/BlogEditorForm.astro
@@ -1,0 +1,584 @@
+---
+/**
+ * Shared blog authoring form for the dedicated editor pages (`/admin/blog/new`,
+ * `/admin/blog/edit/[slug]`). Replaces the accordion-buried add/edit forms that lived inline in
+ * `/admin/blog` (issue #114). The field set, `name` attributes, hidden inputs, `data-*` hooks, and
+ * the form-POST contract to `/api/admin/content` are preserved EXACTLY — only the layout changes
+ * (main column = title + body; sidebar = all metadata, nothing hidden in `<details>`). So the
+ * client module (`blog-admin-client.ts`) keeps wiring conditional-required, schedule toggling, slug
+ * autofill/collision, the body-required submit guard, and the upload widget unchanged.
+ *
+ * Redirect targets match the previous behavior byte-for-byte (the endpoint uses one `redirectTo`
+ * for both success and error, content.ts:389-411): new → /admin/blog?saved=new, edit →
+ * /admin/blog?saved=<slug>. Success lands on the list with its existing status-aware flash; a
+ * (rare, client-validated) server error lands there with the error flash — same as the old page.
+ */
+import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
+import { renderPostBody, blogPostToEditData, type BlogPost } from '@lib/blog-content';
+import TipTapEditor from '@components/TipTapEditor';
+
+interface Props {
+  mode: 'new' | 'edit';
+  /** The post being edited; required when mode === 'edit'. */
+  post?: BlogPost;
+  /** Existing slugs for the new-post collision check (read by `[data-existing-slugs]`). */
+  existingSlugs?: string[];
+}
+
+const { mode, post, existingSlugs = [] } = Astro.props;
+const isEdit = mode === 'edit';
+
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD default for the date input
+
+// Preserve the exact redirect contract of the previous inline forms (content.ts shares one
+// redirectTo for success AND error). Success → list with the status-aware saved flash.
+const redirectTo = isEdit
+  ? `/admin/blog?saved=${encodeURIComponent(post!.slug)}`
+  : '/admin/blog?saved=new';
+
+// Edit carries the reconstructable data.* fields (incl. categories/tags with no input) so the
+// wholesale-replace upsert never drops them (#84). Field list lives in `blogPostToEditData` (tested).
+const baseDataJson = isEdit ? JSON.stringify(blogPostToEditData(post!)) : null;
+
+// Server-rendered body for the editor to hydrate with (markdown or HTML both load as HTML).
+const initialBodyHtml = isEdit ? renderPostBody(post!.body) : '';
+
+const statusBadge = (p: BlogPost): { label: string; cls: string } => {
+  switch (p.status) {
+    case 'published':
+      return { label: 'Published', cls: 'bg-green-50 text-green-800 border border-green-200' };
+    case 'scheduled':
+      return { label: 'Scheduled', cls: 'bg-blue-50 text-blue-800 border border-blue-200' };
+    case 'archived':
+      return { label: 'Archived', cls: 'bg-stone-100 text-earth-brown border border-stone-300' };
+    default:
+      return { label: 'Draft', cls: 'bg-amber-50 text-amber-800 border border-amber-200' };
+  }
+};
+const badge = isEdit
+  ? statusBadge(post!)
+  : { label: 'New draft', cls: 'bg-amber-50 text-amber-800 border border-amber-200' };
+
+// Stable id suffix so multiple help-text ids never collide (only ever one form per page, but keep
+// the ids self-describing).
+const idns = isEdit ? `edit-${post!.slug}` : 'new';
+---
+
+<form
+  method="post"
+  action="/api/admin/content"
+  class="space-y-6"
+  data-blog-form
+  data-new-blog-form={!isEdit ? '' : undefined}
+  data-existing-slugs={!isEdit ? JSON.stringify(existingSlugs) : undefined}
+>
+  <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+  <input type="hidden" name={BLOG_FORM_FIELDS.redirectTo} value={redirectTo} />
+  {!isEdit && <input type="hidden" name={BLOG_FORM_FIELDS.createOnly} value="true" />}
+  {isEdit && <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post!.slug} />}
+  {isEdit && <input type="hidden" name={BLOG_FORM_FIELDS.baseDataJson} value={baseDataJson} />}
+
+  {/* Action bar — Back, status, Save. Not sticky: AdminLayout's header already sticks to top-0. */}
+  <div
+    class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
+  >
+    <div class="flex items-center gap-3">
+      <a
+        href="/admin/blog"
+        class="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-semibold text-earth-brown hover:bg-gray-50"
+      >
+        ← Posts
+      </a>
+      <span class={`rounded-full px-2.5 py-1 text-xs font-semibold ${badge.cls}`}
+        >{badge.label}</span
+      >
+      {
+        isEdit && post!.status === 'published' && (
+          <a
+            href={`/blog/${post!.slug}`}
+            target="_blank"
+            rel="noopener"
+            class="text-sm font-medium text-forest-canopy hover:underline"
+          >
+            View on site ↗
+          </a>
+        )
+      }
+    </div>
+    <button
+      type="submit"
+      class="rounded-lg bg-forest-canopy px-4 py-2 text-sm font-semibold text-white hover:bg-moss-green"
+    >
+      Save post
+    </button>
+  </div>
+
+  <div class="grid gap-6 lg:grid-cols-3">
+    {/* MAIN COLUMN — title + body canvas */}
+    <div class="space-y-4 lg:col-span-2">
+      <label class="block text-sm font-medium">
+        <span class="mb-1 block">Title</span>
+        <input
+          type="text"
+          name={BLOG_FORM_FIELDS.title}
+          required
+          maxlength="300"
+          value={isEdit ? post!.title : undefined}
+          placeholder="Post title"
+          class="w-full rounded-lg border border-gray-300 px-3 py-2 text-lg font-semibold"
+        />
+      </label>
+
+      <div class="block text-sm font-medium">
+        <span class="mb-1 block">Body (required to publish)</span>
+        {
+          isEdit ? (
+            <TipTapEditor
+              client:load
+              fieldName={BLOG_FORM_FIELDS.bodyRaw}
+              initialHtml={initialBodyHtml}
+            />
+          ) : (
+            <TipTapEditor client:load fieldName={BLOG_FORM_FIELDS.bodyRaw} />
+          )
+        }
+        <p class="mt-2 text-xs text-earth-brown/70">
+          Use the toolbar to format. Every image inside your post needs a description (alt text) — a
+          post can't be published with an empty or one-word image description. Upload images at
+          <a
+            href="/admin/media"
+            target="_blank"
+            rel="noopener"
+            class="font-medium text-forest-canopy hover:underline"
+          >
+            Media (opens in a new tab)
+          </a>, then use the image button in the editor to insert by address.
+        </p>
+      </div>
+    </div>
+
+    {/* SIDEBAR — all metadata, always visible */}
+    <aside class="space-y-4">
+      {/* Publishing */}
+      <section class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-earth-brown/70">
+          Publishing
+        </h2>
+        <label class="block text-sm font-medium">
+          Status
+          <select
+            name={BLOG_FORM_FIELDS.status}
+            aria-describedby={`status-help-${idns}`}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          >
+            <option value="draft" selected={!isEdit || post!.status === 'draft'}>Draft</option>
+            <option value="published" selected={isEdit && post!.status === 'published'}>
+              Published
+            </option>
+            <option value="scheduled" selected={isEdit && post!.status === 'scheduled'}>
+              Scheduled
+            </option>
+            <option value="archived" selected={isEdit && post!.status === 'archived'}>
+              Archived
+            </option>
+          </select>
+          <span id={`status-help-${idns}`} class="mt-1 block text-xs text-earth-brown/70">
+            To publish (now or scheduled) you also need an excerpt, a body, and a date; if you set a
+            featured image you also need an image description. Set <strong>Archived</strong> to hide
+            a post without deleting it. New posts appear at their link immediately after publishing;
+            the index and edits to already-published posts can take up to 5 minutes to update.
+          </span>
+        </label>
+
+        {
+          /* Schedule control — shown only when Status = Scheduled (client toggles visibility +
+            `required` in lockstep; the client writes the UTC-Z instant into the hidden field). */
+        }
+        <div
+          class="mt-3 block text-sm font-medium"
+          data-schedule-group
+          hidden={isEdit ? post!.status !== 'scheduled' : true}
+        >
+          <label class="block">
+            Go live on (your local time)
+            <input
+              type="datetime-local"
+              name={BLOG_FORM_FIELDS.publishedAtLocal}
+              aria-describedby={`schedule-help-${idns}`}
+              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+            />
+          </label>
+          <input
+            type="hidden"
+            name={BLOG_FORM_FIELDS.publishedAt}
+            value={isEdit ? (post!.publishedAt ?? '') : ''}
+          />
+          <span id={`schedule-help-${idns}`} class="mt-1 block text-xs text-earth-brown/70">
+            Pick a future date and time — the post stays hidden until then, when it publishes
+            automatically (checked every 5 minutes). Not ready to commit to a time? Set Status back
+            to Draft instead.
+          </span>
+        </div>
+
+        <label class="mt-3 block text-sm font-medium">
+          Date (required to publish)
+          <input
+            type="date"
+            name={BLOG_FORM_FIELDS.date}
+            value={isEdit ? post!.date : today}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+      </section>
+
+      {/* Details */}
+      <section class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-earth-brown/70">
+          Details
+        </h2>
+
+        <label class="block text-sm font-medium">
+          Web address (slug)
+          {
+            isEdit ? (
+              <>
+                <input
+                  type="text"
+                  value={post!.slug}
+                  readonly
+                  class="mt-1 w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 text-earth-brown/80"
+                />
+                <span class="mt-1 block text-xs text-earth-brown/70">
+                  A post's address can't be changed. To rename it, create a new post, copy the
+                  content over, publish it, then delete the old one.
+                </span>
+              </>
+            ) : (
+              <>
+                <input
+                  type="text"
+                  name={BLOG_FORM_FIELDS.slug}
+                  required
+                  maxlength="100"
+                  pattern="[a-z0-9-_]+"
+                  aria-describedby={`slug-help-${idns}`}
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+                />
+                <span id={`slug-help-${idns}`} class="mt-1 block text-xs text-earth-brown/70">
+                  This becomes the post's web address and can't be changed later — don't start it
+                  with a date, dates are added automatically on the page.
+                </span>
+              </>
+            )
+          }
+        </label>
+
+        <label class="mt-3 block text-sm font-medium">
+          Author
+          <input
+            type="text"
+            name={BLOG_FORM_FIELDS.author}
+            value={isEdit ? post!.author : 'Spicebush Team'}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+
+        <label class="mt-3 block text-sm font-medium">
+          Excerpt (required to publish)
+          {/* prettier-ignore */}
+          <textarea
+            name={BLOG_FORM_FIELDS.excerptRaw}
+            rows="4"
+            maxlength="1000"
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+            >{isEdit ? post!.excerpt : ''}</textarea
+          >
+        </label>
+      </section>
+
+      {/* Featured image */}
+      <section
+        class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+        data-blog-upload
+        data-upload-context={isEdit ? 'edit' : 'add'}
+      >
+        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-earth-brown/70">
+          Featured image (optional)
+        </h2>
+        <label class="block text-sm font-medium">
+          Featured image address
+          <input
+            type="text"
+            name={BLOG_FORM_FIELDS.image}
+            data-photo-url-input
+            pattern="(/(?![/\\]).*|https://.*)"
+            value={isEdit ? post!.image : undefined}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <input
+            type="file"
+            accept="image/*"
+            data-upload-file
+            aria-label="Choose an image file to upload"
+            class="max-w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+          />
+          <button
+            type="button"
+            data-upload-button
+            class="rounded-lg bg-forest-canopy px-3 py-2 text-xs font-semibold text-white hover:bg-moss-green"
+          >
+            Upload
+          </button>
+          <a
+            href="/admin/media"
+            data-upload-crop-link
+            target="_blank"
+            rel="noopener"
+            class="hidden rounded-lg border border-forest-canopy bg-white px-3 py-2 text-xs font-semibold text-forest-canopy hover:bg-forest-canopy hover:text-white"
+          >
+            Crop &amp; focal editor (opens in a new tab)
+          </a>
+        </div>
+        <div class="mt-2 hidden" data-copy-row>
+          <label class="block text-xs font-medium text-earth-brown/80">
+            Image address
+            <input
+              type="text"
+              data-copy-source
+              readonly
+              aria-label="Uploaded image address"
+              class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
+            />
+          </label>
+          <button
+            type="button"
+            data-copy-button
+            class="mt-1 rounded-lg border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-earth-brown hover:bg-gray-50"
+          >
+            Copy address
+          </button>
+        </div>
+        <p
+          data-upload-status
+          aria-live="polite"
+          class="mt-2 min-h-[1.25rem] text-xs text-earth-brown/80"
+        >
+        </p>
+
+        <label class="mt-3 block text-sm font-medium">
+          Image description (required to publish when an image is set)
+          <input
+            type="text"
+            name={BLOG_FORM_FIELDS.imageAlt}
+            minlength="6"
+            value={isEdit ? post!.imageAlt : undefined}
+            aria-describedby={`imagealt-help-${idns}`}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+          <span id={`imagealt-help-${idns}`} class="mt-1 block text-xs text-earth-brown/70">
+            At least 6 characters describing what's in the picture — not a file name, and not just
+            "photo" or "picture". E.g. "Children planting seedlings in the school garden".
+          </span>
+        </label>
+      </section>
+
+      {/* SEO */}
+      <section class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-earth-brown/70">
+          SEO (optional)
+        </h2>
+        <label class="block text-sm font-medium">
+          SEO title
+          <input
+            type="text"
+            name={BLOG_FORM_FIELDS.seoTitle}
+            value={isEdit ? post!.seoTitle : undefined}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+        <label class="mt-3 block text-sm font-medium">
+          SEO description
+          <input
+            type="text"
+            name={BLOG_FORM_FIELDS.seoDescription}
+            value={isEdit ? post!.seoDescription : undefined}
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+      </section>
+
+      {
+        /* Categories & tags — read-only for now (no taxonomy editor yet; carried losslessly via
+          baseDataJson). Shown so the owner can SEE what a post is filed under. */
+      }
+      {
+        isEdit && ((post!.categories?.length ?? 0) > 0 || (post!.tags?.length ?? 0) > 0) && (
+          <section class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+            <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-earth-brown/70">
+              Categories &amp; tags
+            </h2>
+            {(post!.categories?.length ?? 0) > 0 && (
+              <div class="mb-2">
+                <span class="block text-xs font-medium text-earth-brown/70">Categories</span>
+                <div class="mt-1 flex flex-wrap gap-1.5">
+                  {post!.categories!.map(c => (
+                    <span class="rounded-full bg-moss-green/10 px-2 py-0.5 text-xs text-earth-brown">
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {(post!.tags?.length ?? 0) > 0 && (
+              <div>
+                <span class="block text-xs font-medium text-earth-brown/70">Tags</span>
+                <div class="mt-1 flex flex-wrap gap-1.5">
+                  {post!.tags!.map(t => (
+                    <span class="rounded-full bg-stone-100 px-2 py-0.5 text-xs text-earth-brown">
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            <p class="mt-2 text-xs text-earth-brown/60">
+              Editing categories &amp; tags is coming soon.
+            </p>
+          </section>
+        )
+      }
+
+      <button
+        type="submit"
+        class="w-full rounded-lg bg-forest-canopy px-4 py-2 font-semibold text-white hover:bg-moss-green"
+      >
+        Save post
+      </button>
+    </aside>
+  </div>
+</form>
+
+<script>
+  import { initBlogAdmin } from '@lib/blog-admin-client';
+
+  const slugify = (value: string): string =>
+    String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  // Media upload widget — POSTs the chosen file to /api/media/upload, fills the featured-image
+  // address, and surfaces a copy-address row + crop link. Moved verbatim from the old inline
+  // /admin/blog script (it now only lives where the upload widget renders: the editor pages).
+  function initBlogUploads(): void {
+    document.querySelectorAll('[data-blog-upload]').forEach(card => {
+      if (!(card instanceof HTMLElement)) return;
+      const form = card.closest('form');
+      if (!(form instanceof HTMLFormElement)) return;
+
+      const fileInput = card.querySelector('[data-upload-file]');
+      const uploadButton = card.querySelector('[data-upload-button]');
+      const statusNode = card.querySelector('[data-upload-status]');
+      const cropLink = card.querySelector('[data-upload-crop-link]');
+      const photoInput = card.querySelector('[data-photo-url-input]');
+      const copyRow = card.querySelector('[data-copy-row]');
+      const copySource = card.querySelector('[data-copy-source]');
+      const copyButton = card.querySelector('[data-copy-button]');
+      const titleInput = form.querySelector('[name="title"]');
+
+      if (
+        !(fileInput instanceof HTMLInputElement) ||
+        !(uploadButton instanceof HTMLButtonElement) ||
+        !(statusNode instanceof HTMLElement) ||
+        !(photoInput instanceof HTMLInputElement)
+      ) {
+        return;
+      }
+
+      const announce = (message: string): void => {
+        statusNode.textContent = message;
+      };
+
+      uploadButton.addEventListener('click', async () => {
+        const selectedFile = fileInput.files && fileInput.files[0];
+        if (!selectedFile) {
+          announce('Please choose an image file first.');
+          return;
+        }
+
+        const titleValue = titleInput instanceof HTMLInputElement ? titleInput.value.trim() : '';
+        const requestedSlug = slugify(`blog-${titleValue || selectedFile.name}`);
+
+        const requestData = new FormData();
+        requestData.append('file', selectedFile);
+        requestData.append('createPhotoEntry', 'true');
+        requestData.append('category', 'blog');
+        requestData.append('title', titleValue ? `${titleValue} image` : 'Blog image');
+        if (requestedSlug) requestData.append('slug', requestedSlug);
+
+        uploadButton.setAttribute('disabled', 'disabled');
+        uploadButton.classList.add('opacity-60', 'cursor-not-allowed');
+        announce('Uploading…');
+
+        try {
+          const response = await fetch('/api/media/upload', { method: 'POST', body: requestData });
+          const payload = await response.json().catch(() => ({}));
+
+          if (!response.ok || payload.success !== true) {
+            const message =
+              typeof payload.error === 'string'
+                ? payload.error
+                : 'Upload failed — please try again.';
+            announce(message);
+            return;
+          }
+
+          const uploadedUrl = typeof payload.url === 'string' ? payload.url : '';
+          const photoSlug = typeof payload.photoSlug === 'string' ? payload.photoSlug : '';
+
+          if (uploadedUrl) {
+            photoInput.value = uploadedUrl;
+            photoInput.dispatchEvent(new Event('input', { bubbles: true }));
+            if (copyRow instanceof HTMLElement) copyRow.classList.remove('hidden');
+            if (copySource instanceof HTMLInputElement) copySource.value = uploadedUrl;
+          }
+
+          if (cropLink instanceof HTMLAnchorElement && photoSlug) {
+            cropLink.href = `/admin/media?slug=${encodeURIComponent(photoSlug)}`;
+            cropLink.classList.remove('hidden');
+          }
+
+          announce('Image attached — save the post to keep it.');
+        } catch {
+          announce('Upload failed — please try again.');
+        } finally {
+          uploadButton.removeAttribute('disabled');
+          uploadButton.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+      });
+
+      if (copyButton instanceof HTMLButtonElement && copySource instanceof HTMLInputElement) {
+        copyButton.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(copySource.value);
+            announce('Address copied.');
+          } catch {
+            copySource.select();
+            announce('Press Ctrl/Cmd+C to copy the selected address.');
+          }
+        });
+      }
+    });
+  }
+
+  function init(): void {
+    initBlogAdmin();
+    initBlogUploads();
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/app/src/pages/admin/blog.astro
+++ b/app/src/pages/admin/blog.astro
@@ -1,23 +1,19 @@
 ---
+/**
+ * Blog list / dashboard (issue #114 redesign). Authoring + editing now live on dedicated pages
+ * (/admin/blog/new, /admin/blog/edit/[slug]); this page is a clean, scannable list with bulk and
+ * per-row lifecycle actions. The flash logic and the bulk / quick-action form-POST contracts are
+ * unchanged — the editor pages still redirect here with ?saved=… / ?error=… on save.
+ */
 import AdminLayout from '@layouts/AdminLayout.astro';
-import {
-  getBlogPostViewCounts,
-  getManagedBlogPosts,
-  renderPostBody,
-  blogPostToEditData,
-  type BlogPost
-} from '@lib/blog-content';
+import { getBlogPostViewCounts, getManagedBlogPosts, type BlogPost } from '@lib/blog-content';
 import { BLOG_FORM_FIELDS } from '@lib/blog-form-fields';
-import TipTapEditor from '@components/TipTapEditor';
 
 const posts = await getManagedBlogPosts(); // uncached, no status filter, pre-sorted
 const errorMessage = Astro.url.searchParams.get('error');
 const savedSlug = errorMessage ? null : Astro.url.searchParams.get('saved'); // success never shows alongside an error (R1-F15)
-const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD default for the date input
 
-// Split into the four lifecycle sections; comparator already applied inside getManagedBlogPosts
-// (do NOT re-sort). Drafts catch any stray/unknown status too (R1-F9) — though the Phase-2 DB CHECK
-// now constrains blog rows to the four states.
+// Split into the four lifecycle sections; comparator already applied inside getManagedBlogPosts.
 const publishedPosts = posts.filter(p => p.status === 'published');
 const scheduledPosts = posts.filter(p => p.status === 'scheduled');
 const archivedPosts = posts.filter(p => p.status === 'archived');
@@ -25,12 +21,8 @@ const draftPosts = posts.filter(
   p => p.status !== 'published' && p.status !== 'scheduled' && p.status !== 'archived'
 );
 
-// Best-effort per-post view counts (Phase 5) — only published posts have a public `/blog/{slug}`
-// page, so only they can accrue `page_view` events. Constrained to these slugs in SQL (R3-F3).
+// Best-effort per-post view counts (Phase 5) — only published posts have a public page.
 const viewCounts = await getBlogPostViewCounts(publishedPosts.map(p => p.slug));
-
-// Existing-slug list for the client collision check (server-rendered into a data- attribute).
-const existingSlugs = posts.map(p => p.slug);
 
 // State-specific saved copy (R4-F12): resolve the saved slug's status.
 const savedPost =
@@ -38,19 +30,13 @@ const savedPost =
     ? (posts.find(p => p.slug === savedSlug) ?? null)
     : null;
 
-// Resolve the success-flash copy.
 let savedMessage: string | null = null;
 if (savedSlug === 'deleted') {
   savedMessage = 'Post deleted.';
 } else if (savedSlug === 'new') {
-  // KNOWN, DELIBERATE deviation from R4-F12 for saved=new (see PR description): the add-form
-  // redirect carries the STATIC literal /admin/blog?saved=new (R1-F15) and BlogPost has no
-  // timestamp, so the just-created row cannot be identified to resolve its status. Use the
-  // two-state copy that names BOTH states (the safety goal — owners must not think a draft is live).
   savedMessage =
     'Saved. If you set status to Published it is now live at its link. If you saved it as a draft it is NOT yet visible to the public — set status to Published when ready.';
 } else if (savedPost) {
-  // State-specific saved copy across the four lifecycle states (R1-F26/R4-F12).
   switch (savedPost.status) {
     case 'published':
       savedMessage = 'Published — now live at its link.';
@@ -69,8 +55,6 @@ if (savedSlug === 'deleted') {
   }
 }
 
-// Four-state badge (R1-F26): each lifecycle status reads distinctly so a scheduled/archived post
-// is never mislabelled as a generic "Draft".
 const statusBadgeClass = (post: BlogPost): string => {
   switch (post.status) {
     case 'published':
@@ -95,16 +79,11 @@ const statusBadgeLabel = (post: BlogPost): string => {
       return 'Draft';
   }
 };
-
-// `baseDataJson` for an edit form: carry the blog data.* fields reconstructable from `post`,
-// including categories/tags (which have no form input) so the wholesale-replace upsert does not
-// drop them on edit (#84). The field list lives in `blogPostToEditData` so it is unit-tested.
-const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditData(post));
 ---
 
 <AdminLayout title="Manage Blog">
   {
-    /* PR-2 deviation 5 (R1-F33/R2-F28/R3-F22): success flash is role=status with a manual Dismiss button and NO data-admin-alert (no 6s auto-hide — WCAG 2.2.1). faq.astro:100-108 DOES carry data-admin-alert; this must not. */
+    /* Success flash: role=status, manual Dismiss, NO data-admin-alert (no 6s auto-hide — WCAG 2.2.1). */
   }
   {
     savedMessage && (
@@ -125,9 +104,6 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
   }
 
   {
-    /* PR-2 deviation 5 (R2-F28/R3-F22): error flash is role=alert + tabindex=-1 + data-error-flash, NO data-admin-alert. Focus is driven by the client module init, not by ARIA. */
-  }
-  {
     errorMessage && (
       <p
         role="alert"
@@ -140,28 +116,35 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
     )
   }
 
-  <div class="space-y-6" data-existing-slugs={JSON.stringify(existingSlugs)}>
+  <div class="space-y-6">
     <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <h2 class="mb-2 text-lg font-semibold">Blog Manager</h2>
-      <p class="text-sm text-earth-brown/80">
-        Write a post and choose how it goes out: keep it a <strong>Draft</strong> (private),
-        <strong>Publish</strong> it now, <strong>Schedule</strong> it to go live automatically later,
-        or <strong>Archive</strong> an old post to hide it without deleting (you can restore it any time).
-        Posts are grouped by state below; tick the boxes to archive or delete several at once. The blog
-        index, and edits to already-published posts, can take up to 5 minutes to update.
-      </p>
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="text-lg font-semibold">Blog Manager</h2>
+          <p class="mt-1 max-w-2xl text-sm text-earth-brown/80">
+            Click a post to open the editor. Each post can be a <strong>Draft</strong> (private),
+            <strong>Published</strong> (live), <strong>Scheduled</strong> (auto-publishes later), or
+            <strong>Archived</strong> (hidden but kept). Tick the boxes to archive or delete several
+            at once. The blog index, and edits to already-published posts, can take up to 5 minutes to
+            update.
+          </p>
+        </div>
+        <a
+          href="/admin/blog/new"
+          class="shrink-0 rounded-lg bg-forest-canopy px-4 py-2 text-sm font-semibold text-white hover:bg-moss-green"
+        >
+          + New Post
+        </a>
+      </div>
     </section>
 
-    {
-      /* Phase 7 placeholder — AI writing is planned but NOT built (issue #110). It activates only once
-        the school supplies its own Anthropic API key. Purely informational: no inputs, no API calls. */
-    }
+    {/* AI writing — planned but NOT built (issue #110). Purely informational. */}
     <section
-      class="rounded-2xl border border-dashed border-forest-canopy/40 bg-forest-canopy/5 p-5"
+      class="rounded-2xl border border-dashed border-forest-canopy/40 bg-forest-canopy/5 p-4"
       aria-label="AI writing assistant — coming soon"
     >
       <div class="flex flex-wrap items-center gap-2">
-        <h2 class="text-lg font-semibold text-earth-brown">AI Writing Assistant</h2>
+        <h2 class="text-base font-semibold text-earth-brown">AI Writing Assistant</h2>
         <span
           class="rounded-full bg-forest-canopy/15 px-2.5 py-0.5 text-xs font-semibold text-forest-canopy"
         >
@@ -169,316 +152,13 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
         </span>
       </div>
       <p class="mt-2 text-sm text-earth-brown/80">
-        Draft generation, rewrite/expand helpers, SEO title &amp; description suggestions, and a
-        school "voice" profile are planned for the editor. They are <strong>not enabled yet</strong
-        >.
-      </p>
-      <p class="mt-2 text-sm text-earth-brown/80">
-        Because the AI runs on a paid service, this feature activates only when the school provides
-        its own <strong>Anthropic API key</strong>. When you're ready to turn it on (or want to talk
-        through whether it's worth it), reach out to your site developer — nothing here needs setup
-        until then.
+        Draft generation, rewrite/expand helpers, and SEO suggestions are planned for the editor.
+        Because the AI runs on a paid service, this activates only when the school provides its own
+        <strong>Anthropic API key</strong>. Reach out to your site developer when you're ready.
       </p>
     </section>
 
-    <section class="space-y-4">
-      <details class="rounded-xl border border-gray-200 bg-white shadow-sm">
-        <summary class="cursor-pointer px-5 py-4 text-base font-semibold text-earth-brown"
-          >Add new post</summary
-        >
-        <div class="space-y-4 border-t border-gray-200 p-5">
-          <form
-            method="post"
-            action="/api/admin/content"
-            class="space-y-4"
-            data-blog-form
-            data-new-blog-form
-          >
-            <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
-            <input type="hidden" name={BLOG_FORM_FIELDS.createOnly} value="true" />
-            {
-              /* R1-F15: static literal redirect (no slug) — do NOT rewrite to carry the new slug. */
-            }
-            <input type="hidden" name={BLOG_FORM_FIELDS.redirectTo} value="/admin/blog?saved=new" />
-
-            <div class="grid gap-3 md:grid-cols-2">
-              <label class="block text-sm font-medium md:col-span-2">
-                Title
-                <input
-                  type="text"
-                  name={BLOG_FORM_FIELDS.title}
-                  required
-                  maxlength="300"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                />
-              </label>
-
-              <label class="block text-sm font-medium md:col-span-2">
-                Web address (slug)
-                <input
-                  type="text"
-                  name={BLOG_FORM_FIELDS.slug}
-                  required
-                  maxlength="100"
-                  pattern="[a-z0-9-_]+"
-                  aria-describedby="add-slug-help"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                />
-                <span id="add-slug-help" class="mt-1 block text-xs text-earth-brown/70">
-                  This becomes the post's web address and can't be changed later — don't start it
-                  with a date, dates are added automatically on the page.
-                </span>
-              </label>
-
-              {
-                /* PR-2 deviation 1 (R2-F14): status select renders TOP-LEVEL, never inside a collapsed <details>. */
-              }
-              {
-                /* PR-2 deviation 6 absent here — add-form defaults to Draft (R4-F11, add-form only). */
-              }
-              <label class="block text-sm font-medium">
-                Status
-                <select
-                  name={BLOG_FORM_FIELDS.status}
-                  aria-describedby="add-status-help"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                >
-                  <option value="draft" selected>Draft</option>
-                  <option value="published">Published</option>
-                  <option value="scheduled">Scheduled</option>
-                  <option value="archived">Archived</option>
-                </select>
-                <span id="add-status-help" class="mt-1 block text-xs text-earth-brown/70">
-                  Title is always required. To publish (now or scheduled) you also need an excerpt,
-                  a body, and a date; if you set a featured image you also need an image
-                  description. Scheduled posts go live automatically at the time you pick. New posts
-                  appear at their link immediately after publishing. The blog index, and edits to
-                  already-published posts, can take up to 5 minutes to update.
-                </span>
-              </label>
-
-              {
-                /* Schedule control — shown only when Status = Scheduled (toggled by the client).
-                  No static `required` (a hidden required field is unsubmittable); the client adds
-                  `required` in lockstep with visibility. The visible value is local wall-clock; the
-                  client writes the UTC-Z instant into the hidden `data.publishedAt` on submit. */
-              }
-              <div class="block text-sm font-medium" data-schedule-group hidden>
-                <label class="block">
-                  Go live on (your local time)
-                  <input
-                    type="datetime-local"
-                    name={BLOG_FORM_FIELDS.publishedAtLocal}
-                    aria-describedby="add-schedule-help"
-                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                  />
-                </label>
-                <input type="hidden" name={BLOG_FORM_FIELDS.publishedAt} value="" />
-                <span id="add-schedule-help" class="mt-1 block text-xs text-earth-brown/70">
-                  Pick a future date and time — the post stays hidden until then, when it publishes
-                  automatically (checked every 5 minutes). Not ready to commit to a time? Set Status
-                  back to Draft instead.
-                </span>
-              </div>
-
-              <label class="block text-sm font-medium">
-                Date (required to publish)
-                <input
-                  type="date"
-                  name={BLOG_FORM_FIELDS.date}
-                  value={today}
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                />
-              </label>
-
-              <label class="block text-sm font-medium md:col-span-2">
-                Author
-                <input
-                  type="text"
-                  name={BLOG_FORM_FIELDS.author}
-                  value="Spicebush Team"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                />
-              </label>
-
-              <label class="block text-sm font-medium md:col-span-2">
-                Excerpt (required to publish)
-                {
-                  /* PR-2 deviation 2 (R2-F8): tight interpolation under prettier-ignore. Empty for the add-form. */
-                }
-                {/* prettier-ignore */}
-                <textarea
-                  name={BLOG_FORM_FIELDS.excerptRaw}
-                  rows="3"
-                  maxlength="1000"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"></textarea>
-              </label>
-
-              <div class="block text-sm font-medium md:col-span-2">
-                <span class="mb-1 block">Body (required to publish)</span>
-                <TipTapEditor client:load fieldName={BLOG_FORM_FIELDS.bodyRaw} />
-              </div>
-            </div>
-
-            {/* Editor tips — the WYSIWYG toolbar replaces the old Markdown guide. */}
-            <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-              <summary class="cursor-pointer text-sm font-semibold text-earth-brown"
-                >Editor tips</summary
-              >
-              <div class="mt-3 space-y-2 text-xs text-earth-brown/80">
-                <p>
-                  Use the toolbar to format. Every image inside your post needs a description (alt
-                  text) — a post can't be published with an empty or one-word image description.
-                </p>
-                <p>
-                  Upload images at
-                  <a
-                    href="/admin/media"
-                    target="_blank"
-                    rel="noopener"
-                    class="font-medium text-forest-canopy hover:underline"
-                  >
-                    Media (opens in a new tab)
-                  </a>, then use the image button in the editor to insert by address.
-                </p>
-              </div>
-            </details>
-
-            {/* Featured-image widget — PR-2 §3.4 (mirror staff.astro). */}
-            <div
-              class="rounded-lg border border-gray-200 bg-gray-50 p-3"
-              data-blog-upload
-              data-upload-context="add"
-            >
-              <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-earth-brown/70">
-                Featured image (optional)
-              </p>
-              <label class="block text-sm font-medium">
-                Featured image address
-                <input
-                  type="text"
-                  name={BLOG_FORM_FIELDS.image}
-                  data-photo-url-input
-                  pattern="(/(?![/\\]).*|https://.*)"
-                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <div class="mt-2 flex flex-wrap items-center gap-2">
-                <input
-                  type="file"
-                  accept="image/*"
-                  data-upload-file
-                  aria-label="Choose an image file to upload"
-                  class="max-w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
-                />
-                <button
-                  type="button"
-                  data-upload-button
-                  class="rounded-lg bg-forest-canopy px-3 py-2 text-xs font-semibold text-white hover:bg-moss-green"
-                >
-                  Upload
-                </button>
-                <a
-                  href="/admin/media"
-                  data-upload-crop-link
-                  target="_blank"
-                  rel="noopener"
-                  class="hidden rounded-lg border border-forest-canopy bg-white px-3 py-2 text-xs font-semibold text-forest-canopy hover:bg-forest-canopy hover:text-white"
-                >
-                  Crop &amp; focal editor (opens in a new tab)
-                </a>
-              </div>
-              {/* R1-F20 + R2-F30: copy-address affordance. */}
-              <div class="mt-2 hidden" data-copy-row>
-                <label class="block text-xs font-medium text-earth-brown/80">
-                  Image address
-                  <input
-                    type="text"
-                    data-copy-source
-                    readonly
-                    aria-label="Uploaded image address"
-                    class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
-                  />
-                </label>
-                <button
-                  type="button"
-                  data-copy-button
-                  class="mt-1 rounded-lg border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-earth-brown hover:bg-gray-50"
-                >
-                  Copy address
-                </button>
-                <span class="mt-1 block text-xs text-earth-brown/70">
-                  To put this image inside your post, copy this address into
-                  <code>![description](address)</code>.
-                </span>
-              </div>
-              {
-                /* PR-2 deviation 7 (R4-F14): live region is PERMANENTLY RENDERED + visually empty — NO hidden/display:none (staff.astro:451 has `hidden`; that suppresses announcements). */
-              }
-              <p
-                data-upload-status
-                aria-live="polite"
-                class="mt-2 min-h-[1.25rem] text-xs text-earth-brown/80"
-              >
-              </p>
-            </div>
-
-            <label class="block text-sm font-medium md:col-span-2">
-              Image description (required to publish when an image is set)
-              <input
-                type="text"
-                name={BLOG_FORM_FIELDS.imageAlt}
-                minlength="6"
-                aria-describedby="add-imagealt-help"
-                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-              />
-              <span id="add-imagealt-help" class="mt-1 block text-xs text-earth-brown/70">
-                At least 6 characters describing what's in the picture — not a file name, and not
-                just "photo" or "picture". E.g. "Children planting seedlings in the school garden".
-              </span>
-            </label>
-
-            <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-              <summary class="cursor-pointer text-sm font-semibold text-earth-brown"
-                >SEO (optional)</summary
-              >
-              <div class="mt-3 grid gap-3 md:grid-cols-2">
-                <label class="block text-sm font-medium md:col-span-2">
-                  SEO title
-                  <input
-                    type="text"
-                    name={BLOG_FORM_FIELDS.seoTitle}
-                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                  />
-                </label>
-                <label class="block text-sm font-medium md:col-span-2">
-                  SEO description
-                  <input
-                    type="text"
-                    name={BLOG_FORM_FIELDS.seoDescription}
-                    class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                  />
-                </label>
-              </div>
-            </details>
-
-            <button
-              type="submit"
-              class="rounded-lg bg-forest-canopy px-4 py-2 font-semibold text-white hover:bg-moss-green"
-            >
-              Save post
-            </button>
-          </form>
-        </div>
-      </details>
-    </section>
-
-    {
-      /* Bulk-actions toolbar. The per-post checkboxes live in each row and associate with this form
-        via the `form="bulk-blog-form"` attribute (HTML forbids nesting them inside the per-post edit
-        forms). The submit buttons carry the action; the client adds a count-aware confirm (R4-F14)
-        and `data-no-loading` keeps the shared loading-state handler from disabling them on cancel. */
-    }
+    {/* Bulk-actions toolbar. Per-post checkboxes associate via `form="bulk-blog-form"`. */}
     <section class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
       <form
         id="bulk-blog-form"
@@ -524,59 +204,60 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
         { heading: 'Archived posts', group: archivedPosts }
       ].map(({ heading, group }) => (
         <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-          <h2 class="mb-3 text-lg font-semibold">{heading}</h2>
+          <h2 class="mb-3 text-lg font-semibold">
+            {heading} <span class="text-sm font-normal text-earth-brown/60">({group.length})</span>
+          </h2>
           {group.length === 0 ? (
             <p class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-earth-brown/80">
               No posts here yet.
             </p>
           ) : (
-            <div class="space-y-3">
+            <ul class="divide-y divide-gray-100">
               {group.map(post => (
-                <div class="flex items-start gap-2">
-                  {/* Bulk-select checkbox — beside the row, NOT inside <summary> (a click there
-                      would toggle the accordion). Associated with the toolbar form via `form=`. */}
+                <li class="flex flex-wrap items-center gap-3 py-3">
                   <input
                     type="checkbox"
                     name="slugs"
                     value={post.slug}
                     form="bulk-blog-form"
                     aria-label={`Select ${post.title} for a bulk action`}
-                    class="mt-4 ml-1 h-4 w-4 shrink-0"
+                    class="h-4 w-4 shrink-0"
                   />
-                  <details
-                    open={post.slug === savedSlug}
-                    class="flex-1 rounded-lg border border-gray-200 bg-white"
-                  >
-                    <summary class="cursor-pointer px-4 py-3">
-                      <span class="flex flex-wrap items-center justify-between gap-2">
-                        <span class="font-semibold text-earth-brown">{post.title}</span>
-                        <span class="flex items-center gap-2 text-xs">
-                          {/* Best-effort view count — only published posts are in the map (R3-F3).
-                              The count is a number (auto-escaped); no raw page_path is ever rendered. */}
-                          {viewCounts.has(post.slug) && (
-                            <span
-                              class="text-earth-brown/70"
-                              title="Approximate page views from site analytics — best-effort and can be over- or under-counted; not an authoritative figure."
-                            >
-                              {viewCounts.get(post.slug)} views
-                            </span>
-                          )}
-                          <span class={`rounded-full px-2 py-1 ${statusBadgeClass(post)}`}>
-                            {statusBadgeLabel(post)}
-                          </span>
-                          {post.date && <span class="text-earth-brown/70">{post.date}</span>}
-                        </span>
+                  <div class="min-w-0 flex-1">
+                    <a
+                      href={`/admin/blog/edit/${post.slug}`}
+                      class="font-semibold text-earth-brown hover:text-forest-canopy hover:underline"
+                    >
+                      {post.title}
+                    </a>
+                    <div class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-earth-brown/70">
+                      <span class={`rounded-full px-2 py-0.5 ${statusBadgeClass(post)}`}>
+                        {statusBadgeLabel(post)}
                       </span>
-                    </summary>
+                      {post.date && <span>{post.date}</span>}
+                      {viewCounts.has(post.slug) && (
+                        <span title="Approximate page views from site analytics — best-effort and can be over- or under-counted; not an authoritative figure.">
+                          {viewCounts.get(post.slug)} views
+                        </span>
+                      )}
+                    </div>
+                  </div>
 
-                    <div class="border-t border-gray-200 p-4">
-                      {/* Edit form — NO createOnly (R deviation 6 status select below). */}
-                      <form
-                        method="post"
-                        action="/api/admin/content"
-                        class="space-y-4"
-                        data-blog-form
+                  <div class="flex flex-wrap items-center gap-2">
+                    {post.status === 'published' && (
+                      <a
+                        href={`/blog/${post.slug}`}
+                        target="_blank"
+                        rel="noopener"
+                        class="text-sm font-medium text-forest-canopy hover:underline"
                       >
+                        View ↗
+                      </a>
+                    )}
+
+                    {post.status === 'archived' ? (
+                      <form method="post" action="/api/admin/content">
+                        <input type="hidden" name={BLOG_FORM_FIELDS.action} value="restore" />
                         <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
                         <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
                         <input
@@ -584,365 +265,67 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
                           name={BLOG_FORM_FIELDS.redirectTo}
                           value={`/admin/blog?saved=${encodeURIComponent(post.slug)}`}
                         />
-                        <input
-                          type="hidden"
-                          name={BLOG_FORM_FIELDS.baseDataJson}
-                          value={baseDataFor(post)}
-                        />
-
-                        <div class="grid gap-3 md:grid-cols-2">
-                          <label class="block text-sm font-medium md:col-span-2">
-                            Title
-                            <input
-                              type="text"
-                              name={BLOG_FORM_FIELDS.title}
-                              required
-                              maxlength="300"
-                              value={post.title}
-                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                            />
-                          </label>
-
-                          <label class="block text-sm font-medium md:col-span-2">
-                            Web address (slug)
-                            <input
-                              type="text"
-                              value={post.slug}
-                              readonly
-                              class="mt-1 w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 text-earth-brown/80"
-                            />
-                            <span class="mt-1 block text-xs text-earth-brown/70">
-                              Need to change a post's address? Create a new post, copy the content
-                              over, publish it, then delete the old one.
-                            </span>
-                          </label>
-
-                          {/* PR-2 deviation 1 (R2-F14): status select top-level. */}
-                          {/* R3-F10/R4-F12: each option's `selected` matches the post's EXACT status,
-                            so an untouched edit re-submits the current status. The prior
-                            `selected={post.status !== 'draft'}` collapsed scheduled/archived into
-                            "Published" and would silently publish them on save — fixed here. */}
-                          <label class="block text-sm font-medium">
-                            Status
-                            <select
-                              name={BLOG_FORM_FIELDS.status}
-                              aria-describedby={`edit-status-help-${post.slug}`}
-                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                            >
-                              <option value="draft" selected={post.status === 'draft'}>
-                                Draft
-                              </option>
-                              <option value="published" selected={post.status === 'published'}>
-                                Published
-                              </option>
-                              <option value="scheduled" selected={post.status === 'scheduled'}>
-                                Scheduled
-                              </option>
-                              <option value="archived" selected={post.status === 'archived'}>
-                                Archived
-                              </option>
-                            </select>
-                            {/* PR-2 R1-F38: staleness helper text linked to the edit-form status control. */}
-                            <span
-                              id={`edit-status-help-${post.slug}`}
-                              class="mt-1 block text-xs text-earth-brown/70"
-                            >
-                              Set <strong>Archived</strong> to hide a post without deleting it (you
-                              can restore it any time). New posts appear at their link immediately
-                              after publishing. The blog index, and edits to already-published
-                              posts, can take up to 5 minutes to update.
-                            </span>
-                          </label>
-
-                          {/* Schedule control — shown when this post is (or is being set) Scheduled.
-                            No static `required`; the client toggles visibility + `required` in
-                            lockstep and round-trips the time through the hidden UTC field. */}
-                          <div
-                            class="block text-sm font-medium"
-                            data-schedule-group
-                            hidden={post.status !== 'scheduled'}
-                          >
-                            <label class="block">
-                              Go live on (your local time)
-                              <input
-                                type="datetime-local"
-                                name={BLOG_FORM_FIELDS.publishedAtLocal}
-                                aria-describedby={`edit-schedule-help-${post.slug}`}
-                                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                              />
-                            </label>
-                            <input
-                              type="hidden"
-                              name={BLOG_FORM_FIELDS.publishedAt}
-                              value={post.publishedAt ?? ''}
-                            />
-                            <span
-                              id={`edit-schedule-help-${post.slug}`}
-                              class="mt-1 block text-xs text-earth-brown/70"
-                            >
-                              Pick a future date and time — the post stays hidden until then, when
-                              it publishes automatically (checked every 5 minutes). Not ready? Set
-                              Status back to Draft instead.
-                            </span>
-                          </div>
-
-                          <label class="block text-sm font-medium">
-                            Date (required to publish)
-                            <input
-                              type="date"
-                              name={BLOG_FORM_FIELDS.date}
-                              value={post.date}
-                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                            />
-                          </label>
-
-                          <label class="block text-sm font-medium md:col-span-2">
-                            Author
-                            <input
-                              type="text"
-                              name={BLOG_FORM_FIELDS.author}
-                              value={post.author}
-                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                            />
-                          </label>
-
-                          <label class="block text-sm font-medium md:col-span-2">
-                            Excerpt (required to publish)
-                            {/* prettier-ignore */}
-                            <textarea name={BLOG_FORM_FIELDS.excerptRaw} rows="3" maxlength="1000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2">{post.excerpt}</textarea>
-                          </label>
-
-                          <div class="block text-sm font-medium md:col-span-2">
-                            <span class="mb-1 block">Body (required to publish)</span>
-                            {/* Per-post island hydrates when the accordion opens (client:visible). initialHtml is
-                              the server render of the stored body, so markdown or HTML both load as HTML. */}
-                            <TipTapEditor
-                              client:visible
-                              fieldName={BLOG_FORM_FIELDS.bodyRaw}
-                              initialHtml={renderPostBody(post.body)}
-                            />
-                          </div>
-                        </div>
-
-                        <div
-                          class="rounded-lg border border-gray-200 bg-gray-50 p-3"
-                          data-blog-upload
-                          data-upload-context="edit"
-                        >
-                          <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-earth-brown/70">
-                            Featured image (optional)
-                          </p>
-                          <label class="block text-sm font-medium">
-                            Featured image address
-                            <input
-                              type="text"
-                              name={BLOG_FORM_FIELDS.image}
-                              data-photo-url-input
-                              pattern="(/(?![/\\]).*|https://.*)"
-                              value={post.image}
-                              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                            />
-                          </label>
-                          <div class="mt-2 flex flex-wrap items-center gap-2">
-                            <input
-                              type="file"
-                              accept="image/*"
-                              data-upload-file
-                              aria-label="Choose an image file to upload"
-                              class="max-w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
-                            />
-                            <button
-                              type="button"
-                              data-upload-button
-                              class="rounded-lg bg-forest-canopy px-3 py-2 text-xs font-semibold text-white hover:bg-moss-green"
-                            >
-                              Upload
-                            </button>
-                            <a
-                              href="/admin/media"
-                              data-upload-crop-link
-                              target="_blank"
-                              rel="noopener"
-                              class="hidden rounded-lg border border-forest-canopy bg-white px-3 py-2 text-xs font-semibold text-forest-canopy hover:bg-forest-canopy hover:text-white"
-                            >
-                              Crop &amp; focal editor (opens in a new tab)
-                            </a>
-                          </div>
-                          <div class="mt-2 hidden" data-copy-row>
-                            <label class="block text-xs font-medium text-earth-brown/80">
-                              Image address
-                              <input
-                                type="text"
-                                data-copy-source
-                                readonly
-                                aria-label="Uploaded image address"
-                                class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs"
-                              />
-                            </label>
-                            <button
-                              type="button"
-                              data-copy-button
-                              class="mt-1 rounded-lg border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-earth-brown hover:bg-gray-50"
-                            >
-                              Copy address
-                            </button>
-                            <span class="mt-1 block text-xs text-earth-brown/70">
-                              To put this image inside your post, copy this address into
-                              <code>![description](address)</code>.
-                            </span>
-                          </div>
-                          {/* PR-2 deviation 7 (R4-F14): permanently rendered, visually-empty live region (no hidden/display:none). */}
-                          <p
-                            data-upload-status
-                            aria-live="polite"
-                            class="mt-2 min-h-[1.25rem] text-xs text-earth-brown/80"
-                          />
-                        </div>
-
-                        <label class="block text-sm font-medium md:col-span-2">
-                          Image description (required to publish when an image is set)
-                          <input
-                            type="text"
-                            name={BLOG_FORM_FIELDS.imageAlt}
-                            minlength="6"
-                            value={post.imageAlt}
-                            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                          />
-                          <span class="mt-1 block text-xs text-earth-brown/70">
-                            At least 6 characters describing what's in the picture — not a file
-                            name, and not just "photo" or "picture".
-                          </span>
-                        </label>
-
-                        <details class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-                          <summary class="cursor-pointer text-sm font-semibold text-earth-brown">
-                            SEO (optional)
-                          </summary>
-                          <div class="mt-3 grid gap-3 md:grid-cols-2">
-                            <label class="block text-sm font-medium md:col-span-2">
-                              SEO title
-                              <input
-                                type="text"
-                                name={BLOG_FORM_FIELDS.seoTitle}
-                                value={post.seoTitle}
-                                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                              />
-                            </label>
-                            <label class="block text-sm font-medium md:col-span-2">
-                              SEO description
-                              <input
-                                type="text"
-                                name={BLOG_FORM_FIELDS.seoDescription}
-                                value={post.seoDescription}
-                                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2"
-                              />
-                            </label>
-                          </div>
-                        </details>
-
                         <button
                           type="submit"
-                          class="rounded-lg bg-forest-canopy px-4 py-2 font-semibold text-white hover:bg-moss-green"
+                          class="rounded-lg border border-forest-canopy/40 bg-white px-3 py-1.5 text-sm font-semibold text-forest-canopy hover:bg-moss-green/10"
                         >
-                          Save post
+                          Restore
                         </button>
                       </form>
-
-                      {/* Preview — server-rendered through the public pipeline. */}
-                      {/* render previews lazily via ?preview={slug} if the collection exceeds ~30 posts */}
-                      <details open={post.slug === savedSlug} class="mt-4">
-                        <summary class="cursor-pointer text-sm font-semibold text-earth-brown">
-                          Preview
-                        </summary>
-                        <p class="mt-2 text-xs text-earth-brown/70">
-                          Save first — the preview shows your last saved version.
-                        </p>
-                        <div
-                          class="prose mt-2 max-w-none text-sm"
-                          set:html={renderPostBody(post.body)}
+                    ) : (
+                      <form
+                        method="post"
+                        action="/api/admin/content"
+                        data-confirm="Archive this post? It will be hidden from the public but kept — you can restore it any time."
+                      >
+                        <input type="hidden" name={BLOG_FORM_FIELDS.action} value="archive" />
+                        <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+                        <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
+                        <input
+                          type="hidden"
+                          name={BLOG_FORM_FIELDS.redirectTo}
+                          value={`/admin/blog?saved=${encodeURIComponent(post.slug)}`}
                         />
-                      </details>
-
-                      <div class="mt-4 flex flex-wrap items-center gap-3">
-                        {post.status === 'published' && (
-                          <a
-                            href={`/blog/${post.slug}`}
-                            target="_blank"
-                            rel="noopener"
-                            class="text-sm font-medium text-forest-canopy hover:underline"
-                          >
-                            View on site ↗
-                          </a>
-                        )}
-
-                        {/* Per-row lifecycle quick actions (R4-F12): Archive any non-archived post,
-                          Restore (→ Draft) an archived one. Both POST the PR3 endpoint actions. */}
-                        {post.status === 'archived' ? (
-                          <form method="post" action="/api/admin/content">
-                            <input type="hidden" name={BLOG_FORM_FIELDS.action} value="restore" />
-                            <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
-                            <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
-                            <input
-                              type="hidden"
-                              name={BLOG_FORM_FIELDS.redirectTo}
-                              value={`/admin/blog?saved=${encodeURIComponent(post.slug)}`}
-                            />
-                            <button
-                              type="submit"
-                              class="rounded-lg border border-forest-canopy/40 bg-white px-3 py-2 text-sm font-semibold text-forest-canopy hover:bg-moss-green/10"
-                            >
-                              Restore to draft
-                            </button>
-                          </form>
-                        ) : (
-                          <form
-                            method="post"
-                            action="/api/admin/content"
-                            data-confirm="Archive this post? It will be hidden from the public but kept — you can restore it any time."
-                          >
-                            <input type="hidden" name={BLOG_FORM_FIELDS.action} value="archive" />
-                            <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
-                            <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
-                            <input
-                              type="hidden"
-                              name={BLOG_FORM_FIELDS.redirectTo}
-                              value={`/admin/blog?saved=${encodeURIComponent(post.slug)}`}
-                            />
-                            <button
-                              type="submit"
-                              class="rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm font-semibold text-earth-brown hover:bg-stone-50"
-                            >
-                              Archive
-                            </button>
-                          </form>
-                        )}
-
-                        <form
-                          method="post"
-                          action="/api/admin/content"
-                          data-confirm="Delete this post? If you are renaming its address, make sure the new copy is saved first. This cannot be undone."
+                        <button
+                          type="submit"
+                          class="rounded-lg border border-stone-300 bg-white px-3 py-1.5 text-sm font-semibold text-earth-brown hover:bg-stone-50"
                         >
-                          <input type="hidden" name={BLOG_FORM_FIELDS.action} value="delete" />
-                          <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
-                          <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
-                          <input
-                            type="hidden"
-                            name={BLOG_FORM_FIELDS.redirectTo}
-                            value="/admin/blog?saved=deleted"
-                          />
-                          <button
-                            type="submit"
-                            class="rounded-lg border border-red-300 bg-white px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50"
-                          >
-                            Delete post
-                          </button>
-                        </form>
-                      </div>
-                    </div>
-                  </details>
-                </div>
+                          Archive
+                        </button>
+                      </form>
+                    )}
+
+                    <form
+                      method="post"
+                      action="/api/admin/content"
+                      data-confirm="Delete this post? If you are renaming its address, make sure the new copy is saved first. This cannot be undone."
+                    >
+                      <input type="hidden" name={BLOG_FORM_FIELDS.action} value="delete" />
+                      <input type="hidden" name={BLOG_FORM_FIELDS.collection} value="blog" />
+                      <input type="hidden" name={BLOG_FORM_FIELDS.slug} value={post.slug} />
+                      <input
+                        type="hidden"
+                        name={BLOG_FORM_FIELDS.redirectTo}
+                        value="/admin/blog?saved=deleted"
+                      />
+                      <button
+                        type="submit"
+                        class="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-50"
+                      >
+                        Delete
+                      </button>
+                    </form>
+
+                    <a
+                      href={`/admin/blog/edit/${post.slug}`}
+                      class="rounded-lg bg-forest-canopy px-3 py-1.5 text-sm font-semibold text-white hover:bg-moss-green"
+                    >
+                      Edit
+                    </a>
+                  </div>
+                </li>
               ))}
-            </div>
+            </ul>
           )}
         </section>
       ))
@@ -950,122 +333,10 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
   </div>
 </AdminLayout>
 
-{
-  /* The processed script imports the client module so its @lib import resolves at bundle time (builder-verify 24). */
-}
 <script>
   import { initBlogAdmin } from '@lib/blog-admin-client';
 
-  const slugify = (value: string): string =>
-    String(value || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9-_]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-
-  function initBlogUploads(): void {
-    document.querySelectorAll('[data-blog-upload]').forEach(card => {
-      if (!(card instanceof HTMLElement)) return;
-      const form = card.closest('form');
-      if (!(form instanceof HTMLFormElement)) return;
-
-      const fileInput = card.querySelector('[data-upload-file]');
-      const uploadButton = card.querySelector('[data-upload-button]');
-      const statusNode = card.querySelector('[data-upload-status]');
-      const cropLink = card.querySelector('[data-upload-crop-link]');
-      const photoInput = card.querySelector('[data-photo-url-input]');
-      const copyRow = card.querySelector('[data-copy-row]');
-      const copySource = card.querySelector('[data-copy-source]');
-      const copyButton = card.querySelector('[data-copy-button]');
-      const titleInput = form.querySelector('[name="title"]');
-
-      if (
-        !(fileInput instanceof HTMLInputElement) ||
-        !(uploadButton instanceof HTMLButtonElement) ||
-        !(statusNode instanceof HTMLElement) ||
-        !(photoInput instanceof HTMLInputElement)
-      ) {
-        return;
-      }
-
-      const announce = (message: string): void => {
-        statusNode.textContent = message;
-      };
-
-      uploadButton.addEventListener('click', async () => {
-        const selectedFile = fileInput.files && fileInput.files[0];
-        if (!selectedFile) {
-          announce('Please choose an image file first.');
-          return;
-        }
-
-        const titleValue = titleInput instanceof HTMLInputElement ? titleInput.value.trim() : '';
-        const requestedSlug = slugify(`blog-${titleValue || selectedFile.name}`);
-
-        const requestData = new FormData();
-        requestData.append('file', selectedFile);
-        requestData.append('createPhotoEntry', 'true');
-        requestData.append('category', 'blog');
-        requestData.append('title', titleValue ? `${titleValue} image` : 'Blog image');
-        if (requestedSlug) requestData.append('slug', requestedSlug);
-
-        uploadButton.setAttribute('disabled', 'disabled');
-        uploadButton.classList.add('opacity-60', 'cursor-not-allowed');
-        announce('Uploading…');
-
-        try {
-          const response = await fetch('/api/media/upload', { method: 'POST', body: requestData });
-          const payload = await response.json().catch(() => ({}));
-
-          if (!response.ok || payload.success !== true) {
-            const message =
-              typeof payload.error === 'string'
-                ? payload.error
-                : 'Upload failed — please try again.';
-            announce(message);
-            return;
-          }
-
-          const uploadedUrl = typeof payload.url === 'string' ? payload.url : '';
-          const photoSlug = typeof payload.photoSlug === 'string' ? payload.photoSlug : '';
-
-          if (uploadedUrl) {
-            photoInput.value = uploadedUrl;
-            // Re-evaluate the conditional imageAlt requirement (R1-F18).
-            photoInput.dispatchEvent(new Event('input', { bubbles: true }));
-
-            if (copyRow instanceof HTMLElement) copyRow.classList.remove('hidden');
-            if (copySource instanceof HTMLInputElement) copySource.value = uploadedUrl;
-          }
-
-          if (cropLink instanceof HTMLAnchorElement && photoSlug) {
-            cropLink.href = `/admin/media?slug=${encodeURIComponent(photoSlug)}`;
-            cropLink.classList.remove('hidden');
-          }
-
-          announce('Image attached — save the post to keep it.');
-        } catch {
-          announce('Upload failed — please try again.');
-        } finally {
-          uploadButton.removeAttribute('disabled');
-          uploadButton.classList.remove('opacity-60', 'cursor-not-allowed');
-        }
-      });
-
-      if (copyButton instanceof HTMLButtonElement && copySource instanceof HTMLInputElement) {
-        copyButton.addEventListener('click', async () => {
-          try {
-            await navigator.clipboard.writeText(copySource.value);
-            announce('Address copied.');
-          } catch {
-            copySource.select();
-            announce('Press Ctrl/Cmd+C to copy the selected address.');
-          }
-        });
-      }
-    });
-  }
-
+  // Dismiss the success flash (role=status has no auto-hide by design).
   function initDismissFlash(): void {
     document.querySelectorAll('[data-dismiss-flash]').forEach(button => {
       if (!(button instanceof HTMLElement)) return;
@@ -1076,8 +347,7 @@ const baseDataFor = (post: BlogPost): string => JSON.stringify(blogPostToEditDat
   }
 
   function init(): void {
-    initBlogAdmin();
-    initBlogUploads();
+    initBlogAdmin(); // wires the bulk-action confirm + error-flash focus on this page
     initDismissFlash();
   }
 

--- a/app/src/pages/admin/blog/edit/[slug].astro
+++ b/app/src/pages/admin/blog/edit/[slug].astro
@@ -1,0 +1,24 @@
+---
+/**
+ * Dedicated blog-post editor (issue #114). Replaces the accordion edit-form that unfolded inside
+ * each list row in /admin/blog. Auth is enforced by the /admin middleware. A missing slug bounces
+ * back to the list with an error flash (the list renders ?error).
+ */
+import AdminLayout from '@layouts/AdminLayout.astro';
+import BlogEditorForm from '@components/admin/BlogEditorForm.astro';
+import { getManagedBlogPosts } from '@lib/blog-content';
+
+const { slug } = Astro.params;
+const posts = await getManagedBlogPosts(); // uncached, all statuses
+const post = posts.find(p => p.slug === slug);
+
+if (!post) {
+  return Astro.redirect(
+    `/admin/blog?error=${encodeURIComponent('That post could not be found — it may have been deleted.')}`
+  );
+}
+---
+
+<AdminLayout title={`Edit: ${post.title}`}>
+  <BlogEditorForm mode="edit" post={post} />
+</AdminLayout>

--- a/app/src/pages/admin/blog/new.astro
+++ b/app/src/pages/admin/blog/new.astro
@@ -1,0 +1,18 @@
+---
+/**
+ * Dedicated "new blog post" editor (issue #114). Replaces the accordion add-form that lived inline
+ * in /admin/blog. Auth is enforced by the /admin middleware (same gate as the rest of /admin/blog).
+ * AdminLayout supplies the <main> landmark + the page <h1> (via `title`) + shared admin scripts.
+ */
+import AdminLayout from '@layouts/AdminLayout.astro';
+import BlogEditorForm from '@components/admin/BlogEditorForm.astro';
+import { getManagedBlogPosts } from '@lib/blog-content';
+
+// Existing slugs power the client-side collision check ([data-existing-slugs] on the new form).
+const posts = await getManagedBlogPosts();
+const existingSlugs = posts.map(p => p.slug);
+---
+
+<AdminLayout title="New blog post">
+  <BlogEditorForm mode="new" existingSlugs={existingSlugs} />
+</AdminLayout>

--- a/docs/adr/011-blog-admin-editor-redesign.md
+++ b/docs/adr/011-blog-admin-editor-redesign.md
@@ -1,0 +1,59 @@
+# ADR-011: Dedicated blog editor pages over the single-page accordion dashboard
+
+**Date**: 2026-06-09
+**Status**: Accepted (supersedes the R3-F15 "keep-accordion" choice recorded in `docs/specs/blog.md`)
+
+## Context
+
+The Blog V2 admin (`/admin/blog`) shipped as a single ~1,086-line page built from nested `<details>`
+accordions: list + create + edit all stacked on one page, the TipTap editor buried inside an
+accordion (and the metadata buried in further accordions nested inside it), and link/image insertion
+driven by raw `window.prompt()` boxes. During the V2 build the owner explicitly chose to keep the
+per-post accordion edit forms over a scannable table (recorded as **R3-F15**). In use, the owner
+found the result "strange" — nothing is visible until expanded, which is the opposite of the WYSIWYG
+experience TipTap can provide (issue **#114**).
+
+The editor *component* (`TipTapEditor.tsx`) is capable; the problem is the page that wraps it. We
+workshopped the direction with the owner, who chose: a **dedicated editor page** layout, a **polished
++ expanded toolset**, **in-editor dialogs + a live side-by-side preview**, and a **brand-only color
+palette**.
+
+## Decision
+
+Split the admin into a **list page** and **dedicated editor pages**, delivered across three PRs:
+
+- **PR A (this ADR's first increment).** `/admin/blog` becomes a clean, scannable list (four
+  lifecycle groups, bulk + per-row actions, a New Post button). The authoring form moves to dedicated
+  routes `/admin/blog/new` and `/admin/blog/edit/[slug]`, sharing one component
+  `app/src/components/admin/BlogEditorForm.astro` — title + TipTap body in the main column, **all
+  metadata in an always-visible sidebar**. The form-POST contract to `/api/admin/content` (field
+  names, hidden inputs, `createOnly`/`baseDataJson`, `redirectTo`, validation, upload widget, flash
+  logic) is **preserved exactly**; only the layout changes, so the backend, the client module
+  (`blog-admin-client.ts`), and every R-numbered behavior carry over unchanged.
+- **PR B.** Polish + power tools (grouped/labeled/sticky toolbar, undo/redo, horizontal rule,
+  word/character count, in-editor link & image dialogs wired to `/admin/media`), plus **highlight**
+  (`<mark>`) and **brand-palette text colors** (class-based). The only new XSS surface is bounded:
+  `<mark>` + the brand color/highlight classes added to `STRICT_CONFIG_V2` (`blog-html.ts`) and the
+  extensions→sanitizer matrix test; `style`/`id` stay banned (ADR-009's render-time sanitization
+  remains the trust boundary).
+- **PR C.** A live side-by-side preview pane (rendered through the same `renderBodyHtml` the public
+  page uses) replacing the Edit/Preview toggle, plus a responsive/accessibility pass.
+
+This reverses **R3-F15**: the scannable list the owner previously declined is now the chosen design,
+because the dedicated editor makes the per-row accordion redundant.
+
+## Consequences
+
+- **Better authoring UX**: a focused, fully-visible editing surface (WordPress/Ghost-style) instead
+  of nested disclosures; the list is scannable at a glance.
+- **No backend or data change**: the redesign is UI-only against the existing endpoint. Slug
+  immutability, scheduled publishing, image-alt validation, and the four-state lifecycle are
+  untouched.
+- **Bounded new security surface** (PR B only): two new construct types in the render-time sanitizer,
+  each covered by the matrix test. The write path still stores raw editor HTML; sanitize-at-render
+  stays the sole trust boundary (per ADR-009 / `docs/specs/blog.md`).
+- **Editing URL changes**: editing now happens at `/admin/blog/edit/[slug]` rather than an inline
+  accordion. After a save the owner returns to the list with the existing status-aware flash (the
+  redirect targets are unchanged).
+- **Deferred**: a taxonomy (categories/tags) editor remains out of scope; the sidebar shows existing
+  categories/tags read-only and the values are still carried losslessly via `baseDataJson`.

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -188,35 +188,44 @@ real fixes the previously-broken link that 301'd to `/contact`.
 
 ## Admin Routes
 
-| Route                     | Description                                                                                                                                    |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/admin/blog`             | Blog authoring dashboard — add-post form + draft/published lists with inline edit, preview, and delete. File: `app/src/pages/admin/blog.astro` |
-| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts`                       |
+| Route                     | Description                                                                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/admin/blog`             | Blog dashboard — a scannable list of all posts (four lifecycle groups) with bulk + per-row lifecycle actions and a **New Post** button. File: `app/src/pages/admin/blog.astro` |
+| `/admin/blog/new`         | Dedicated new-post editor. File: `app/src/pages/admin/blog/new.astro`                                                                                          |
+| `/admin/blog/edit/[slug]` | Dedicated editor for an existing post. File: `app/src/pages/admin/blog/edit/[slug].astro`                                                                      |
+| `POST /api/admin/content` | Generic content endpoint (existing) — the blog uses it via `collection=blog`. File: `app/src/pages/api/admin/content.ts`                                       |
 
-The admin page is a structural clone of `app/src/pages/admin/faq.astro` (AdminLayout wrapper,
-`?saved=` / `?error=` flash params, `<details>` add-form + collapsible per-item edit forms). A link
-to `/admin/blog` (label "Blog") is added to `app/src/components/AdminNav.astro` under "Content".
+The list and the editor share the `AdminLayout` wrapper and the `?saved=` / `?error=` flash params.
+The editor form lives in one shared component, `app/src/components/admin/BlogEditorForm.astro` (used
+by both `new` and `edit`), so the field set is authored once. The **#114 admin redesign** replaced
+the accordion add/edit forms that previously lived inline on the list page with these dedicated
+editor pages (it preserved the form-POST contract, field names, validation, upload widget, and flash
+logic exactly — only the layout changed). A link to `/admin/blog` (label "Blog") is in
+`app/src/components/AdminNav.astro` under "Content".
 
 ### Page structure
 
-- **Add new post** — a `<details>` form posting to `/api/admin/content` with hidden
-  `collection=blog`, `createOnly=true`, `redirectTo=/admin/blog?saved=new`. Fields: title, slug,
-  date, author, excerpt, body (TipTap rich-text editor — see [Authoring Model](#authoring-model)),
-  featured image (upload widget + URL input), image description (alt), SEO title/description
-  (collapsed, optional), and a status select (Draft / Published, default Draft).
-- **Post list** — two groups, **Drafts** and **Published**, ordered by `compareBlogPosts`. Every row
-  with `type='blog'` is shown regardless of status (any non-`published` status, including a
-  stray/legacy value, sorts under Drafts). Status badges pair color with text using AA-passing
-  pairings.
-- **Edit form** — the same field set, pre-filled. Slug is read-only (a hidden input plus a display).
-  The status `<select>` renders `selected={post.status}` so an untouched edit retains the post's
-  current status (editing a published post without touching status keeps it published). The image
-  input prefills `value={post.image}`. The edit form carries no `createOnly`.
-- **Preview** — a nested `<details>` containing the server-rendered output of
-  `renderPostBody(post.body)` — the identical public render pipeline, zero-JS. On save, the saved
-  post's `<details>` (and its preview) server-render `open` so the save → redirect → preview loop
-  works.
-- **Delete** — a per-post form posting `action=delete`, `collection=blog`, `slug`,
+The dashboard and the editor are separate pages (#114 redesign):
+
+- **List (`/admin/blog`)** — four lifecycle groups (Published, Scheduled, Drafts, Archived), each a
+  scannable list of rows ordered by `compareBlogPosts`. Every row with `type='blog'` is shown
+  regardless of status (any non-`published`/`scheduled`/`archived` value sorts under Drafts). Each
+  row shows the title (a link to the editor), a four-state status badge (color paired with AA-passing
+  text), the date, an optional "N views" badge (published only), per-row quick actions (View on site,
+  Archive/Restore, Delete), and an **Edit** link. A **New Post** button opens the editor.
+- **Editor (`/admin/blog/new`, `/admin/blog/edit/[slug]`)** — the shared `BlogEditorForm.astro`
+  renders the title + TipTap body in the main column and **all metadata in an always-visible
+  sidebar** (status + schedule, date, slug, author, excerpt, featured image + alt, SEO; categories
+  and tags shown read-only when present). Nothing is hidden in `<details>`. The form posts to
+  `/api/admin/content`: `new` carries `createOnly=true` and `redirectTo=/admin/blog?saved=new`; `edit`
+  carries the post's `slug` (hidden), `baseDataJson`, and `redirectTo=/admin/blog?saved=<slug>`. The
+  status `<select>` renders `selected` matching the post's EXACT status, so an untouched edit retains
+  it. The slug is editable on `new` (with the collision check) and read-only on `edit`; a missing slug
+  on `edit` redirects to the list with an error flash.
+- **Preview** — the TipTap editor's own Preview button renders the current body through `renderBodyHtml`
+  (the same render-time pipeline the public page uses). The separate server-rendered accordion preview
+  was removed with the accordions.
+- **Delete** — a per-row form on the list posts `action=delete`, `collection=blog`, `slug`,
   `redirectTo=/admin/blog?saved=deleted`, with a confirmation prompt.
 
 ### Form field names
@@ -230,15 +239,15 @@ through this module so drift fails a test.
 
 ### Layout constraints
 
-- The status `<select>` always renders top-level, never inside a collapsed `<details>` (a required
-  control inside a collapsed, unfocusable disclosure can be silently un-submittable in Chrome).
-- Only optional, never-required fields (the "SEO (optional)" group) may live inside collapsed
-  sub-details. Date, excerpt, body, image, and imageAlt (all conditionally required) render
-  top-level.
-- The body and excerpt textareas are authored with tight interpolation
-  (`<textarea …>{post.body}</textarea>`, zero whitespace) under a `<!-- prettier-ignore -->` guard,
+- Every field is **always visible** on the editor page — none lives inside a collapsed `<details>`
+  (the #114 redesign removed the accordions). The status `<select>` and all conditionally-required
+  fields (date, excerpt, body, image, imageAlt) sit in the always-visible main column / sidebar, so a
+  required control can never be hidden in a collapsed, unfocusable disclosure (which can be silently
+  un-submittable in Chrome).
+- The excerpt textarea is authored with tight interpolation
+  (`<textarea …>{post.excerpt}</textarea>`, zero whitespace) under a `<!-- prettier-ignore -->` guard,
   because the `_raw` form path deliberately skips the parser's trim; `normalizeBlogData` is the
-  backstop trim.
+  backstop trim. (The body is the TipTap island's hidden field, not a textarea.)
 
 ### Featured image (media system reuse)
 
@@ -380,9 +389,9 @@ contract). This format contract lives in `app/src/lib/blog-publish-schedule.ts`
 imported by BOTH `validateBlogData` (save gate) and the scheduled-publish cron (fire predicate),
 so a post that saves cleanly is exactly the set the cron will fire — one contract, no drift.
 
-#### Authoring the lifecycle (`/admin/blog` form + `blog-admin-client.ts`)
+#### Authoring the lifecycle (`BlogEditorForm.astro` + `blog-admin-client.ts`)
 
-The add/edit forms expose all four statuses in the status dropdown. Each edit-form option's
+The editor's status dropdown exposes all four statuses. Each edit option's
 `selected` matches the post's EXACT status (R3-F10) — the prior `selected={post.status !== 'draft'}`
 would have silently published a scheduled/archived post on an untouched save. Scheduling specifics:
 
@@ -397,11 +406,13 @@ would have silently published a scheduled/archived post on an untouched save. Sc
   overridable `confirm()` ("this publishes now, not at that time") so a future date never silently
   publishes-now. `archived` is selectable here and round-trips to Draft/Published via a normal save.
 
-#### Dashboard (`/admin/blog` list — keep-accordion, R3-F15 owner override)
+#### Dashboard (`/admin/blog` list — scannable rows, #114 redesign)
 
-The list keeps the per-post `<details>` accordion edit forms (the owner chose this over a scannable
-table) and adds lifecycle management in place: posts are grouped into four sections (Published,
-Scheduled, Drafts, Archived); each row carries a four-state status badge and per-row quick actions —
+The list is a scannable set of rows that link to the dedicated editor — the **#114 redesign**
+replaced the per-post `<details>` accordion edit forms, **superseding the earlier R3-F15
+keep-accordion choice**. Lifecycle management stays in place: posts are grouped into four sections
+(Published, Scheduled, Drafts, Archived); each row carries a four-state status badge and per-row
+quick actions —
 **Archive** (any non-archived) / **Restore to draft** (archived, R4-F12) — that POST the
 `action=archive`/`action=restore` endpoints. **Bulk** select uses a checkbox per row associated via
 `form="bulk-blog-form"` (HTML forbids nesting them in the per-post edit forms) and a toolbar whose


### PR DESCRIPTION
**PR A of 3** for the blog admin redesign (#114). Layout-only; the power toolset (PR B) and live side-by-side preview (PR C) follow.

## What

Replaces the single ~1,086-line `/admin/blog` accordion dashboard with a focused, everything-visible layout:

- **`/admin/blog`** → a clean **scannable list**: four lifecycle groups (Published/Scheduled/Drafts/Archived), each row with a status badge, date, optional view count, per-row actions (View ↗ / Archive / Restore / Delete) and an **Edit** link, plus a **New Post** button. No accordions, no inline forms.
- **`/admin/blog/new`** and **`/admin/blog/edit/[slug]`** → **dedicated editor pages** sharing `app/src/components/admin/BlogEditorForm.astro`: title + TipTap body in the main column, **all metadata in an always-visible sidebar** (status + schedule, date, slug, author, excerpt, featured image + alt, SEO; existing categories/tags shown read-only).

## Preserved exactly (UI-only change)

The `/api/admin/content` form-POST contract is byte-for-byte preserved — field names (`blog-form-fields.ts`), hidden inputs (`createOnly`, `baseDataJson`, `slug`, `redirectTo`), the redirect targets (success/error both land on the list with the existing status-aware flash), and every `data-*` hook the client module keys off (`data-blog-form`, `data-new-blog-form`, `data-existing-slugs`, `data-schedule-group`, `data-blog-upload`, `data-bulk-blog-form`). So conditional-required, slug autofill/collision, schedule toggling, the body-required submit guard, the media upload widget, and bulk actions all carry over **unchanged**. Slug stays immutable on edit.

This reverses the R3-F15 keep-accordion choice — see **ADR-011**.

## Gates (run locally on the branch)

- lint ✅ · typecheck ✅ (0 errors/0 warnings; pre-existing `ts(6385)` hint only) · **498 tests pass** ✅ · build ✅ (SSR function generated) · prettier ✅

## Docs

`docs/specs/blog.md` (Admin Routes, Page structure, Layout constraints, Authoring lifecycle, Dashboard sections) updated; new `docs/adr/011-blog-admin-editor-redesign.md`.

## Note on review

Per the redesign's merge-on-CI-green policy, the live editor UX is verified by the owner post-deploy. The interactive TipTap authoring flow can't be exercised by CI.

Refs #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Separated blog admin dashboard into a scannable list view with dedicated pages for creating and editing posts
  * Added featured image upload widget with automatic slug generation and clipboard copy functionality

* **Documentation**
  * Updated specifications and architecture records documenting the admin blog redesign

<!-- end of auto-generated comment: release notes by coderabbit.ai -->