### PR TITLE
feat(blog): editor power tools — highlight, brand color, undo/redo, HR, word count (PR B of #114)

### DIFF
--- a/app/src/components/TipTapEditor.tsx
+++ b/app/src/components/TipTapEditor.tsx
@@ -88,7 +88,9 @@ export default function TipTapEditor({
   }, []);
 
   const updateCounts = useCallback((editor: Editor) => {
-    const text = editor.state.doc.textContent;
+    // Use getText with a block separator: doc.textContent joins blocks with an EMPTY separator, so
+    // "<p>hello</p><p>world</p>" would collapse to "helloworld" and undercount as one word.
+    const text = editor.getText({ blockSeparator: ' ' });
     const trimmed = text.trim();
     setCounts({ words: trimmed ? trimmed.split(/\s+/).length : 0, chars: text.length });
   }, []);

--- a/app/src/components/TipTapEditor.tsx
+++ b/app/src/components/TipTapEditor.tsx
@@ -10,7 +10,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent, type Editor } from '@tiptap/react';
-import { buildBlogEditorExtensions } from '@lib/blog-editor-extensions';
+import { buildBlogEditorExtensions, BRAND_TEXT_COLORS } from '@lib/blog-editor-extensions';
 import { renderBodyHtml } from '@lib/blog-html';
 
 type ImagePick = { src: string; alt: string };
@@ -56,6 +56,22 @@ function ToolbarButton({ onClick, isActive = false, label, children }: ToolbarBu
   );
 }
 
+/** Visual separator between toolbar groups (decorative). */
+function ToolbarDivider() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 1,
+        alignSelf: 'stretch',
+        minHeight: 20,
+        background: '#d1d5db',
+        margin: '0 2px'
+      }}
+    />
+  );
+}
+
 export default function TipTapEditor({
   initialHtml = '',
   fieldName = 'bodyRaw',
@@ -64,10 +80,17 @@ export default function TipTapEditor({
   const [showPreview, setShowPreview] = useState(false);
   const [previewHtml, setPreviewHtml] = useState('');
   const [isDirty, setIsDirty] = useState(false);
+  const [counts, setCounts] = useState({ words: 0, chars: 0 });
   const hiddenRef = useRef<HTMLInputElement | null>(null);
 
   const syncHidden = useCallback((editor: Editor) => {
     if (hiddenRef.current) hiddenRef.current.value = editor.getHTML();
+  }, []);
+
+  const updateCounts = useCallback((editor: Editor) => {
+    const text = editor.state.doc.textContent;
+    const trimmed = text.trim();
+    setCounts({ words: trimmed ? trimmed.split(/\s+/).length : 0, chars: text.length });
   }, []);
 
   const editor = useEditor({
@@ -83,9 +106,13 @@ export default function TipTapEditor({
         'aria-label': 'Post body'
       }
     },
-    onCreate: ({ editor }) => syncHidden(editor),
+    onCreate: ({ editor }) => {
+      syncHidden(editor);
+      updateCounts(editor);
+    },
     onUpdate: ({ editor }) => {
       syncHidden(editor);
+      updateCounts(editor);
       setIsDirty(true);
     }
   });
@@ -149,6 +176,17 @@ export default function TipTapEditor({
       <input type="hidden" name={fieldName} ref={hiddenRef} defaultValue={initialHtml} />
 
       <div className="blog-editor-toolbar" role="toolbar" aria-label="Text formatting">
+        {/* History */}
+        <ToolbarButton label="Undo" onClick={() => editor.chain().focus().undo().run()}>
+          ↶
+        </ToolbarButton>
+        <ToolbarButton label="Redo" onClick={() => editor.chain().focus().redo().run()}>
+          ↷
+        </ToolbarButton>
+
+        <ToolbarDivider />
+
+        {/* Inline text */}
         <ToolbarButton
           label="Bold"
           isActive={editor.isActive('bold')}
@@ -177,7 +215,42 @@ export default function TipTapEditor({
         >
           <s>S</s>
         </ToolbarButton>
+        <ToolbarButton
+          label="Highlight"
+          isActive={editor.isActive('highlight')}
+          onClick={() => editor.chain().focus().toggleHighlight().run()}
+        >
+          <mark>H</mark>
+        </ToolbarButton>
+        <select
+          aria-label="Text color"
+          value={(editor.getAttributes('brandTextColor').color as string) || ''}
+          onChange={e => {
+            const value = e.target.value;
+            if (value) editor.chain().focus().setBrandTextColor(value).run();
+            else editor.chain().focus().unsetBrandTextColor().run();
+          }}
+          style={{
+            font: 'inherit',
+            fontSize: '0.8125rem',
+            padding: '0.25rem 0.4rem',
+            border: '1px solid #d1d5db',
+            borderRadius: 6,
+            background: 'white',
+            cursor: 'pointer'
+          }}
+        >
+          <option value="">Color</option>
+          {BRAND_TEXT_COLORS.map(color => (
+            <option key={color.key} value={color.key}>
+              {color.label}
+            </option>
+          ))}
+        </select>
 
+        <ToolbarDivider />
+
+        {/* Headings */}
         <ToolbarButton
           label="Heading 2"
           isActive={editor.isActive('heading', { level: 2 })}
@@ -200,6 +273,9 @@ export default function TipTapEditor({
           H4
         </ToolbarButton>
 
+        <ToolbarDivider />
+
+        {/* Blocks */}
         <ToolbarButton
           label="Bullet list"
           isActive={editor.isActive('bulletList')}
@@ -228,7 +304,16 @@ export default function TipTapEditor({
         >
           {'</>'}
         </ToolbarButton>
+        <ToolbarButton
+          label="Horizontal line"
+          onClick={() => editor.chain().focus().setHorizontalRule().run()}
+        >
+          ―
+        </ToolbarButton>
 
+        <ToolbarDivider />
+
+        {/* Alignment */}
         <ToolbarButton
           label="Align left"
           isActive={editor.isActive({ textAlign: 'left' })}
@@ -251,6 +336,9 @@ export default function TipTapEditor({
           ⇥
         </ToolbarButton>
 
+        <ToolbarDivider />
+
+        {/* Insert */}
         <ToolbarButton label="Insert link" isActive={editor.isActive('link')} onClick={insertLink}>
           🔗
         </ToolbarButton>
@@ -266,6 +354,9 @@ export default function TipTapEditor({
           ▦
         </ToolbarButton>
 
+        <ToolbarDivider />
+
+        {/* View */}
         <ToolbarButton
           label={showPreview ? 'Back to editing' : 'Preview as visitor'}
           isActive={showPreview}
@@ -283,6 +374,12 @@ export default function TipTapEditor({
         />
       ) : (
         <EditorContent editor={editor} />
+      )}
+
+      {!showPreview && (
+        <p style={{ marginTop: 6, fontSize: '0.75rem', color: '#6b6256', textAlign: 'right' }}>
+          {counts.words} {counts.words === 1 ? 'word' : 'words'} · {counts.chars} characters
+        </p>
       )}
     </div>
   );

--- a/app/src/lib/blog-editor-extensions.ts
+++ b/app/src/lib/blog-editor-extensions.ts
@@ -21,7 +21,7 @@ import { TableRow } from '@tiptap/extension-table-row';
 import { TableHeader } from '@tiptap/extension-table-header';
 import { TableCell } from '@tiptap/extension-table-cell';
 import Image from '@tiptap/extension-image';
-import type { Extensions } from '@tiptap/core';
+import { Mark, mergeAttributes, type Extensions } from '@tiptap/core';
 
 /** The four alignments the editor supports, mapped to the enumerated sanitizer-allowlisted classes. */
 const ALIGNMENT_TO_CLASS: Record<string, string> = {
@@ -70,6 +70,116 @@ export const ClassTextAlign = TextAlign.extend({
 });
 
 /**
+ * Highlight mark → a bare `<mark>` with NO attributes (PR B / #114). A custom Mark rather than
+ * `@tiptap/extension-highlight` so we add zero dependencies and emit nothing the sanitizer must
+ * value-check: `<mark>` is added to `STRICT_CONFIG_V2.ALLOWED_TAGS` and carries no attrs.
+ */
+export const Highlight = Mark.create({
+  name: 'highlight',
+  parseHTML() {
+    return [{ tag: 'mark' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['mark', mergeAttributes(HTMLAttributes), 0];
+  },
+  addCommands() {
+    return {
+      toggleHighlight:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name)
+    };
+  }
+});
+
+/**
+ * Brand text color — a class-based `<span>` mark (PR B / #114). The owner picked a fixed on-brand
+ * palette; each color is an ENUMERATED class (`text-forest-canopy|moss-green|sunlight-gold|earth-brown`)
+ * never an inline `style` (which stays banned). The sanitizer admits `<span>` only with these
+ * allowlisted class tokens, so a `<span>` can never carry anything but a brand color.
+ */
+export const BRAND_TEXT_COLORS = [
+  { key: 'forest', label: 'Forest canopy', class: 'text-forest-canopy' },
+  { key: 'moss', label: 'Moss green', class: 'text-moss-green' },
+  { key: 'gold', label: 'Sunlight gold', class: 'text-sunlight-gold' },
+  { key: 'earth', label: 'Earth brown', class: 'text-earth-brown' }
+] as const;
+
+/** The exact class tokens the sanitizer must allow on `<span>` — keep in lockstep with `blog-html.ts`. */
+export const BRAND_TEXT_COLOR_CLASSES = BRAND_TEXT_COLORS.map(c => c.class);
+
+const COLOR_KEY_TO_CLASS: Record<string, string> = Object.fromEntries(
+  BRAND_TEXT_COLORS.map(c => [c.key, c.class])
+);
+const CLASS_TO_COLOR_KEY: Record<string, string> = Object.fromEntries(
+  BRAND_TEXT_COLORS.map(c => [c.class, c.key])
+);
+
+export const BrandTextColor = Mark.create({
+  name: 'brandTextColor',
+  addAttributes() {
+    return {
+      color: {
+        default: null,
+        parseHTML: (element: HTMLElement): string | null => {
+          for (const cls of Array.from(element.classList)) {
+            if (CLASS_TO_COLOR_KEY[cls]) return CLASS_TO_COLOR_KEY[cls];
+          }
+          return null;
+        },
+        renderHTML: (attributes: Record<string, unknown>): Record<string, string> => {
+          const key = attributes.color;
+          const cls = typeof key === 'string' ? COLOR_KEY_TO_CLASS[key] : undefined;
+          return cls ? { class: cls } : {};
+        }
+      }
+    };
+  },
+  parseHTML() {
+    // Only claim a <span> that already carries a brand color class — never absorb arbitrary spans.
+    return [
+      {
+        tag: 'span',
+        getAttrs: (element: HTMLElement | string): false | Record<string, never> => {
+          if (typeof element === 'string') return false;
+          for (const cls of Array.from(element.classList)) {
+            if (CLASS_TO_COLOR_KEY[cls]) return {};
+          }
+          return false;
+        }
+      }
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes(HTMLAttributes), 0];
+  },
+  addCommands() {
+    return {
+      setBrandTextColor:
+        (color: string) =>
+        ({ commands }) =>
+          commands.setMark(this.name, { color }),
+      unsetBrandTextColor:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name)
+    };
+  }
+});
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    highlight: {
+      toggleHighlight: () => ReturnType;
+    };
+    brandTextColor: {
+      setBrandTextColor: (color: string) => ReturnType;
+      unsetBrandTextColor: () => ReturnType;
+    };
+  }
+}
+
+/**
  * Build the configured Blog V2 editor extension set. Call (rather than export a frozen array) so the
  * island and the test each get an independent instance — TipTap extensions hold per-editor state.
  */
@@ -84,6 +194,10 @@ export function buildBlogEditorExtensions(): Extensions {
     // Block images. allowBase64:false rejects data:/base64 at the editor level too, mirroring the
     // render-time sanitizer's data: block (blog-html.ts) — images must be real URLs (media library
     // or site-relative paths), never inline blobs.
-    Image.configure({ inline: false, allowBase64: false })
+    Image.configure({ inline: false, allowBase64: false }),
+    // PR B power tools (#114): bare <mark> highlight + class-based brand text color. Both emit only
+    // sanitizer-allowlisted output (mark with no attrs; span with an enumerated brand color class).
+    Highlight,
+    BrandTextColor
   ];
 }

--- a/app/src/lib/blog-html.test.ts
+++ b/app/src/lib/blog-html.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import { generateHTML, generateJSON } from '@tiptap/html';
 import DOMPurify from 'isomorphic-dompurify';
 import { renderBodyHtml, collectHtmlImageAlts } from './blog-html';
-import { buildBlogEditorExtensions } from './blog-editor-extensions';
+import { buildBlogEditorExtensions, BRAND_TEXT_COLOR_CLASSES } from './blog-editor-extensions';
 
 // Real TipTap emission for an input: parse to ProseMirror JSON then re-serialize through the EXACT
 // configured extension set (D1-F10) — the sanitizer is tested against what the editor truly emits,
@@ -179,6 +179,41 @@ describe('renderBodyHtml — V1 trust-boundary properties hold (hostile inputs)'
   it('returns "" for empty/non-string input', () => {
     expect(renderBodyHtml('')).toBe('');
     expect(renderBodyHtml(undefined as unknown as string)).toBe('');
+  });
+});
+
+describe('renderBodyHtml — PR B power tools (#114): highlight + brand text color', () => {
+  it('keeps a bare <mark> highlight (real TipTap emission), no attributes', () => {
+    const out = renderBodyHtml(tiptapHtml('<p><mark>highlighted</mark></p>'));
+    expect(out).toContain('<mark>highlighted</mark>');
+  });
+
+  it('round-trips every brand text color through the editor as a class-based <span>', () => {
+    for (const cls of BRAND_TEXT_COLOR_CLASSES) {
+      const out = renderBodyHtml(tiptapHtml(`<p><span class="${cls}">x</span></p>`));
+      expect(out).toContain(`<span class="${cls}">x</span>`);
+    }
+  });
+
+  it('strips style/id/event handlers off <mark> and brand-color <span> (sanitizer boundary)', () => {
+    const mark = renderBodyHtml('<mark style="background:red" onclick="x()">h</mark>');
+    expect(mark).toContain('<mark>h</mark>');
+    expect(mark).not.toContain('style=');
+    expect(mark).not.toContain('onclick');
+
+    const span = renderBodyHtml(
+      '<span class="text-forest-canopy" style="color:red" id="z">x</span>'
+    );
+    expect(span).toContain('class="text-forest-canopy"');
+    expect(span).not.toContain('style=');
+    expect(span).not.toContain('id=');
+  });
+
+  it('drops a non-brand class on <span>, leaving a bare span (no utility-class abuse)', () => {
+    const out = renderBodyHtml('<span class="bg-red-500 absolute inset-0">x</span>');
+    expect(out).not.toContain('bg-red-500');
+    expect(out).not.toContain('class=');
+    expect(out).toContain('>x</span>');
   });
 });
 

--- a/app/src/lib/blog-html.ts
+++ b/app/src/lib/blog-html.ts
@@ -48,7 +48,10 @@ export const STRICT_CONFIG_V2 = {
     'u', // underline (first-class)
     's', // strike (TipTap normalizes <del>/<strike> to <s>)
     'colgroup',
-    'col' // table column groups TipTap emits
+    'col', // table column groups TipTap emits
+    // PR B power tools (#114):
+    'mark', // highlight — emitted with NO attributes
+    'span' // brand text color — survives ONLY with an enumerated brand color class (see ALLOWED_CLASSES); bare otherwise
   ],
   // V1 baseline ['href','src','alt','title'] + V2 delta. NO 'id'. NO 'style' (text-align is class-based;
   // tables resizable:false). 'class'/'target'/'rel' are value-enumerated by the hook below; 'colwidth'
@@ -69,7 +72,13 @@ export const STRICT_CONFIG_V2 = {
   ADD_URI_SAFE_ATTR: ['class', 'target', 'rel', 'colspan', 'rowspan']
 };
 
-/** The ONLY `class` tokens kept on body content: code-block language hints + the four text-align classes. */
+/**
+ * The ONLY `class` tokens kept on body content: code-block language hints, the four text-align
+ * classes, and the four brand text-color classes (PR B #114). Any other class token is dropped.
+ * The brand color set must stay in lockstep with `BRAND_TEXT_COLOR_CLASSES` in
+ * `blog-editor-extensions.ts` (asserted by the sanitizer matrix test, not imported here — that file
+ * pulls in TipTap, which must not reach the SSR render path).
+ */
 const ALLOWED_CLASSES = new Set([
   'language-js',
   'language-ts',
@@ -84,7 +93,12 @@ const ALLOWED_CLASSES = new Set([
   'text-left',
   'text-center',
   'text-right',
-  'text-justify'
+  'text-justify',
+  // Brand text colors (PR B #114):
+  'text-forest-canopy',
+  'text-moss-green',
+  'text-sunlight-gold',
+  'text-earth-brown'
 ]);
 const ALLOWED_REL = new Set(['noopener', 'noreferrer', 'nofollow']);
 const ALLOWED_TARGET = new Set(['_blank', '_self']);

--- a/docs/specs/blog.md
+++ b/docs/specs/blog.md
@@ -21,9 +21,14 @@ intentionally out and why.
 
 ## Authoring Model
 
-- Posts are authored in a **TipTap WYSIWYG editor** at `/admin/blog` (ADR-009); the editor's HTML is
-  stored in `data.body`. Bold/italic/underline/strike, H2–H4, lists, blockquote, code blocks, links,
-  images, tables, and **class-based** text alignment are first-class.
+- Posts are authored in a **TipTap WYSIWYG editor** (ADR-009; redesigned to dedicated editor pages in
+  ADR-011, #114). The editor's HTML is stored in `data.body`. Bold/italic/underline/strike,
+  **highlight** (`<mark>`), **class-based brand text color**
+  (`text-forest-canopy|moss-green|sunlight-gold|earth-brown`), H2–H4, lists, blockquote, code blocks,
+  **horizontal rules**, links, images, tables, and **class-based** text alignment are first-class. The
+  grouped toolbar also has undo/redo and a live word/character count. All color/alignment/highlight
+  output is **class-based, never inline `style`** (which stays banned) — see
+  [Rendering & Sanitization](#rendering--sanitization).
 - The body is **re-sanitized at every render** through `renderBodyHtml` (DOMPurify `STRICT_CONFIG_V2`,
   `app/src/lib/blog-html.ts`) — sanitize-at-render is the trust boundary, never sanitize-at-write only.
   `style` is banned (alignment is class-based; tables `resizable:false`). During the markdown→HTML
@@ -526,54 +531,51 @@ realistic hostile input is raw HTML an owner pastes (`<img src=x onerror=...>`, 
 barrier. The stored body is re-sanitized on every render, and `set:html` appears exactly once in
 blog code (plus the admin preview call site).
 
-### Strict DOMPurify config (authoritative)
+### Render-time sanitizer config — `STRICT_CONFIG_V2` (authoritative)
+
+Every TipTap/HTML body renders through `renderBodyHtml` → `DOMPurify.sanitize(html, STRICT_CONFIG_V2)`
+(`app/src/lib/blog-html.ts`). This is the authoritative steady-state config:
 
 ```typescript
-DOMPurify.sanitize(html, {
+// app/src/lib/blog-html.ts
+export const STRICT_CONFIG_V2 = {
   ALLOWED_TAGS: [
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "p",
-    "a",
-    "ul",
-    "ol",
-    "li",
-    "strong",
-    "em",
-    "b",
-    "i",
-    "blockquote",
-    "code",
-    "pre",
-    "img",
-    "hr",
-    "br",
-    "table",
-    "thead",
-    "tbody",
-    "tr",
-    "th",
-    "td",
-    "del",
+    // V1 baseline:
+    'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'ul', 'ol', 'li', 'strong', 'em', 'b', 'i',
+    'blockquote', 'code', 'pre', 'img', 'hr', 'br', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'del',
+    // V2 delta: underline/strike, table column groups, then PR B (#114) highlight + brand-color span
+    'u', 's', 'colgroup', 'col', 'mark', 'span'
   ],
-  ALLOWED_ATTR: ["href", "src", "alt", "title"], // NO 'id' — heading anchors are cut, so author
-  // ids must never reach the public page; DOMPurify
-  // strips every author-supplied id (no DOM-clobbering
-  // surface; resolved by removal)
-  ALLOW_DATA_ATTR: false, // defaults to TRUE and is checked BEFORE ALLOWED_ATTR — without these,
-  ALLOW_ARIA_ATTR: false, // an authored <p data-admin-alert> survives "strict" sanitization and
-  // trips AdminLayout's auto-remove in the preview; aria spoofing reaches
-  // screen-reader users
+  // NO 'id', NO 'style'. class/target/rel are admitted by NAME then VALUE-ENUMERATED by the hook below.
+  ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'target', 'rel', 'class', 'colspan', 'rowspan'],
+  ALLOW_DATA_ATTR: false,
+  ALLOW_ARIA_ATTR: false,
+  // https/mailto/tel/site-relative (NOT https-only — live posts carry mailto:/tel:, R3-F1). Blocks
+  // javascript:/vbscript:/protocol-relative and the backslash form '/\evil.com' (parsed as '//evil.com').
   ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?![/\\]))/i,
-  // HTTPS-only for body links/images (unifies the body trust boundary with the featured-image
-  // policy); NO '#'/fragment alternative (heading anchors cut, so fragment links have no targets);
-  // blocks javascript:, data:, vbscript:, protocol-relative, AND the backslash form '/\evil.com'
-  // (which WHATWG URL and browsers parse as '//evil.com')
-});
+  // Mark structural/enumerated attrs URI-safe so the URI regexp gates only true URIs (href/src).
+  ADD_URI_SAFE_ATTR: ['class', 'target', 'rel', 'colspan', 'rowspan']
+};
 ```
+
+A `uponSanitizeAttribute` hook (`enumerateBodyAttrs`) value-restricts the by-name-only attributes —
+registered around each sanitize call and removed in a `finally` so it never leaks to another path:
+
+- **`class`** → kept tokens limited to code-block language hints (`language-*`), the four text-align
+  classes (`text-left|center|right|justify`), and the four brand text-color classes
+  (`text-forest-canopy|moss-green|sunlight-gold|earth-brown`). Any other token is dropped; an empty
+  result drops the `class` attribute entirely. So `<span>`/`<mark>` can never carry anything but an
+  allowlisted **presentational class** — no inline `style`, no utility-class/CSS-injection abuse.
+- **`rel`** → `noopener|noreferrer|nofollow`; **`target`** → `_blank|_self`; anything else dropped.
+- **`src`/`href`** → `data:` rejected (DOMPurify otherwise admits `data:` on its default image tags
+  regardless of `ALLOWED_URI_REGEXP`).
+
+> **Legacy markdown path (transitional).** Not-yet-converted legacy markdown bodies still render via
+> `renderMarkdownToHtml` (`marked` → `DOMPurify.sanitize(html, STRICT_CONFIG)`), whose V1
+> `STRICT_CONFIG` is **narrower** (`ALLOWED_ATTR: ['href','src','alt','title']`; no `class`/`target`/
+> `rel`, no `u`/`s`/`mark`/`span`, no enumeration hook). It is retained only until the markdown→HTML
+> conversion is fully ratified (see `docs/runbooks/blog-html-conversion.md`); the steady-state
+> config for the primary path is `STRICT_CONFIG_V2` above.
 
 ### URI policy
 


### PR DESCRIPTION
**PR B of 3** for the blog admin redesign (#114). The "robust toolset" increment; PR C adds in-editor link/image dialogs + a live side-by-side preview.

## What

Grouped, labeled TipTap toolbar with new formatting:

- **Highlight** (`<mark>`) and **class-based brand text color** (forest-canopy / moss-green / sunlight-gold / earth-brown) — both implemented as **custom marks with zero new dependencies**. Color is class-based, **never inline `style`**.
- **Undo/redo** (StarterKit history), **horizontal rule** (`<hr>`, already allow-listed), and a **live word/character count** (computed in-component, no extension).
- Toolbar regrouped with dividers: History · Text · Headings · Blocks · Align · Insert · View.

## Security delta (bounded — the only new XSS surface)

`STRICT_CONFIG_V2` (`blog-html.ts`) gains `mark` + `span` in `ALLOWED_TAGS` and the four brand color classes in the enumerated `class` allow-list. `style`/`id` stay banned and `class` is value-enumerated, so a `<span>`/`<mark>` can **only ever carry an allow-listed presentational class** — no inline style, no utility-class/CSS-injection abuse.

New tests in `blog-html.test.ts` (the extensions→sanitizer matrix, generated from the **real TipTap emission**):
- `<mark>` and every brand-color `<span>` round-trip through the editor and survive sanitization.
- The sanitizer strips `style`/`id`/event handlers off them and drops non-brand classes to a bare element.

**502 tests pass** (was 498). lint ✅ · typecheck ✅ (0/0; pre-existing `ts(6385)` hint only) · build ✅ · prettier ✅.

## Docs / closes #116

`docs/specs/blog.md`:
- Authoring Model lists the new constructs (highlight, brand color, HR, word count; all class-based).
- The render-time sanitizer section now prints the **real `STRICT_CONFIG_V2`** + the `enumerateBodyAttrs` hook, and relabels the legacy V1 block as transitional — which **closes #116** (the spec previously documented the V1 config as "authoritative").

## Needs a live check (per the redesign's policy)

The interactive toolbar (applying highlight/color to a selection, undo/redo, the count updating) is best eyeballed on the live deploy.

Refs #114. Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)