### PR TITLE
fix(seo): host-aware noindex + 301 so the Netlify subdomain stops being indexed

### DIFF
--- a/app/src/lib/site-origin.test.ts
+++ b/app/src/lib/site-origin.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isProductionHostname, resolveSiteOrigin } from './site-origin';
+
+describe('isProductionHostname', () => {
+  it('accepts the canonical apex and www hostnames, case-insensitively', () => {
+    expect(isProductionHostname('spicebushmontessori.org')).toBe(true);
+    expect(isProductionHostname('www.spicebushmontessori.org')).toBe(true);
+    expect(isProductionHostname('SpicebushMontessori.org')).toBe(true);
+  });
+
+  it('rejects the Netlify default subdomain, previews, and local hosts', () => {
+    expect(isProductionHostname('spicebush-testing.netlify.app')).toBe(false);
+    expect(isProductionHostname('deploy-preview-42--spicebush-testing.netlify.app')).toBe(false);
+    expect(isProductionHostname('testing--spicebush-testing.netlify.app')).toBe(false);
+    expect(isProductionHostname('localhost')).toBe(false);
+    expect(isProductionHostname('spicebushmontessori.org.evil.example')).toBe(false);
+  });
+});
+
+describe('resolveSiteOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the provided site URL origin', () => {
+    expect(resolveSiteOrigin(new URL('https://example.org/some/path'))).toBe(
+      'https://example.org'
+    );
+  });
+
+  it('falls back to PUBLIC_SITE_URL, then the hardcoded production origin', () => {
+    vi.stubEnv('PUBLIC_SITE_URL', 'https://staging.example.org');
+    expect(resolveSiteOrigin()).toBe('https://staging.example.org');
+
+    vi.stubEnv('PUBLIC_SITE_URL', 'not a url');
+    expect(resolveSiteOrigin()).toBe('https://spicebushmontessori.org');
+  });
+});

--- a/app/src/lib/site-origin.ts
+++ b/app/src/lib/site-origin.ts
@@ -8,6 +8,17 @@
  * NOTE: a structurally-similar private `resolveSiteOrigin` exists in `seo-config.ts`
  * (accepts `URL | string`); this file is NOT a refactor of that helper.
  */
+/**
+ * Hostnames that serve the canonical production site. Anything else — the
+ * spicebush-testing.netlify.app default subdomain, deploy previews, branch
+ * deploys, localhost — must never be indexed by search engines (#127).
+ */
+const PRODUCTION_HOSTNAMES = new Set(['spicebushmontessori.org', 'www.spicebushmontessori.org']);
+
+export function isProductionHostname(hostname: string): boolean {
+  return PRODUCTION_HOSTNAMES.has(hostname.toLowerCase());
+}
+
 export function resolveSiteOrigin(site?: URL): string {
   if (site?.origin) return site.origin;
 

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { APIContext, MiddlewareNext } from 'astro';
 import { isAdminEmail } from '@lib/admin-config';
+import { isProductionHostname } from '@lib/site-origin';
 import { ADMIN_SESSION_COOKIE_NAME, validateAdminSession } from '@lib/auth/admin-session';
 import { evaluateCampMode, parseCampModeSettings, type CampModeEvaluation } from '@lib/camp-mode';
 import { queryFirst, queryRows } from '@lib/db/client';
@@ -225,7 +226,31 @@ const handleComingSoon = async (context: APIContext, next: MiddlewareNext) => {
   return handleCampMode(context, next);
 };
 
-export const onRequest = async (context: APIContext, next: MiddlewareNext) => {
+const NOINDEX_HEADER_VALUE = 'noindex, nofollow';
+
+/**
+ * Non-production hosts (the spicebush-testing.netlify.app default subdomain,
+ * deploy previews, branch deploys) serve the same app but must never be
+ * indexed by search engines (#127). robots.txt intentionally keeps these hosts
+ * crawlable so Googlebot can see this header and drop already-indexed URLs.
+ */
+const applyIndexingPolicy = (context: APIContext, response: Response): Response => {
+  if (isProductionHostname(context.url.hostname)) {
+    return response;
+  }
+
+  try {
+    response.headers.set('X-Robots-Tag', NOINDEX_HEADER_VALUE);
+    return response;
+  } catch {
+    // Responses proxied from fetch() carry immutable headers; clone before stamping.
+    const copy = new Response(response.body, response);
+    copy.headers.set('X-Robots-Tag', NOINDEX_HEADER_VALUE);
+    return copy;
+  }
+};
+
+const handleRequest = async (context: APIContext, next: MiddlewareNext) => {
   const locals = context.locals as unknown as Record<string, unknown>;
   const sessionToken = context.cookies.get(ADMIN_SESSION_COOKIE_NAME)?.value;
   let userId: string | null = null;
@@ -272,4 +297,9 @@ export const onRequest = async (context: APIContext, next: MiddlewareNext) => {
   }
 
   return handleComingSoon(context, next);
+};
+
+export const onRequest = async (context: APIContext, next: MiddlewareNext) => {
+  const response = await handleRequest(context, next);
+  return applyIndexingPolicy(context, response);
 };

--- a/app/src/pages/robots.txt.test.ts
+++ b/app/src/pages/robots.txt.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSeoSettingsMock } = vi.hoisted(() => ({
+  getSeoSettingsMock: vi.fn()
+}));
+
+vi.mock('@lib/seo-config', () => ({
+  getSeoSettings: getSeoSettingsMock
+}));
+
+import { GET } from './robots.txt';
+
+type RobotsContext = Parameters<typeof GET>[0];
+
+const requestRobots = async (requestUrl: string): Promise<string> => {
+  const context = {
+    site: new URL('https://spicebushmontessori.org'),
+    url: new URL(requestUrl)
+  } as unknown as RobotsContext;
+  const response = await GET(context);
+  return response.text();
+};
+
+describe('GET /robots.txt', () => {
+  beforeEach(() => {
+    getSeoSettingsMock.mockReset();
+    getSeoSettingsMock.mockResolvedValue({
+      global: {
+        siteNoIndex: false,
+        robotsDisallowPaths: ['/admin', '/api']
+      },
+      pageOverrides: {}
+    });
+  });
+
+  it('advertises sitemaps on the production hostname', async () => {
+    const body = await requestRobots('https://spicebushmontessori.org/robots.txt');
+
+    expect(body).toContain('Allow: /');
+    expect(body).toContain('Disallow: /admin');
+    expect(body).toContain('Sitemap: https://spicebushmontessori.org/sitemap-index.xml');
+    expect(body).toContain('Sitemap: https://spicebushmontessori.org/sitemap-blog.xml');
+  });
+
+  it('omits sitemaps but keeps crawl rules on non-production hostnames', async () => {
+    const body = await requestRobots(
+      'https://deploy-preview-7--spicebush-testing.netlify.app/robots.txt'
+    );
+
+    // Crawl stays allowed so Googlebot can see the middleware X-Robots-Tag noindex (#127).
+    expect(body).toContain('Allow: /');
+    expect(body).toContain('Disallow: /admin');
+    expect(body).not.toContain('Sitemap:');
+  });
+
+  it('serves a full disallow when the site-wide noindex kill switch is on', async () => {
+    getSeoSettingsMock.mockResolvedValue({
+      global: { siteNoIndex: true, robotsDisallowPaths: ['/admin'] },
+      pageOverrides: {}
+    });
+
+    const body = await requestRobots('https://spicebushmontessori.org/robots.txt');
+    expect(body).toContain('Disallow: /');
+    expect(body).not.toContain('Allow: /');
+  });
+});

--- a/app/src/pages/robots.txt.ts
+++ b/app/src/pages/robots.txt.ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from 'astro';
 import { getSeoSettings } from '@lib/seo-config';
-import { resolveSiteOrigin } from '@lib/site-origin';
+import { isProductionHostname, resolveSiteOrigin } from '@lib/site-origin';
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ site }) => {
+export const GET: APIRoute = async ({ site, url }) => {
   const siteOrigin = resolveSiteOrigin(site);
   const seoSettings = await getSeoSettings(siteOrigin);
 
@@ -21,8 +21,13 @@ export const GET: APIRoute = async ({ site }) => {
     });
   }
 
-  lines.push(`Sitemap: ${new URL('/sitemap-index.xml', siteOrigin).toString()}`);
-  lines.push(`Sitemap: ${new URL('/sitemap-blog.xml', siteOrigin).toString()}`);
+  // Only the canonical domain advertises sitemaps. Non-production hosts (deploy previews,
+  // branch deploys) stay crawlable on purpose: middleware stamps them with
+  // X-Robots-Tag noindex, and Googlebot can only see that header on URLs it may crawl (#127).
+  if (isProductionHostname(url.hostname)) {
+    lines.push(`Sitemap: ${new URL('/sitemap-index.xml', siteOrigin).toString()}`);
+    lines.push(`Sitemap: ${new URL('/sitemap-blog.xml', siteOrigin).toString()}`);
+  }
 
   return new Response(`${lines.join('\n')}\n`, {
     headers: {

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -209,6 +209,30 @@ curl -I https://<preview-url>/donate
 curl -I https://<preview-url>/enrollment
 ```
 
+### 5c. Non-Production Host Indexing Protection (#127)
+
+The default Netlify subdomain serves the same deploy as the production domain, and
+deploy previews/branch deploys serve work in progress. None of them may be indexed:
+
+```bash
+# Default subdomain 301s to the canonical domain (netlify.toml host redirect)
+curl -sI https://spicebush-testing.netlify.app/ | grep -iE '^(HTTP|location)'
+#   → HTTP/2 301, location: https://spicebushmontessori.org/
+
+# Previews and branch deploys stay reachable but carry a noindex header (middleware)
+curl -sI https://<preview-url>/ | grep -i x-robots-tag
+#   → x-robots-tag: noindex, nofollow
+
+# Non-production robots.txt keeps crawl open (so the noindex header is visible
+# to Googlebot) but advertises no sitemaps
+curl -s https://<preview-url>/robots.txt
+#   → Allow: / + Disallow rules, NO "Sitemap:" lines
+
+# Production must NOT carry the header and must advertise sitemaps
+curl -sI https://spicebushmontessori.org/ | grep -i x-robots-tag   # → (empty)
+curl -s https://spicebushmontessori.org/robots.txt | grep Sitemap  # → 2 lines
+```
+
 ---
 
 ## 6. Deploy

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -78,7 +78,7 @@ SpicebushWebapp/              (repo root -- deploy from here)
 Defined in `src/middleware.ts`. Request handling chain:
 
 ```
-Auth check -> Coming-soon gate -> Camp mode routing -> Page render
+Auth check -> Coming-soon gate -> Camp mode routing -> Page render -> Indexing policy header
 ```
 
 ### Auth
@@ -100,6 +100,17 @@ Auth check -> Coming-soon gate -> Camp mode routing -> Page render
 - Camp mode redirects `/camp` to `/camp-coming-soon` when camp is inactive (non-admin visitors)
 - Camp mode redirects `/camp-coming-soon` to `/camp` when camp is active
 - Admins can see camp pages in prep mode regardless of public visibility
+
+### Indexing Policy (#127)
+
+- Every response from a non-production hostname (anything other than
+  `spicebushmontessori.org` / `www.spicebushmontessori.org` — see
+  `isProductionHostname()` in `@lib/site-origin`) gets `X-Robots-Tag: noindex, nofollow`
+- This covers deploy previews and branch deploys; the bare
+  `spicebush-testing.netlify.app` subdomain is additionally 301-redirected to the
+  canonical domain via a host-scoped rule in `netlify.toml`
+- `robots.txt` on non-production hosts keeps crawl open (so the noindex header is
+  visible to crawlers) but omits the `Sitemap:` lines
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -58,7 +58,18 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
-# Redirects configuration 
+# Redirects configuration
+
+# The default Netlify subdomain serves the same deploy as the production domain.
+# 301 it to the canonical domain so search engines consolidate there (issue #127).
+# Deploy previews / branch deploys are NOT redirected; Astro middleware serves
+# them X-Robots-Tag: noindex instead.
+[[redirects]]
+  from = "https://spicebush-testing.netlify.app/*"
+  to = "https://spicebushmontessori.org/:splat"
+  status = 301
+  force = true
+
 [[redirects]]
   from = "/admin/*"
   to = "/admin/:splat"


### PR DESCRIPTION
Closes #127

## Problem

`spicebush-testing.netlify.app` is the default Netlify subdomain of the **production** site — it serves the exact same deploy as spicebushmontessori.org, and Google has indexed it (`/contact/`, `/about` confirmed via `site:` search). Deploy previews and branch deploys were equally indexable. Nothing in the app was host-aware.

## Fix

| Layer | Change |
|---|---|
| `netlify.toml` | Force-301 `https://spicebush-testing.netlify.app/*` → `https://spicebushmontessori.org/:splat` (host-scoped; previews/branch deploys unaffected) |
| `middleware.ts` | `X-Robots-Tag: noindex, nofollow` on every response whose hostname isn't `spicebushmontessori.org`/`www.` — covers previews + branch deploys |
| `robots.txt.ts` | Sitemap lines only on the canonical hostname; non-prod hosts stay **crawlable** so Googlebot can actually see the noindex header (a blanket Disallow would freeze already-indexed URLs in the index, per Google's documented crawl/noindex interaction) |

## Tests

- `site-origin.test.ts` — hostname classification (apex, www, case, previews, lookalike suffix)
- `robots.txt.test.ts` — sitemap presence/absence per host, kill-switch disallow
- Full suite: 44 files / 509 tests green; lint `--max-warnings=0` + `astro check` clean

## Docs

- `docs/specs/architecture.md` — middleware pipeline now documents the indexing-policy stage
- `docs/runbooks/deploy.md` — §5c verification curls for the redirect/header/robots behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic redirection from the default hosting subdomain to the canonical production website.
  * Added indexing protection for previews and other non-production hosts.
  * Non-production `robots.txt` responses omit sitemap links.

* **Documentation**
  * Documented deployment checks and indexing behavior for production and non-production environments.

* **Tests**
  * Added coverage for hostname detection, redirects, robots rules, sitemap visibility, and indexing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->