### PR TITLE
fix(tuition): computed school-year fallback, roll seed to 2026-2027

### DIFF
--- a/app/src/content/config.ts
+++ b/app/src/content/config.ts
@@ -1,5 +1,7 @@
 import { z, defineCollection } from 'astro:content';
 
+import { getCurrentSchoolYear } from '../lib/school-year';
+
 const staffCollection = defineCollection({
   type: 'content',
   schema: z.object({
@@ -31,7 +33,7 @@ const tuitionCollection = defineCollection({
     extended_care_price: z.number().default(0).optional(),
     extended_care_available: z.boolean().default(false).optional(),
     is_constant_rate: z.boolean().default(false).optional(),
-    school_year: z.string().default('2025-2026').optional(),
+    school_year: z.string().default(getCurrentSchoolYear).optional(),
     income_threshold_type: z
       .enum(['Greater Than or Equal To', 'Less Than'])
       .default('Greater Than or Equal To')

--- a/app/src/content/settings/current-school-year.md
+++ b/app/src/content/settings/current-school-year.md
@@ -1,7 +1,7 @@
 ---
 name: 'Current School Year'
 key: 'current_school_year'
-value: '2025-2026'
+value: '2026-2027'
 description: 'The current academic school year'
 type: 'string'
 ---

--- a/app/src/lib/school-year.test.ts
+++ b/app/src/lib/school-year.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCurrentSchoolYear } from './school-year';
+
+describe('getCurrentSchoolYear', () => {
+  it('rolls over on July 1', () => {
+    expect(getCurrentSchoolYear(new Date(2026, 5, 30))).toBe('2025-2026'); // Jun 30
+    expect(getCurrentSchoolYear(new Date(2026, 6, 1))).toBe('2026-2027'); // Jul 1
+  });
+
+  it('keeps the started year through the following spring', () => {
+    expect(getCurrentSchoolYear(new Date(2026, 8, 15))).toBe('2026-2027'); // Sep
+    expect(getCurrentSchoolYear(new Date(2027, 0, 10))).toBe('2026-2027'); // Jan
+    expect(getCurrentSchoolYear(new Date(2027, 4, 31))).toBe('2026-2027'); // May
+  });
+});

--- a/app/src/lib/school-year.ts
+++ b/app/src/lib/school-year.ts
@@ -1,0 +1,10 @@
+/**
+ * The school year rolls over on July 1: June 30 still belongs to the year that
+ * started the previous fall, July 1 begins the next one. Used as the fallback
+ * anywhere the `current_school_year` DB setting is missing so hardcoded
+ * defaults can never go stale again (#128). The DB setting always wins when set.
+ */
+export function getCurrentSchoolYear(now: Date = new Date()): string {
+  const year = now.getFullYear();
+  return now.getMonth() >= 6 ? `${year}-${year + 1}` : `${year - 1}-${year}`;
+}

--- a/app/src/lib/tuition-forms.test.ts
+++ b/app/src/lib/tuition-forms.test.ts
@@ -6,6 +6,7 @@ import {
   renderPrograms,
   renderRates
 } from './tuition-forms';
+import { getCurrentSchoolYear } from './school-year';
 
 describe('tuition-forms helpers', () => {
   it('creates program form markup for defaults and existing records', () => {
@@ -189,7 +190,9 @@ describe('tuition-forms helpers', () => {
     expect(Number((document.getElementById('annual-increase') as HTMLInputElement).value)).toBe(4);
 
     populateSettings({});
-    expect((document.getElementById('school-year') as HTMLInputElement).value).toBe('2025-2026');
+    expect((document.getElementById('school-year') as HTMLInputElement).value).toBe(
+      getCurrentSchoolYear()
+    );
     expect((document.getElementById('upfront-discount') as HTMLInputElement).value).toBe('5');
     expect((document.getElementById('sibling-discount') as HTMLInputElement).value).toBe('10');
     expect((document.getElementById('annual-increase') as HTMLInputElement).value).toBe('4');

--- a/app/src/lib/tuition-forms.ts
+++ b/app/src/lib/tuition-forms.ts
@@ -1,6 +1,8 @@
 // Tuition Form Templates and Utilities
 // Extracted from tuition.astro to reduce complexity
 
+import { getCurrentSchoolYear } from './school-year';
+
 interface Program {
   id: string;
   name: string;
@@ -142,7 +144,7 @@ export function createRateForm(rate: TuitionRate | null = null, programs: Progra
         </div>
         <div>
           <label class="block text-sm font-medium text-earth-brown mb-2">School Year</label>
-          <input type="text" id="rate-school-year" value="${rate?.school_year || '2025-2026'}" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest-canopy focus:border-transparent" />
+          <input type="text" id="rate-school-year" value="${rate?.school_year || getCurrentSchoolYear()}" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest-canopy focus:border-transparent" />
         </div>
       </div>
 
@@ -249,7 +251,7 @@ export function populateSettings(settings: Record<string, unknown>): void {
   if (schoolYearInput) {
     const schoolYear = settings.current_school_year;
     schoolYearInput.value =
-      typeof schoolYear === 'string' && schoolYear.trim() ? schoolYear : '2025-2026';
+      typeof schoolYear === 'string' && schoolYear.trim() ? schoolYear : getCurrentSchoolYear();
   }
   if (upfrontDiscountInput)
     upfrontDiscountInput.value = String(toNumber(settings.upfront_discount_rate, 0.05) * 100);

--- a/app/src/pages/admin/tuition.astro
+++ b/app/src/pages/admin/tuition.astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from '@layouts/AdminLayout.astro';
 import { db, type ContentEntry } from '@lib/db';
+import { getCurrentSchoolYear } from '@lib/school-year';
 
 type TuitionEntry = ContentEntry<Record<string, unknown>>;
 
@@ -185,7 +186,7 @@ const allRates = entries
       programId: stringFrom(data.program_id, ''),
       rateLabel,
       tuitionPrice: numberInputValue(data.tuition_price, ''),
-      schoolYear: stringFrom(data.school_year, '2025-2026'),
+      schoolYear: stringFrom(data.school_year, getCurrentSchoolYear()),
       displayOrder: numberFrom(data.display_order, levelOrder),
       extendedCareAvailable:
         data.extended_care_available === undefined ? true : boolFrom(data.extended_care_available),
@@ -669,7 +670,7 @@ const totalRates =
             {allPrograms.map(program => {
               const nextLevel = nextLevelForRates(program.rates);
               const nextLevelOrder = rateLevelOrder.get(nextLevel) ?? 1;
-              const defaultYear = program.rates[0]?.schoolYear || '2025-2026';
+              const defaultYear = program.rates[0]?.schoolYear || getCurrentSchoolYear();
 
               return (
                 <details class="rounded-lg border border-gray-200 bg-gray-50">

--- a/app/src/pages/admissions/tuition-calculator.astro
+++ b/app/src/pages/admissions/tuition-calculator.astro
@@ -4,6 +4,7 @@ import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import TuitionCalculatorComponent from '../../components/TuitionCalculator.tsx';
 import { db } from '@lib/db';
+import { getCurrentSchoolYear } from '@lib/school-year';
 import { logServerError } from '@lib/server-logger';
 
 interface ProgramRecord {
@@ -64,7 +65,7 @@ let rates: RateRecord[] = [];
 let calculatorSettings: CalculatorSettings = {
   upfrontDiscountRate: 0.05,
   siblingDiscountRate: 0.1,
-  currentSchoolYear: '2025-2026'
+  currentSchoolYear: getCurrentSchoolYear()
 };
 let loadError: string | null = null;
 

--- a/docs/specs/data-model.md
+++ b/docs/specs/data-model.md
@@ -73,6 +73,7 @@ Key-value site settings. Used for coming-soon mode, camp mode, email routing con
 | ---------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ticker_items`   | JSON array of `{ text, href?, expiresAt?, type? }` | Phase 6 news ticker. No dedicated table — the array order _is_ the display order. Value-level safety (href scheme, expiry, ≤5) is enforced at render in `getActiveTickerItems`, not on write (the endpoint validates the key only). |
 | `ticker_enabled` | `boolean` (default absent → `false`)               | Master on/off. Absent/falsey → the ticker renders nothing. Read with a dedicated 5-min TTL (R4-F11), never via `getAllSettings()`.                                                                                                  |
+| `current_school_year` | `string` (`"YYYY-YYYY"`)                      | Drives the school-year label on the public tuition calculator and admin tuition forms. When absent, code falls back to `getCurrentSchoolYear()` (`@lib/school-year`), which rolls over every July 1 — never a hardcoded year (#128). |
 
 **Seeded keys (by migration):**
 


### PR DESCRIPTION
Closes #128

## Problem

In August 2026 the public tuition calculator still said "Calculations use the **2025-2026** tuition tables". The label comes from the `current_school_year` DB setting (now updated to `2026-2027` — one-row ops change, done directly), but `'2025-2026'` was also hardcoded as a fallback in five places, guaranteed to go stale again every summer.

## Fix

- New `getCurrentSchoolYear()` in `@lib/school-year` — rolls over July 1, always current
- Replaces every hardcoded fallback: public calculator page, admin tuition page (rate default + program group default), `tuition-forms.ts` (rate form + `populateSettings`), content schema zod default
- Seed file `current-school-year.md` rolled to `2026-2027` so a reseed can't regress the DB setting

## ⚠️ Deliberately NOT changed

The 10 tuition **rate rows** keep `school_year=2025-2026` internally — no 2026-2027 pricing has been entered by the school (admin settings carry a 4% `annual_increase_rate`). If 2026-27 pricing differs, amounts must be updated in `/admin/tuition`. Relabeling data rows would fake a pricing decision the school hasn't made.

## Tests

- `school-year.test.ts` — July 1 rollover boundary + through-spring stability
- `tuition-forms.test.ts` — fallback expectation now derived from the util
- Full suite: 43 files / 504 tests green; lint `--max-warnings=0` + `astro check` clean

## Docs

- `docs/specs/data-model.md` — documents `current_school_year` + computed fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)